### PR TITLE
Shift .selected .sub-selected padding to all level-3 li

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -781,9 +781,7 @@ $content-width: $page-width - $sidebar-width - $col-spacing * 2;
           }
 
           li.sub-selected {
-            padding-top: 6px;
             background-color: #fcc;
-            margin-bottom: 3px;
           }
         }
 
@@ -826,6 +824,11 @@ $content-width: $page-width - $sidebar-width - $col-spacing * 2;
           &.sub-selected {
             // fancy me up.
           }
+        }
+
+        &.level-3 {
+            padding-top: 6px;
+            margin-bottom: 3px;
         }
       }
     }


### PR DESCRIPTION
This avoids selected list items from having a few extra pixels added, at the expense of some extra space usage for every list item.

Haven't thoroughly checked this change's impact on other parts of the site, just its effect on [the original problem from Twitter](https://twitter.com/tomdale/status/290280704565182465).
