### PR TITLE
Removing a reference to the obsolete StateManager, using Routes instead

### DIFF
--- a/source/guides/understanding-ember/the-view-layer.md
+++ b/source/guides/understanding-ember/the-view-layer.md
@@ -276,7 +276,7 @@ implements that event as a method:
 App.DeleteButton = Ember.View.create({
   click: function(event) {
     var item = this.get('content');
-    App.Router.router.trigger('deleteItem', item);
+    this.get('controller').send('deleteItem', item);
   }
 });
 ```


### PR DESCRIPTION
Changing the reference to use router code that I know works, but is probably wrong. The code I've put in seems overly verbose.

If someone wants to show a better way to accomplish passing a message from views to routers, I'll update the PR with the _correct_ way to do this?
