### PR TITLE
Add missing quote in code snippet

### DIFF
--- a/source/guides/asynchrony.md
+++ b/source/guides/asynchrony.md
@@ -210,7 +210,7 @@ App.Button = Ember.View.extend({
 });
 
 var button = App.Button.create({
-  title: "Hi jQuery UI!
+  title: "Hi jQuery UI!"
 }).appendTo('#something');
 ```
 


### PR DESCRIPTION
In asynchrony guide, the "side-effect callbacks" code snippet is missing a double-quote. Causes bad syntax highlight
