### PR TITLE
RESTAdapter semantics changes

### DIFF
--- a/source/guides/models/the-rest-adapter.md
+++ b/source/guides/models/the-rest-adapter.md
@@ -108,7 +108,7 @@ The JSON should encode the relationship as an array of IDs:
 ```js
 {
   "post": {
-    "comments": [1, 2, 3]
+    "comment_ids": [1, 2, 3]
   }
 }
 ```
@@ -144,7 +144,7 @@ outside the JSON root, and are represented as an array of hashes:
   "post": {
     "id": 1,
     "title": "Rails is omakase",
-    "comments": [1, 2, 3]
+    "comment_ids": [1, 2, 3]
   },
 
   "comments": [{


### PR DESCRIPTION
This example doesn't work anymore since: https://github.com/emberjs/data/commit/7b5455d04d7acf9faf07e6ecf40f4af25c0e394a
