### PR TITLE
Fix markdown formatting in enumerables.md

### DIFF
--- a/assets/docs/enumerables.md
+++ b/assets/docs/enumerables.md
@@ -130,7 +130,7 @@ For arbitrary filtering, use the (you guessed it) `filter` method. The filter me
 var arr = [1,2,3,4,5];
 
 arr.filter(function(item, index, self) {
-  if(item < 4) { return true; }
+  if (item &lt; 4) { return true; }
 })
 
 // returns [1,2,3]


### PR DESCRIPTION
For some reason, the "<" in  "if (item < 4)" causes markdown to get all grumpy, and messes up the styling after the Filter section when you view the page on github at https://github.com/emberjs/website/blob/master/assets/docs/enumerables.md

Changing the < to &lt; fixes the issue.
