### PR TITLE
Removed unnecessary quotes around {{action}} name.

### DIFF
--- a/data/api.yml
+++ b/data/api.yml
@@ -7185,7 +7185,7 @@ classitems:
     \   click me\n  </div>\n</div>\n```\n\nClicking \"click me\" will trigger the
     `anActionName` method of the\n`AController`. In this case, no additional parameters
     will be passed.\n\nIf you provide additional parameters to the helper:\n\n```handlebars\n<button
-    {{action 'edit' post}}>Edit</button>\n```\n\nThose parameters will be passed along
+    {{action edit post}}>Edit</button>\n```\n\nThose parameters will be passed along
     as arguments to the JavaScript\nfunction implementing the action.\n\n### Event
     Propagation\n\nEvents triggered through the action helper will automatically have\n`.preventDefault()`
     called on them. You do not need to do so in your event\nhandlers.\n\nTo also disable

--- a/source/guides/routing/sending-events-from-templates.md
+++ b/source/guides/routing/sending-events-from-templates.md
@@ -5,19 +5,19 @@ Use the `{{action}}` helper to attach a handler in your view class to an event t
 To attach an element's `click` event to the `edit()` handler in the current view:
 
 ```handlebars
-<a href="#" {{action "edit" on="click"}}>Edit</a>
+<a href="#" {{action edit on="click"}}>Edit</a>
 ```
 
 Because the default event is `click`, this could be written more concisely as:
 
 ```handlebars
-<a href="#" {{action "edit"}}>Edit</a>
+<a href="#" {{action edit}}>Edit</a>
 ```
 
 Although the view containing the `{{action}}` helper will be targeted by default, it is possible to target a different view:
 
 ```handlebars
-<a href="#" {{action "edit" target="parentView"}}>Edit</a>
+<a href="#" {{action edit target="parentView"}}>Edit</a>
 ```
 
 The action handler can optionally accept a jQuery event object, which will be extended to include `view` and `context` properties. These properties can be useful when targeting a different view with your action. For instance:

--- a/source/guides/templates/actions.md
+++ b/source/guides/templates/actions.md
@@ -18,9 +18,9 @@ and supports expanding the post with additional information.
 
 {{#if isExpanded}}
   <div class='body'>{{body}}</div>
-  <button {{action "contract"}}>Contract</button>
+  <button {{action contract}}>Contract</button>
 {{else}}
-  <button {{action "expand"}}>Show More...</button>
+  <button {{action expand}}>Show More...</button>
 {{/if}}
 ```
 


### PR DESCRIPTION
Considering the quotes around the action name are no longer necessary, I
think it'd be less distracting if we just presented them without the
quotes. Seems more intuitive this way: an action name ultimately
resolved to a function, which makes it kind of weird to represent as a
string when you're first learning this stuff.
