### PR TITLE
Small Fix To Object Model Docs: "Class" should be "Instance"

### DIFF
--- a/source/docs/object_model.md
+++ b/source/docs/object_model.md
@@ -25,7 +25,7 @@ person.say("Hello") // alerts "Hello"
 ```
 
 When creating an instance, you can also add additional properties to the
-class by passing in an object.
+instance by passing in an object.
 
 ```javascript
 var tom = Person.create({


### PR DESCRIPTION
Just started playing around with ember yesterday.  Seems fantastic.  Noticed what I'm pretty sure is a typo:

Currently it says: "When creating an instance, you can also add additional properties to the class by passing in an object."

But it should say:

"When creating an instance, you can also add additional properties to the instance by passing in an object."

Hope that helps
Jonah
