### PR TITLE
Syntax-highlight all Handlebars snippets as `handlebars`. Fixes #80

### DIFF
--- a/source/docs/handlebars.md
+++ b/source/docs/handlebars.md
@@ -8,7 +8,7 @@ You should store your Handlebars templates inside your application's HTML file. 
 
 To immediately insert a template into your document, place it inside a `<script>` tag within your `<body>` tag:
 
-```html
+```handlebars
 <html>
   <body>
     <script type="text/x-handlebars">
@@ -20,7 +20,7 @@ To immediately insert a template into your document, place it inside a `<script>
 
 To make a template available to be used later, give the `<script>` tag a `data-template-name` attribute:
 
-```html
+```handlebars
 <html>
   <head>
     <script type="text/x-handlebars" data-template-name="say-hello">
@@ -36,7 +36,7 @@ You can use `Ember.View` to render a Handlebars template and insert it into the 
 
 To tell the view which template to use, set its `templateName` property. For example, if I had a `<script>` tag like this:
 
-```html
+```handlebars
 <html>
   <head>
     <script type="text/x-handlebars" data-template-name="say-hello">
@@ -79,7 +79,7 @@ To remove a view from the document, call `remove`:
 
 As you've already seen, you can print the value of a property by enclosing it in a Handlebars expression, or a series of braces, like this:
 
-```html
+```handlebars
 My new car is {{color}}.
 ```
 
@@ -99,7 +99,7 @@ My new car is blue.
 
 You can also specify global paths:
 
-```html
+```handlebars
 My new car is {{App.carController.color}}.
 ```
 
@@ -119,14 +119,14 @@ blue
 
 Because all Handlebars expressions are wrapped in these markers, make sure each HTML tag stays inside the same block. For example, you shouldn't do this:
 
-```html
+```handlebars
 <!-- Don't do it! -->
 <div {{#if isUrgent}}class="urgent"{{/if}}>
 ```
 
 If you want to avoid your property output getting wrapped in these markers, use the `unbound` helper:
 
-```html
+```handlebars
 My new car is {{unbound color}}.
 ```
 
@@ -154,7 +154,7 @@ App.SayHelloView = Ember.View.extend({
 In order to display part of the template only if the `person` object exists, we
 can use the `{{#if}}` helper to conditionally render a block:
 
-```html
+```handlebars
 {{#if person}}
   Welcome back, <b>{{person.firstName}} {{person.lastName}}</b>!
 {{/if}}
@@ -166,7 +166,7 @@ Handlebars will not render the block if the argument passed evaluates to
 If the expression evaluates to falsy, we can also display an alternate template
 using `{{else}}`:
 
-```html
+```handlebars
 {{#if person}}
   Welcome back, <b>{{person.firstName}} {{person.lastName}}</b>!
 {{else}}
@@ -176,7 +176,7 @@ using `{{else}}`:
 
 To only render a block if a value is falsy, use `{{#unless}}`:
 
-```html
+```handlebars
 {{#unless hasPaid}}
   You owe: ${{total}}
 {{/unless}}
@@ -193,7 +193,7 @@ Sometimes you may want to invoke a section of your template with a context
 different than the Ember.View. For example, we can clean up the above template by
 using the `{{#with}}` helper:
 
-```html
+```handlebars
 {{#with person}}
   Welcome back, <b>{{firstName}} {{lastName}}</b>!
 {{/with}}
@@ -216,7 +216,7 @@ App.LogoView = Ember.View.extend({
 
 The best way to display the URL as an image in Handlebars is like this:
 
-```html
+```handlebars
 <div id="logo">
   <img {{bindAttr src="logoUrl"}} alt="Logo">
 </div>
@@ -240,7 +240,7 @@ App.InputView = Ember.View.extend({
 
 And this template:
 
-```html
+```handlebars
 <input type="checkbox" {{bindAttr disabled="isDisabled"}}>
 ```
 
@@ -261,7 +261,7 @@ App.AlertView = Ember.View.extend({
 });
 ```
 
-```html
+```handlebars
 <div {{bindAttr class="priority"}}>
   Warning!
 </div>
@@ -277,7 +277,7 @@ This template will emit the following HTML:
 
 If the value to which you bind is a Boolean, however, the dasherized version of that property will be applied as a class:
 
-```html
+```handlebars
 <div {{bindAttr class="isUrgent"}}>
   Warning!
 </div>
@@ -380,12 +380,12 @@ App.InfoView = Ember.View.extend({
 });
 ```
 
-```html
+```handlebars
 User: {{firstName}} {{lastName}}
 {{view App.InfoView}}
 ```
 
-```html
+```handlebars
 <b>Posts:</b> {{posts}}
 <br>
 <b>Hobbies:</b> {{hobbies}}
@@ -425,7 +425,7 @@ App.UserView = Ember.View.extend({
 });
 ```
 
-```html
+```handlebars
 User: {{firstName}} {{lastName}}
 {{view infoView}}
 ```
@@ -454,7 +454,7 @@ App.InfoView = Ember.View.extend({
 });
 ```
 
-```html
+```handlebars
 User: {{firstName}} {{lastName}}
 {{#view App.InfoView}}
   <b>Posts:</b> {{posts}}
@@ -503,7 +503,7 @@ do that by passing additional arguments to the `{{#view}}` helper. If all
 you're doing is configuring bindings, this often allows you to bypass having to
 create a new subclass.
 
-```html
+```handlebars
 User: {{firstName}} {{lastName}}
 {{#view App.UserView postsBinding="App.userController.content.posts"
         hobbiesBinding="App.userController.content.hobbies"}}
@@ -526,13 +526,13 @@ of the parent's HTML element.
 By default, new instances of `Ember.View` create a `<div>` element. You can
 override this by passing a `tagName` parameter:
 
-```html
+```handlebars
 {{view App.InfoView tagName="span"}}
 ```
 
 You can also assign an ID attribute to the view's HTML element by passing an `id` parameter:
 
-```html
+```handlebars
 {{view App.InfoView id="info-view"}}
 ```
 
@@ -547,7 +547,7 @@ This makes it easy to style using CSS ID selectors:
 
 You can assign class names similarly:
 
-```html
+```handlebars
 {{view App.InfoView class="info urgent"}}
 ```
 
@@ -560,7 +560,7 @@ App.AlertView = Ember.View.extend({
 });
 ```
 
-```html
+```handlebars
 {{view App.AlertView classBinding="isUrgent priority"}}
 ```
 
@@ -581,7 +581,7 @@ App.PeopleView = Ember.View.extend({
 });
 ```
 
-```html
+```handlebars
 <ul>
   {{#each people}}
     <li>Hello, {{name}}!</li>
@@ -602,7 +602,7 @@ If you want to create a view for every item in a list, you can bind a property o
 the current context. For example, this example creates a view for every item in a list and sets
 the `content` property to that item:
 
-```html
+```handlebars
 {{#each App.peopleController}}
   {{#view App.PersonView contentBinding="this"}}
     {{content.firstName}} {{content.lastName}}
@@ -628,7 +628,7 @@ make sure to return a new `SafeString`.
 
 Anywhere in your Handlebars templates, you can now invoke this helper:
 
-```html
+```handlebars
 {{highlight name}}
 ```
 
@@ -648,7 +648,7 @@ They are:
 
 ####Ember.Checkbox
 	
-```html
+```handlebars
     <label>
       {{view Ember.Checkbox checkedBinding="content.isDone"}}
       {{content.title}}
@@ -668,7 +668,7 @@ They are:
 	
 ####Ember.Select
 	
-```html
+```handlebars
 	{{view Ember.Select viewName="select"
                           contentBinding="App.peopleController"
                           optionLabelPath="content.fullName"
@@ -703,7 +703,7 @@ App.myText = Ember.TextField.extend({
 
 You can then use this view as a sub view and capture the events.  In the following example, a change to the Name input would blurr the form and cause the save button to appear.
 
-```html
+```handlebars
 <script id="formDetail" data-template-name='formDetail' type="text/x-handlebars">
     <form>
         <fieldset>

--- a/source/docs/introduction.md
+++ b/source/docs/introduction.md
@@ -27,7 +27,7 @@ that will automatically update the DOM when the underlying objects change.
 
 For a simple example, consider this template of a Person:
 
-```html
+```handlebars
 {{person.name}} is {{person.age}}.
 ```
 
@@ -158,7 +158,7 @@ Ember uses Handlebars, a semantic templating library. To take data from your Jav
 and put it into the DOM, create a `<script>` tag and put it into your HTML, wherever you'd like the
 value to appear:
 
-```html
+```handlebars
 <script type="text/x-handlebars">
   The President of the United States is {{MyApp.president.fullName}}.
 </script>

--- a/source/docs/views.md
+++ b/source/docs/views.md
@@ -11,7 +11,7 @@ as a method on your view.
 
 For example, imagine we have a template like this:
 
-```html
+```handlebars
 {{#view App.ClickableView}}
 This is a clickable area!
 {{/view}}

--- a/source/guides/rails.md
+++ b/source/guides/rails.md
@@ -210,7 +210,7 @@ Photoblog.IndexView = Ember.View.extend({
 
 This is where we define the Ember.js object which manages the view. We simply provide it with a `templateName` property, which points to our handlebars template, and a `controller` property, which manages the view. Here's the template that defines what the index view looks like. Make yours look like the following:
 
-```html
+```handlebars
 <h1>My Photoblog</h1>
 
 {{#each controller}}
@@ -235,7 +235,7 @@ This is where we define the Ember.js object which manages the view. We simply pr
 
 Let's go break this down and explain what's gong on.
 
-```html
+```handlebars
 <h1>My Photoblog</h1>
 
 {{#each controller}}
@@ -243,13 +243,13 @@ Let's go break this down and explain what's gong on.
 
 Our view has a controller, the Photoblog.photosController, which will create in the next step. This is an Ember.ArrayController, so it implements the Ember.Enumerable interface. This means that we can loop over it's contents (each element of the array) using the `#each` Handlerbars experssion.
 
-```html
+```handlebars
 {{#view contentBinding="this"}}
 ```
 
 For each photo managed by the photosController, we will create a subview with the following contents, and have its `content` property be bound to the photo object.
 
-```html
+```handlebars
     <div class="photo">
       <h2>{{content.title}}</h2>
       <img {{bindAttr src="content.url"}}>
@@ -258,7 +258,7 @@ For each photo managed by the photosController, we will create a subview with th
 
 Here, we reference our photo to get its title, and user bindAttr to set the `<img>` tag's `src` attribute to the photo's url.
 
-```html
+```handlebars
       {{#if content.comments.length}}
         <h3>Comments</h3>
         <ul>
@@ -271,7 +271,7 @@ Here, we reference our photo to get its title, and user bindAttr to set the `<im
 
 Next, we see if there are any comments on the photo. If there are, we create a section and list for comments, and iterate through them. Note that in this `{{#each}}` expression, we aren't binding the comment object to the content property, so the context is automatically set to it. We create a new `<li>` for each comment with the comments text, and close out our `{{#each}}` iteration, list, and {{#if}}.
 
-```html
+```handlebars
   {{/view}}
 {{/each}}
 ```
@@ -343,7 +343,7 @@ rails generate ember:view create photo
 
 Modify the template for the create view at `app/assets/javascripts/templates/photos/create.handlebars` to look like this:
 
-```html
+```handlebars
 <h1>Add a New Photo</h1>
 {{template "photos/_form"}}
 ```
@@ -352,7 +352,7 @@ We use the handlebars expression `template` to refer to another template we'd li
 
 Let's create the `_form` template in `app/assets/javascripts/templates/photos/_form.handlebars`. It will include only the form elements for our photo, like so:
 
-```html
+```handlebars
 <label for="title-field">Title:</label>{{view Ember.TextField id="title-field" valueBinding="controller.content.title"}}
 <label for="url-field">URL:</label>{{view Ember.TextField id="url-field" valueBinding="controller.content.url"}}
 
@@ -457,7 +457,7 @@ Now we define the `save` and `cancel` actions we referenced in our create view t
 
 Finally, we will add a button to the index template, at the very bottom, which tells our state manager to show the create view.
 
-```html
+```handlebars
 <button {{action showCreate target="Photoblog.stateManager"}}>Add Photo</button>
 ```
 
@@ -478,7 +478,7 @@ Photoblog.EditView = Ember.View.extend({
 
 Now, we'll add the template for it at `app/assets/javascripts/templates/photos/edit.handlebars`.
 
-```html
+```handlebars
 <h1>Edit a Photo</h1>
 {{template "templates/photos/_form"}}
 ```
@@ -531,7 +531,7 @@ Ensure that you add a comma to the previous `showCreate`. In this action, we're 
 
 Lastly, lets add an edit button to each photo on the page. Below the `<img>` tag, add the following button, which targets our state manager's new `showEdit` action.
 
-```html
+```handlebars
 <a href="#" {{action showEdit target="Photoblog.stateManager"}}>Edit Photo</a>
 ```
 

--- a/source/guides/view_layer.md
+++ b/source/guides/view_layer.md
@@ -141,7 +141,7 @@ The process looks something like:
 
 As Ember renders a templated view, it will generate a view hierarchy. Let's assume we have a template `form`.
 
-```html
+```handlebars
 {{view App.Search placeholder="Search"}}
 {{#view Ember.Button}}Go!{{/view}}
 ```


### PR DESCRIPTION
This is necessary because Handlebars-enhanced HTML is not valid HTML
anymore, causing weird issues as described in #80. Handlebars is
currently not supported by Pygments, so the snippets will come out
unhighlighted, but perhaps there will be support in the future.
