### PR TITLE
Use fully qualified path to fix broken link

### DIFF
--- a/source/guides/application/index.md
+++ b/source/guides/application/index.md
@@ -18,7 +18,7 @@ Having an application object is important for several reasons:
 2. It adds event listeners to the document and is responsible for
    sending events to your views.
 3. It automatically renders the [_application
-   template_](application/the-application-template), the root-most
+   template_](/guides/application/the-application-template), the root-most
    template, into which your other templates will be rendered.
 4. It automatically creates a router and begins routing, based on the
    current URL.


### PR DESCRIPTION
The link to 'application template' on http://emberjs.com/guides/application/ currently uses a relative path which results in a 404. This PR simply uses an absolute path as found elsewhere in the docs.
