### PR TITLE
Add {{else}} documentation for {{each}} helper in Templates guide

### DIFF
--- a/source/guides/templates/displaying-a-list-of-items.md
+++ b/source/guides/templates/displaying-a-list-of-items.md
@@ -52,3 +52,14 @@ Trek's Friends
   <li>Trek's friend Tom!</li>
 </ul>
 ```
+
+The `{{#each}}` helper can have a matching `{{else}}`.
+The contents of this block will render if the collection is empty:
+
+```handlebars
+{{#each people}}
+  Hello, {{name}}!
+{{else}}
+  Sorry, nobody is here.
+{{/each}}  
+```


### PR DESCRIPTION
The `{{else}}` documentation was missing for the `{{each}}` helper.
@trek made a PR for in-source documentation (https://github.com/emberjs/ember.js/pull/1966).

I just added its example in the Templates - "Displaying a List of Items" guide.
