### PR TITLE
proof of concept rendering versioned guides by commit ref

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "thin"
 gem "rack"
 gem "listen"
 gem "builder"
+gem "grit"
 
 group :development do
   gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,11 +22,16 @@ GEM
       fssm (>= 0.2.7)
       sass (~> 3.1)
     daemons (1.1.8)
+    diff-lcs (1.1.3)
     eventmachine (0.12.10)
     execjs (1.4.0)
       multi_json (~> 1.0)
     ffi (1.4.0)
     fssm (0.2.10)
+    grit (2.5.0)
+      diff-lcs (~> 1.1)
+      mime-types (~> 1.15)
+      posix-spawn (~> 0.3.6)
     haml (4.0.0)
       tilt
     highline (1.6.13)
@@ -73,6 +78,7 @@ GEM
       middleman-more (>= 3.0.1)
       sprockets (~> 2.1, < 2.5)
       sprockets-sass (~> 0.9.0)
+    mime-types (1.21)
     multi_json (1.6.1)
     padrino-core (0.10.7)
       activesupport (~> 3.2.0)
@@ -83,6 +89,7 @@ GEM
     padrino-helpers (0.10.7)
       i18n (~> 0.6)
       padrino-core (= 0.10.7)
+    posix-spawn (0.3.6)
     pry (0.9.10)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
@@ -132,6 +139,7 @@ DEPENDENCIES
   activesupport
   builder
   coderay!
+  grit
   highline
   listen
   middleman (~> 3.0)

--- a/data/guide_versions.yml
+++ b/data/guide_versions.yml
@@ -1,0 +1,3 @@
+Current: Edge
+Edge: master
+Old: 4de6feab9c2a

--- a/lib/toc.rb
+++ b/lib/toc.rb
@@ -37,7 +37,7 @@ module TOC
 
         result << %Q{
           <li class="level-1#{current ? ' selected' : ''}">
-            <a href="/guides/#{entries[0].url}">#{section}</a>
+            <a href="/guides/#{@sha}/#{entries[0].url}">#{section}</a>
             <ol#{current ? " class='selected'" : ''}>
         }
 
@@ -54,7 +54,7 @@ module TOC
 
           result << %Q{
             <li class="level-3#{sub_current ? ' sub-selected' : ''}">
-              <a href="/guides/#{entry.url}">#{entry.title}</a>
+              <a href="/guides/#{@sha}/#{entry.url}">#{entry.title}</a>
             </li>
           }
         end
@@ -68,9 +68,9 @@ module TOC
     end
 
     def chapter_name
-      guides = data.guides
+      guides = @guides
 
-      sub_url = request.path.split('/')[1]
+      sub_url = request.path.split('/')[2]
       heading = ''
 
       guides.each_entry do |section, entries|
@@ -121,7 +121,7 @@ module TOC
     def previous_chapter_link
       return '' unless previous_chapter
       %Q{
-        <a class="previous-guide" href="/guides/#{previous_chapter.url}">
+        <a class="previous-guide" href="/guides/#{@sha}/#{previous_chapter.url}">
           \u2190 #{previous_chapter.title}
         </a>
       }
@@ -130,7 +130,7 @@ module TOC
     def next_chapter_link
       return '' unless next_chapter
       %Q{
-      <a class="next-guide" href="/guides/#{next_chapter.url}">
+      <a class="next-guide" href="/guides/#{@sha}/#{next_chapter.url}">
         #{next_chapter.title} \u2192
       </a>
       }

--- a/source/guides/versioned.html.erb
+++ b/source/guides/versioned.html.erb
@@ -1,0 +1,1 @@
+<%= render_individual_file @path, nil, :template_body => @template %>

--- a/source/layout.erb
+++ b/source/layout.erb
@@ -81,7 +81,7 @@
         <a id="logo" href="/">&nbsp;</a>
         <ul id="nav">
           <%= link_to_page "about", "/about" %>
-          <%= link_to_page "guides", "/guides" %>
+          <%= link_to_page "guides", "/guides/#{data.guide_versions[data.guide_versions["Current"]]}" %>
           <%= link_to_page "api", "/api" %>
           <%= link_to_page "community", "/community" %>
           <%= link_to_page "blog", "/blog" %>

--- a/source/layouts/guide.erb
+++ b/source/layouts/guide.erb
@@ -4,8 +4,15 @@
 %>
 
 <% wrap_layout(:layout) do %>
+  <nav>
+    <% data.guide_versions.each do |name, sha| %>
+      <% next if name == "Current" %>
+      <a href="/guides/<%= sha %>"><%= name %></a>
+    <% end %>
+  </nav>
+
   <% content_for(:sidebar) do %>
-    <%= index_for(data.guides) %>
+    <%= index_for(@guides) %>
   <% end %>
 
   <div class="chapter">


### PR DESCRIPTION
@wagenet

Ripping through the git repo with the "grit" gem to get guides and the guides.yml for individual commit references. Could be tags or branches.

I seem to have broken the rendering for the sidebar and the markdown a little bit. I hacked something to render markdown through tilt in an erb template. 
