### PR TITLE
Update tag for Ember.js on StackOverflow

### DIFF
--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -20,7 +20,7 @@ title: "Community"
 <div class="community section">
   <h2>Get Help</h2>
 
-  <p><a href="http://stackoverflow.com">StackOverflow</a> is used to track questions. Just tag your question with <code>emberjs</code> or <a href="http://stackoverflow.com/questions/tagged/emberjs">search for questions with that tag</a>. Please check to see if your question has already been answered before asking a new one.</p>
+  <p><a href="http://stackoverflow.com">StackOverflow</a> is used to track questions. Just tag your question with <code>ember.js</code> or <a href="http://stackoverflow.com/questions/tagged/ember.js">search for questions with that tag</a>. Please check to see if your question has already been answered before asking a new one.</p>
 
   <p>There is also an IRC channel which can be found at <code>#emberjs</code> on Freenode. For more information on connecting to Freenode, please see <a href="http://www.freenode.net">the Freenode website</a>
 </div>


### PR DESCRIPTION
Previously Ember.js related questions were tagged with `emberjs` which has
been renamed to `ember.js` lately.
