### PR TITLE
Added binding attributes to differently named properties

### DIFF
--- a/source/guides/views/customizing-a-views-element.md
+++ b/source/guides/views/customizing-a-views-element.md
@@ -116,6 +116,16 @@ App.MyView = Ember.View.extend({
 });
 ```
 
+You can also bind these attributes to differently named properties:
+
+```javascript
+App.MyView = Ember.View.extend({
+  tagName: 'a',
+  attributeBindings: ['customHref:href'],
+  customHref: "http://emberjs.com"
+});
+```
+
 ### Customizing a View's Element from Handlebars
 
 When you append a view, it creates a new HTML element that holds its content.


### PR DESCRIPTION
Added a small part in the "Customizing a view's element" guide about the possibility to bind an attribute to a property named differently from the attribute.
