### PR TITLE
Make .level-3 links block elements to allow for larger target area

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -322,6 +322,8 @@ ol {
           color: #d84a32;
           font-weight: normal;
           font-size: 12px;
+          padding: .21em 0em .2em 1em;
+          display: block;
         }
         &.sub-selected {
           // fancy me up.


### PR DESCRIPTION
Noticed that the sub-links or .level-3 links in the docs were not blocks so you have to directly click on the text.  This patch will allow users to click on the menu items without precision accuracy.  No big deal if these doesn't get merged in, just me nitpicking.  Tested in Chrome, Firefox, Safari.  No access to IE right now.
