### PR TITLE
Fix documentation for pluralization

### DIFF
--- a/source/guides/models/the-rest-adapter.md
+++ b/source/guides/models/the-rest-adapter.md
@@ -21,10 +21,8 @@ You can specify irregular pluralizations via the adapter's `configure`
 API:
 
 ```js
-DS.RESTAdapter.configure({
-  plurals: {
-    person: "people"
-  }
+DS.RESTAdapter.configure("plurals", {
+  person: "people"
 });
 ```
 


### PR DESCRIPTION
The mentioned way of `DS.RESTAdapter.configure({ plurals: { ... } })` is being silently ignored. I figured this out from the tests, which are using the `DS.RESTAdapter.configure("plurals", { ... });` which works.
