### PR TITLE
Fixing TextFieldView Typo in Docs

### DIFF
--- a/source/guides/view_layer.md
+++ b/source/guides/view_layer.md
@@ -368,8 +368,8 @@ App.FormView = Ember.View.extend({
 
 ```
 {{#view App.FormView}}
-  {{view Ember.TextFieldView valueBinding="controller.firstName"}}
-  {{view Ember.TextFieldView valueBinding="controller.lastName"}}
+  {{view Ember.TextField valueBinding="controller.firstName"}}
+  {{view Ember.TextField valueBinding="controller.lastName"}}
   <button type="submit">Done</button>
 {{/view}}
 ```


### PR DESCRIPTION
It used to say TextFieldView, which was wrong and sad. Now it says
TextField which is happy and fun.
