### PR TITLE
API visibility options are remembered across page refreshes

### DIFF
--- a/source/api_layout.erb
+++ b/source/api_layout.erb
@@ -2,12 +2,28 @@
   <% content_for :head do %>
     <script>
       $(function() {
+        // Restoring method visibility preference from localStorage
+        function initApiOptions() {
+          var type = this.getAttribute('data-type');
+            
+
+          if (localStorage && (checked = localStorage.getItem('api-options-' + type)) != undefined) {
+            // Bools are stored as strings in localStorage
+            checked = checked == 'true';
+            $(this).attr('checked', checked);
+          }
+        };
+
         // Type toggling
         function toggleType() {
+          if ( !localStorage ) return;
           var type = this.getAttribute('data-type');
+
           $('.'+type).toggle(this.checked);
+          localStorage.setItem('api-options-' + type, this.checked);
         }
 
+        $('#api-options input').each(initApiOptions);
         $('#api-options input').each(toggleType);
         $('#api-options input').on('change', toggleType);
 


### PR DESCRIPTION
This is a slight modification from pr #144. This will check to make sure localStorage is available before using it.
