### PR TITLE
update one-way binding example to consistently reflect that the binding is named differently than its observed property

### DIFF
--- a/source/docs/object_model.md
+++ b/source/docs/object_model.md
@@ -320,11 +320,11 @@ App.userView = Ember.View.create({
 // Changing the name of the user object changes
 // the value on the view.
 App.user.set('fullName', "Krang Gates");
-// App.userView.fullName will become "Krang Gates"
+// App.userView.userName will become "Krang Gates"
 
 // ...but changes to the view don't make it back to
 // the object.
-App.userView.set('fullName', "Truckasaurus Gates");
+App.userView.set('userName', "Truckasaurus Gates");
 App.user.get('fullName'); // "Krang Gates"
 ```
 


### PR DESCRIPTION
I'm assuming that the intention was to demonstrate that a binding need not be named to match its observed property. If this was not intended then the binding on `App.userView` should be renamed to `fullNameBinding` and the other changes discarded.
