### PR TITLE
Document REST adapter's URL pattern for loading a relationship

### DIFF
--- a/source/guides/models/the-rest-adapter.md
+++ b/source/guides/models/the-rest-adapter.md
@@ -113,7 +113,9 @@ The JSON should encode the relationship as an array of IDs:
 }
 ```
 
-`Comments` for a `post` can be loaded by `post.get('comments')`. The REST adapter will send a `GET` request to `/comments?ids[]=1&ids[]=2&ids[]=3`.
+`Comments` for a `post` can be loaded by `post.get('comments')`. The 
+REST adapter will send a `GET` request to `/comments?ids[]=1&
+ids[]=2&ids[]=3`.
   
 Any `belongsTo` relationships in the JSON representation should be the
 underscored version of the Ember Data model's name, with the string


### PR DESCRIPTION
This extends the `Post`, `Comments` example in the REST Adapter guide by mentioning the loading of a relationship and the url pattern for it.
