### PR TITLE
Fixing a syntax error in your routing guide

### DIFF
--- a/source/guides/routing/defining-your-routes.md
+++ b/source/guides/routing/defining-your-routes.md
@@ -249,7 +249,7 @@ You cannot nest routes, but you can nest resources:
 
 ```javascript
 App.Router.map(function() {
-  this.resource('post', function({ path: '/post/:post_id' }) {
+  this.resource('post', { path: '/post/:post_id' }, function() {
     this.route('edit');
     this.resource('comments', function() {
     	this.route('new');


### PR DESCRIPTION
Inside of "Defining Your Routes / Nested Resources" there is one example where you pass a Hash with the path-key as a parameter for a callback function. This causes a syntax error.
