### PR TITLE
Added information for Multiple Store Adapters

### DIFF
--- a/source/guides/models/defining-a-store.md
+++ b/source/guides/models/defining-a-store.md
@@ -32,3 +32,14 @@ App.Store = DS.Store.extend({
   adapter: 'App.MyCustomAdapter'
 });
 ```
+
+### Multiple Adapters
+In some instances it can be necessary to need different adapters for
+different models in your project. The Store object supports registering
+multiple adapters like so:
+
+```js
+App.Store.registerAdapter('App.Post', DS.RESTAdapter.extend({
+  // implement adapter
+}));
+```


### PR DESCRIPTION
There is no documentation on registering multiple adapters in the guides.
