### PR TITLE
Added more description on rendering templates in the router

### DIFF
--- a/source/guides/routing/rendering-a-template.md
+++ b/source/guides/routing/rendering-a-template.md
@@ -72,3 +72,22 @@ NOTE: When a template tries to render, and the parent route did not render a tem
 This means that the the current route tried to render into the parent routes template, but the parent route didn't render a template, or if it did, the template did not render 'into' the main template (a default {{outlet}}). For the case of the following routes: Application > Posts > Post, if the posts route does not have a template, the post template will render into the application template.
 
 This default behavior could be what you expect, or it could be unexpected and the waring is there to point out the potential unexpected behavior.
+
+If you want to render two different templates into outlets of two different rendered templates of a route:
+
+```js
+App.PostRoute = App.Route.extend({
+  renderTemplate: function() {
+    this.render('favoritePost', {   // the template to render
+      into: 'index',                // the template to render into
+      outlet: 'detail',       // the name of the outlet in that template
+      controller: 'blogPost'  // the controller to use for the template
+    });
+    this.render('myPost', {   
+      into: 'posts',          
+      outlet: 'post',       
+      controller: 'blogPost' 
+    });
+  }
+});
+```


### PR DESCRIPTION
-The given example helps to understand how to render multiple templates into different outlets.
-Also helps to understand rendering a template into outlet of rendered one using `into` parameter of `render` method
