### PR TITLE
Google+ link in footer

### DIFF
--- a/source/layout.erb
+++ b/source/layout.erb
@@ -97,7 +97,7 @@
         <div class="links">
           <a class="twitter" href="http://twitter.com/emberjs">Twitter</a>
           <a class="github" href="https://github.com/emberjs/ember.js">GitHub</a>
-          <%# <a class="googleplus" href="#">Google+</a> %>
+          <a class="googleplus" href="https://plus.google.com/communities/106387049790387471205">Google+</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Saw this issue lying around and I just started using G+ so I thought I'd add it :smile: 

Fixes #212 
