### PR TITLE
Eliminate implication that checking the checkbox might propagate back.

### DIFF
--- a/source/docs/handlebars.md
+++ b/source/docs/handlebars.md
@@ -234,20 +234,20 @@ If you use `{{bindAttr}}` with a Boolean value, it will add or remove the specif
 
 ```javascript
 App.InputView = Ember.View.extend({
-  isSelected: true
+  isDisabled: true
 });
 ```
 
 And this template:
 
 ```html
-<input type="checkbox" {{bindAttr checked="isSelected"}}>
+<input type="checkbox" {{bindAttr disabled="isDisabled"}}>
 ```
 
 Handlebars will produce the following HTML element:
 
 ```html
-<input type="checkbox" checked>
+<input type="checkbox" disabled>
 ```
 
 ### Binding Class Names with {{bindAttr}}


### PR DESCRIPTION
I got really confused today; thinking that bindAttr on a checkbox would propagate checking and unchecking the checkbox would somehow propagate back to the property bound. I should have known better, but hopefully this fix will help.
