### PR TITLE
Remove starter kit link from homepage

### DIFF
--- a/source/about.html.erb
+++ b/source/about.html.erb
@@ -29,9 +29,6 @@ title: "About"
     <div class="info">51k min+gzip |
       <a class="debug" href="https://raw.github.com/emberjs/ember.js/release-builds/ember-1.0.0-rc.2.min.js">
         minified
-      </a> |
-      <a class="debug" href="https://github.com/emberjs/starter-kit/archive/v1.0.0-rc.2.zip">
-        Starter Kit
       </a>
     </div>
   </div>


### PR DESCRIPTION
This was causing confusion with some of my team members who were trying to get
started with Ember and downloaded this from the site. Since we took down the
starter kit from Github, why not do the same on the website?
