### PR TITLE
Fix templates link in application template md

### DIFF
--- a/source/guides/application/the-application-template.md
+++ b/source/guides/application/the-application-template.md
@@ -43,4 +43,5 @@ to the screen.
 If you're using build tools to load your templates, make sure you name
 the template `application`.
 
-For more information, see [Templates](/guides/templates/) and [Routing](/guides/routing/).
+For more information, see
+[Templates](/guides/templates/handlebars-basics) and [Routing](/guides/routing/).


### PR DESCRIPTION
The application-templates.md has a link at the botton that redirects to an inexistent file.

This fixes it by redirecting to handlebars-basics.
