### PR TITLE
Removed examples info from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,3 @@ bundle exec middleman
 ```
 
 Then visit [http://localhost:4567/](http://localhost:4567/)
-
-### Examples
-
-The example apps are kept in a separate repository at [https://github.com/emberjs/examples](https://github.com/emberjs/examples).
-To get the most up-to-date version of them, run `rake examples:update`
-from the command line. This step is automatically done when you do a
-build.


### PR DESCRIPTION
Because these are deprecated!
