### PR TITLE
Updated the routing guide regarding the deprecated use of controllerFor

### DIFF
--- a/source/guides/routing/redirection.md
+++ b/source/guides/routing/redirection.md
@@ -29,16 +29,18 @@ App.Router.map(function() {
 });
 
 App.TopChartsChooseRoute = Ember.Route.extend({
+  needs: ['application'],
   redirect: function() {
-    var lastFilter = this.controllerFor('application').get('lastFilter');
+    var lastFilter = this.get('controllers.application').get('lastFilter');
     this.transitionTo('topCharts.' + lastFilter || 'songs');
   }
 });
 
 // Superclass to be used by all of the filter routes below
 App.FilterRoute = Ember.Route.extend({
+  needs: ['application'],
   enter: function() {
-    var controller = this.controllerFor('application');
+    var controller = this.get('controllers.application');
     controller.set('lastFilter', this.templateName);
   }
 });

--- a/source/guides/routing/rendering-a-template.md
+++ b/source/guides/routing/rendering-a-template.md
@@ -51,8 +51,10 @@ combination you'd like:
 
 ```js
 App.PostsRoute = Ember.Route.extend({
+  needs: ['favoritePost'],
+
   renderTemplate: function() {
-    var controller = this.controllerFor('favoritePost');
+    var controller = this.get('controllers.favoritePost');
 
     // Render the `favoritePost` template into
     // the outlet `posts`, and display the `favoritePost`

--- a/source/guides/routing/setting-up-a-controller.md
+++ b/source/guides/routing/setting-up-a-controller.md
@@ -41,12 +41,15 @@ The default `setupController` hook sets the `model` property of the
 associated controller to the route handler's model.
 
 If you want to configure a controller other than the controller
-associated with the route handler, use the `controllerFor` method:
+associated with the route handler, you need to provide the name
+of that controller in the `needs` array and `get` that controller
+from the controllers array:
 
 ```js
 App.PostRoute = Ember.Route.extend({
+  needs: ['topPost'],
   setupController: function(controller, model) {
-    this.controllerFor('topPost').set('content', model);
+    this.get('controllers.topPost').set('content', model);
   }
 });
 ```


### PR DESCRIPTION
According to @stefanpenner changes (https://github.com/stefanpenner/ember.js/commit/4f2c27c720a414f740dcfc960d54f34acc145abb), the use of controllerFor is deprecated, so I updated the docs to reflect that.
