### PR TITLE
Align the title

### DIFF
--- a/assets/styles/documentation.css
+++ b/assets/styles/documentation.css
@@ -83,8 +83,9 @@ h2 {
 }
 
 .section h2{
-  margin-top:-56px;
-  font-size: 40px;
+  margin-top: -73px;
+  margin-bottom: 60px;
+  font-size: 40px;  
 }
 
 h3{


### PR DESCRIPTION
Align the title so that it is over the documentation box, not in the border.
