### PR TITLE
Updated copyright year in footer

### DIFF
--- a/source/layout.erb
+++ b/source/layout.erb
@@ -107,7 +107,7 @@
 
     <div id="footer">
       <div id="footer-wrapper">
-        <div class="info">Copyright 2012 <a href="http://tilde.io">Tilde Inc.</a><br>Design by <a href="http://www.heropixel.com">HeroPixel</a></div>
+        <div class="info">Copyright <%= Time.now.strftime('%Y') %> <a href="http://tilde.io">Tilde Inc.</a><br>Design by <a href="http://www.heropixel.com">HeroPixel</a></div>
         <div class="statement">Ember.js is free, open source and always will be.</div>
         <div class="links">
           <a class="twitter" href="http://twitter.com/emberjs">Twitter</a>


### PR DESCRIPTION
Replaced "2012" with <%= Time.now.strftime('%Y') %> so copyright will remain up to date in the future
