### PR TITLE
Fix styles for 404 page

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -86,4 +86,10 @@ helpers do
 
     "<li#{class_name}><a href=\"#{url}\">#{name}</a></li>"
   end
+
+  def page_classes
+    classes = super
+    return 'not-found' if classes == '404'
+    classes
+  end
 end

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -1367,3 +1367,13 @@ body.api {
     display: block;
   }
 }
+
+/**
+  404 Page
+**/
+
+body.not-found #content {
+  margin: 3em auto 0 auto;
+  width: 54em;
+}
+


### PR DESCRIPTION
- 404 body class is now not-found to avoid style compilation error (css classes can't start with a number)

fixes https://github.com/emberjs/website/issues/301
