### PR TITLE
Update defining-your-routes as there is a typo mistake

### DIFF
--- a/source/guides/routing/defining-your-routes.md
+++ b/source/guides/routing/defining-your-routes.md
@@ -226,7 +226,7 @@ followed by an identifier.
 ```js
 App.Router.map(function() {
   this.resource('posts');
-  this.resource('post', { path: '/posts/:post_id' });
+  this.resource('post', { path: '/post/:post_id' });
 });
 
 App.PostRoute = Ember.Route.extend({


### PR DESCRIPTION
In the Dynamic segments example i think there is a typo mistake.
this.resource('post', { path: '/posts/:post_id' }); should be this.resource('post', { path: '/post/:post_id' });
