### PR TITLE
fix typo in dependencies-between-controllers.md

### DIFF
--- a/source/guides/controllers/dependencies-between-controllers.md
+++ b/source/guides/controllers/dependencies-between-controllers.md
@@ -41,7 +41,7 @@ it's parent `PostController`, which can be done via `controllers.post`
 ```
 
 We can also create a binding to give ourselves a shorter way to access
-the `PostControler` (since it is `ObjectController`, we don't need or
+the `PostController` (since it is `ObjectController`, we don't need or
 want the `Post` instance directly).
 
 


### PR DESCRIPTION
Fixes a typo in the guide for managing dependencies between controllers,
changing 'Controler' to 'Controller' (one l vs two ls on the end).

fixes #344
