### PR TITLE
Clarification as to which version the Guides currently apply to

### DIFF
--- a/source/guides/index.md
+++ b/source/guides/index.md
@@ -23,3 +23,7 @@ in the order that we think will be most useful to you as you're learning
 Ember.js, but you can also jump to whatever seems most interesting.
 
 Good luck!
+
+**NOTE:** 
+These guides currently reflect our "master" branch since we are
+in a pre-release cycle.


### PR DESCRIPTION
As per C5's conversation at Tilde today, API pages currently reflect Pre2 but the Guides reflect the "master" branch. This is confusing, here's a quick update..
