### PR TITLE
copy edit: "forebearers" is not actually a word

### DIFF
--- a/source/guides/concepts/core-concepts.md
+++ b/source/guides/concepts/core-concepts.md
@@ -15,7 +15,7 @@ constraints of the web–-we turned to other popular open source projects
 like Ruby on Rails and Backbone.js for inspiration.
 
 Ember.js, therefore, is a synthesis of the powerful tools of our native
-forebearers with the lightweight sensibilities of the modern web. 
+forebears with the lightweight sensibilities of the modern web.
 
 ### Concepts
 


### PR DESCRIPTION
"forebears" means ancestors. "forebearers" is not a word according to
any serious dictionary (Merriam-Webster does not count).

http://katherinebarber.blogspot.com/2012/09/please-forbear-from-using-forebearer.html
