### PR TITLE
Use null instead of empty string on homepage example

### DIFF
--- a/source/about.html.erb
+++ b/source/about.html.erb
@@ -57,8 +57,8 @@ title: "About"
 App = Ember.Application.create();
 
 App.Person = Ember.Object.extend({
-  firstName: "",
-  lastName: "",
+  firstName: null,
+  lastName: null,
 
   fullName: function() {
     return this.get('firstName') +


### PR DESCRIPTION
As requested by @ebryn in #411 . PR was merged before I had the chance to updated it.
