### PR TITLE
Added previous / next links in guides

### DIFF
--- a/lib/toc.rb
+++ b/lib/toc.rb
@@ -75,6 +75,74 @@ module TOC
       %Q{<h1> #{name} </h1>}
     end
 
+    def section_slug
+      request.path.split('/')[2]
+    end
+
+    def guide_slug
+      request.path.split('/')[3]
+    end
+
+    def current_section
+      data.guides.find do |section, entries|
+        entries[0].url.split("/")[0] == section_slug
+      end
+    end
+
+    def current_guide
+      if guide_slug == 'index.html'
+        current_section[1][0]
+      else
+        current_section[1].find{|guide| guide.url.split('/')[1] == guide_slug}
+      end
+    end
+
+    def chapter_links
+      %Q{
+      <footer>
+        #{previous_chapter_link} #{next_chapter_link}
+      </footer>
+      }
+    end
+
+    def previous_chapter_link
+      return '' unless previous_chapter
+      %Q{
+        <a class="previous-guide" href="/guides/#{previous_chapter.url}">
+          \u2190 #{previous_chapter.title}
+        </a>
+      }
+    end
+
+    def next_chapter_link
+      return '' unless next_chapter
+      %Q{
+      <a class="next-guide" href="/guides/#{next_chapter.url}">
+        #{next_chapter.title} \u2192
+      </a>
+      }
+    end
+
+    def previous_chapter
+      guides = current_section[1]
+      current_index = guides.find_index(current_guide)
+      if current_index != 0
+        guides[current_index-1]
+      else
+        nil
+      end
+    end
+
+    def next_chapter
+      guides = current_section[1]
+      current_index = guides.find_index(current_guide)
+      if current_index < guides.length
+        guides[current_index+1]
+      else
+        nil
+      end
+    end
+
     def table_of_contents
       chapters = data.documentation.chapters
       chapters = chapters.collect_concat do |file|

--- a/source/layouts/guide.erb
+++ b/source/layouts/guide.erb
@@ -16,6 +16,7 @@
   <div class="chapter">
     <%= chapter_heading %>
     <%= yield %>
+    <%= chapter_links %>
   </div>
 
   <script>

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -865,6 +865,13 @@ $content-width: $page-width - $sidebar-width - $col-spacing * 2;
   }
 }
 
+.previous-guide {
+  float: left;
+}
+
+.next-guide {
+  float: right;
+}
 
 /**
   Blogs


### PR DESCRIPTION
So much easier to follow the guides with these. Here's how they look:

![Screen Shot 2013-01-02 at 12 30 39 PM](https://f.cloud.github.com/assets/305901/38842/797aa87c-5503-11e2-9424-6785daa24624.png)
