### PR TITLE
Improve Back to Top Alignment and Responsiveness

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -214,9 +214,21 @@ ol {
   position: relative;
 
   #back-to-top {
+    padding-left: 13px;
     text-align: center;
     display: none;
     @include transition(opacity 0.05s linear);
+
+    @media screen and (max-width: 1200px){
+      padding-left: 0px;
+      height: 20px;
+      width: 30px;
+      overflow: hidden;
+    }
+
+    @media screen and (max-width: 1020px){
+      display: none !important;
+    }
   }
 
   a {


### PR DESCRIPTION
Added padding to the "Back to Top" link so that it wasn't suffocating
against the edge of the browser window.

Added some responsive changes to the "Back to Top" link so that it
doesn't cover over Guide section navigation on browser window sizes
below 1200 and 1025 pixels.
