### PR TITLE
Guides: Cannot override computed properties when creating instance

### DIFF
--- a/source/guides/object-model/computed-properties.md
+++ b/source/guides/object-model/computed-properties.md
@@ -30,8 +30,7 @@ The `property` method defines the function as a computed property, and
 defines its dependencies. Those dependencies will come into play
 later when we discuss bindings and observers.
 
-When subclassing a class or creating a new instance, you can
-override any computed properties.
+When subclassing a class, you can override any computed properties.
 
 ### Setting Computed Properties
 


### PR DESCRIPTION
This is stated in the _Classes and Instances_ section and confirmed by the error message "Ember.Object.create no longer supports defining computed properties", so the wording in the _Computed Properties_ section should be changed.
