### PR TITLE
this method should not be included in this particular example

### DIFF
--- a/source/guides/view_layer.md
+++ b/source/guides/view_layer.md
@@ -524,16 +524,8 @@ override the `init` method:
 ```javascript
 App.ToolbarView = Ember.ContainerView.create({
   childViews: ['descriptionView', 'buttonView'],
-
   descriptionView: App.DescriptionView,
   buttonView: Ember.ButtonView,
-
-  addButton: function() {
-    var childViews = this.get('childViews');
-    var button = Ember.ButtonView.create();
-
-    childViews.pushObject(button);
-  }
 });
 ```
 


### PR DESCRIPTION
the previous example details adding a child view by a custom `addButton` method. the next example utilizes `childViews` as an array of strings and therefore the `addButton` view is neither necessary nor utilized.
