### PR TITLE
Path capitalization

### DIFF
--- a/source/docs/handlebars.md
+++ b/source/docs/handlebars.md
@@ -678,11 +678,11 @@ They are:
 	
 ```html
 	{{view Ember.Select viewName="select"
-                          contentBinding="app.peopleController"
+                          contentBinding="App.peopleController"
                           optionLabelPath="content.fullName"
                           optionValuePath="content.id"
                           prompt="Pick a person:"
-                          selectionBinding="app.selectedPersonController.person"}}
+                          selectionBinding="App.selectedPersonController.person"}}
 ```
 	
 ####Ember.TextArea


### PR DESCRIPTION
I was under the impression that global paths needed capital letters. Is that true? Or only in the JS strings?
