### PR TITLE
Add Github link on Examples page

### DIFF
--- a/source/examples/index.html.md
+++ b/source/examples/index.html.md
@@ -6,7 +6,8 @@ title: Examples
 
 As required by law, our JavaScript framework includes a Todos demo.
 
-<a href="/examples/todos/">Visit Todos</a>
+<a href="/examples/todos/">Visit Todos</a> |
+<a href="https://github.com/emberjs/todos">Source</a>
 <a href="/examples/todos/">
 <img src="/images/screenshots/todos.png" class="screenshot">
 </a>
@@ -14,8 +15,7 @@ As required by law, our JavaScript framework includes a Todos demo.
 ## Simple Bindings
 This demo contains an example a simple view bound to a controller.
 
-<a href="/examples/simple_bindings/">
-Visit Simple Bindings</a>
+<a href="/examples/simple_bindings/">Visit Simple Bindings</a>
 <a href="/examples/simple_bindings/">
 <img src="/images/screenshots/simple_bindings.png" class="screenshot">
 </a>
@@ -29,9 +29,7 @@ If you check out this code from GitHub, it includes a node.js server that illust
 into a controller.
 
 
-<a href="/examples/contacts/">
-Visit Contacts
-</a>
+<a href="/examples/contacts/">Visit Contacts</a>
 <a href="/examples/contacts/">
 <img src="/images/screenshots/contacts.png" class="screenshot">
 </a>


### PR DESCRIPTION
Hi,

when I was browsing the site I noticed that I was looking for github links to repos with examples. I managed to find repository with Todos example, so I added link to it. Let me know where rest of examples lie, so I can add more.

Cheers
