### PR TITLE
Source of :rubygems is deprecated. Replaced with 'https://rubygems.org'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem "redcarpet"
 gem "activesupport"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,7 +6,7 @@ GIT
     coderay (1.0.8.rc1)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     activesupport (3.2.12)
       i18n (~> 0.6)


### PR DESCRIPTION
Fixes a deprecation warning when running `bundle install`
