### PR TITLE
Add documentation for double colon syntax in class name bindings

### DIFF
--- a/source/docs/handlebars.md
+++ b/source/docs/handlebars.md
@@ -293,7 +293,7 @@ This emits the following HTML:
 
 Unlike other attributes, you can also bind multiple classes:
 
-```javascript
+```handlebars
 <div {{bindAttr class="isUrgent priority"}}>
   Warning!
 </div>
@@ -302,7 +302,7 @@ Unlike other attributes, you can also bind multiple classes:
 You can also specify an alternate class name to use, instead of just
 dasherizing.
 
-```javascript
+```handlebars
 <div {{bindAttr class="isUrgent:urgent"}}>
   Warning!
 </div>
@@ -310,6 +310,26 @@ dasherizing.
 
 In this case, if the `isUrgent` property is true, the `urgent` class
 will be added. If it is false, the `urgent` class will be removed.
+
+You can also specify a class name which shall be used when the property is `false`:
+
+```handlebars
+<div {{bindAttr class="isEnabled:enabled:disabled"}}>
+  Warning!
+</div>
+```
+
+In this case, if the `isEnabled` property is true, the `enabled` class will be added. If the property is false, the class `disabled` will be added.
+
+This syntax allows the shorthand for only adding a class when a property is `false`, so this:
+
+```handlebars
+<div {{bindAttr class="isEnabled::disabled"}}>
+  Warning!
+</div>
+```
+
+Will add the class `disabled` when `isEnabled` is `false` and add no class if `isEnabled` is `true`.
 
 ### Handling Events with {{action}}
 

--- a/source/docs/views.md
+++ b/source/docs/views.md
@@ -132,8 +132,59 @@ This would render this HTML:
 <div class="ember-view urgent">
 ```
 
+Besides the custom class name for the value being `true`, you can also specify a class name which is used when the value is `false`:
+
+```javascript
+App.MyView = Ember.View.extend({
+  classNameBindings: ['isEnabled:enabled:disabled'],
+  isEnabled: false
+});
+```
+
+This would render this HTML:
+
+```html
+<div class="ember-view disabled">
+```
+
+You can also specify to only add a class when the property is `false` by declaring `classNameBindings` like this:
+
+```javascript
+App.MyView = Ember.View.extend({
+  classNameBindings: ['isEnabled::disabled'],
+  isEnabled: false
+});
+```
+
+This would render this HTML:
+
+```html
+<div class="ember-view disabled">
+```
+
+If the `isEnabled` property is set to `true`, no class name is added:
+
+```html
+<div class="ember-view">
+```
+
+
 If the bound value is a string, that value will be added as a class name without
-modification.
+modification:
+
+```javascript
+App.MyView = Ember.View.extend({
+  classNameBindings: ['priority'],
+  priority: 'highestPriority'
+});
+```
+
+This would render this HTML:
+
+```html
+<div class="ember-view highestPriority">
+```
+
 
 ### Attribute Bindings on a View
 


### PR DESCRIPTION
This adds documentation for emberjs/ember.js#732
