### PR TITLE
Typo - 'model' should be 'content'

### DIFF
--- a/source/guides/routing/setting-up-a-controller.md
+++ b/source/guides/routing/setting-up-a-controller.md
@@ -37,7 +37,7 @@ information, see [Specifying a Route's Model][1].
 
 [1]: /guides/routing/specifying-a-routes-model
 
-The default `setupController` hook sets the `model` property of the
+The default `setupController` hook sets the `content` property of the
 associated controller to the route handler's model.
 
 If you want to configure a controller other than the controller


### PR DESCRIPTION
Small typo fix. Cheers!
