### PR TITLE
Clarify duration math in controller guide

### DIFF
--- a/source/guides/controllers/index.md
+++ b/source/guides/controllers/index.md
@@ -112,13 +112,9 @@ by the template:
 ```javascript
 App.SongController = Ember.ObjectController.extend({
   duration: function() {
-    var seconds = this.get('content.duration'),
-        divisorForMinutes = seconds % 3600,
-        divisorForSeconds = divisorForMinutes % 60,
-        minutes, seconds;
-
-    minutes = Math.floor(divisorForMinutes / 60),
-    seconds = Math.ceil(divisorForSeconds);
+    var duration = this.get('content.duration'),
+         minutes = Math.floor(duration / 60),
+         seconds = duration % 60;
 
     return [minutes, seconds].join(':');
   }.property('content.duration')


### PR DESCRIPTION
The original is more confusing than it needs to be and further it is inaccurate (the `seconds % 3600` operation lops off the number of hours in the track if it is more than an hour).

Also, there is no need for `Math.ciel()` to be called on calculated seconds (provided that the duration property in the model is always an integer number of seconds).

Anyway, I think this is clearer.
