### PR TITLE
Updating base jsfiddle url for 0.9.7.1

### DIFF
--- a/source/community/get_help.md
+++ b/source/community/get_help.md
@@ -4,7 +4,7 @@
 
 [StackOverflow](http://stackoverflow.com) is used for QA's. Just tag your question with ```emberjs``` or search for questions with that [tag](http://stackoverflow.com/questions/tagged/emberjs) and maybe your question has already been asked and answered.
 
-If you have a code specific question be sure to add a JSFiddle which helps to locate the problem you are struggling with. You can use [this](http://jsfiddle.net/Qpkz5/) as a starting point.
+If you have a code specific question be sure to add a JSFiddle which helps to locate the problem you are struggling with. You can use [this](http://jsfiddle.net/vCtbP/) as a starting point.
 
 #### IRC Channel
 


### PR DESCRIPTION
Updating the jsfiddle url to a fiddle using 0.9.7.1 rather than 0.9.7.
