### PR TITLE
Remove reference to per-type-adapters

### DIFF
--- a/source/guides/models/defining-a-store.md
+++ b/source/guides/models/defining-a-store.md
@@ -32,14 +32,3 @@ App.Store = DS.Store.extend({
   adapter: 'App.MyCustomAdapter'
 });
 ```
-
-### Multiple Adapters
-In some instances it can be necessary to need different adapters for
-different models in your project. The Store object supports registering
-multiple adapters like so:
-
-```js
-App.Store.registerAdapter('App.Post', DS.RESTAdapter.extend({
-  // implement adapter
-}));
-```


### PR DESCRIPTION
I don't think we should reference per-type-adapters when emberjs/data#739 is still unsolved. It confuses people into thinking that they can use them, while in fact there is no workaround for the issue.
