### PR TITLE
Shift+clicking on logo prevents default browser action

### DIFF
--- a/source/layout.erb
+++ b/source/layout.erb
@@ -12,10 +12,8 @@
     <script type="text/javascript">
       $(function() {
         $('#logo').on('click', function(evt) {
-          if (evt.shiftKey) {
+          if (evt.shiftKey)
             $('#content-wrapper').toggleClass('grid');
-            return false;
-          }
         });
 
         var backToTop = $('#back-to-top');


### PR DESCRIPTION
Hi,

I'm trying to Cmd+Shift+click on the Ember logo to open it in a new tab and I cannot as the default browser action is being prevented.

I've fixed that by allowing the event to bubble and the default browser action to occur.
