### PR TITLE
Fixed header formatting for App.reset (looked like code, now looks like heading)

### DIFF
--- a/source/blog/2013-02-15-ember-1-0-rc.html.markdown
+++ b/source/blog/2013-02-15-ember-1-0-rc.html.markdown
@@ -79,7 +79,7 @@ that the `activate` hook will run only when a route handler is activated for
 the first time. If a route handler's context changes, the `setupController`
 hook will run again, but not the `activate` hook.
 
-### `App.reset()`
+### App.reset()
 
 If you are trying to run integration tests with Ember, you might have noticed
 that there is no good way to reset all of an application's state.


### PR DESCRIPTION
I became confused as I was reading about 'ROUTER ACTIVATE AND DEACTIVATE' and then came across App.reset() until I realized there was a formatting issue and App.reset() should be its own heading. 
