### PR TITLE
Fixed an error in example javascript

### DIFF
--- a/source/guides/routing/redirection.md
+++ b/source/guides/routing/redirection.md
@@ -31,7 +31,7 @@ App.Router.map(function() {
 App.TopChartsChooseRoute = Ember.Route.extend({
   redirect: function() {
     var lastFilter = this.controllerFor('application').get('lastFilter');
-    this.transitionTo('topCharts.' + lastFilter || 'songs');
+    this.transitionTo('topCharts.' + (lastFilter || 'songs') );
   }
 });
 


### PR DESCRIPTION
The version before throws an error in Chrome telling that "topCharts.undefined" cannot be found.
