### PR TITLE
Fix homepage example to use index

### DIFF
--- a/source/about.html.erb
+++ b/source/about.html.erb
@@ -69,7 +69,7 @@ App.Person = Ember.Object.extend({
   }.property('firstName', 'lastName')
 });
 
-App.ApplicationRoute = Ember.Route.extend({
+App.IndexRoute = Ember.Route.extend({
   model: function() {
     var people = [
       App.Person.create({
@@ -89,6 +89,10 @@ App.ApplicationRoute = Ember.Route.extend({
 
 <% highlight :handlebars, :right do %>
 <script type="text/x-handlebars">
+  {{outlet}}
+</script>
+
+<script type="text/x-handlebars" id="index">
   <h1>People</h1>
 
   <ul>


### PR DESCRIPTION
Returning a model in `ApplicationRoute` might cause the application template to re-render in some cases (as mentioned [here](http://discuss.emberjs.com/t/getting-started-snippet-question/851)).

The application template should never re-render because it is appended to the body, therefore causing a duplicate template on re-render.

This PR also adds an `{{outlet}}`, and since some people are using this example as a starting point, having an outlet ready will make it easier for them to build on the example.
