### PR TITLE
clarified example

### DIFF
--- a/source/guides/templates/links.md
+++ b/source/guides/templates/links.md
@@ -4,39 +4,41 @@ You create a link to a route using the `{{linkTo}}` helper.
 
 ```js
 App.Router.map(function() {
-  this.resource("posts", function(){
-    this.route("post", { path: "/:post_id" });
+  this.resource("photos", function(){
+    this.route("edit", { path: "/:photo_id" });
   });
 });
 ```
 
 ```handlebars
-<!-- posts.handlebars -->
+<!-- photos.handlebars -->
 
 <ul>
-{{#each post in posts}}
-  <li>{{#linkTo posts.post post}}{{post.title}}{{/linkTo}}</li>
+{{#each photo in photos}}
+  <li>{{#linkTo photos.edit photo}}{{photo.title}}{{/linkTo}}</li>
 {{/each}}
 </ul>
 ```
 
-If the model for the `posts` template is a list of three posts, the
+If the model for the `photos` template is a list of three photos, the
 rendered HTML would look something like this:
 
 ```html
 <ul>
-  <li><a href="/posts/1">Infinity Madness</a></li>
-  <li><a href="/posts/2">Hexadecimal Weirdness</a></li>
-  <li><a href="/posts/3">Slashes!</a></li>
+  <li><a href="/photos/1">Happy Kittens</a></li>
+  <li><a href="/photos/2">Puppy Running</a></li>
+  <li><a href="/photos/3">Mountain Landscape</a></li>
 </ul>
 ```
 
-When the rendered link matches the current route, and the same object instance is passed into the helper, then the link is given `class="active"`.
+When the rendered link matches the current route, and the same
+object instance is passed into the helper, then the link is given
+`class="active"`.
 
 The `{{linkTo}}` helper takes:
 
-* The name of a route. In this example, it would be `index`, `posts`, or
-  `post`.
+* The name of a route. In this example, it would be `index`, `photos`, or
+  `edit`.
 * If the route has a [dynamic segment](/guides/routing/defining-your-routes/#toc_dynamic-segments),
   a model that represents the segment. By default, Ember.js will replace the segment with the
   value of the object's `id` property.
@@ -49,8 +51,8 @@ segment.
 
 ```js
 App.Router.map(function() {
-  this.resource("posts", function(){
-    this.resource("post", { path: "/:post_id" }, function(){
+  this.resource("photos", function(){
+    this.resource("photo", { path: "/:photo_id" }, function(){
       this.route("comments");
       this.route("comment", { path: "/comments/:comment_id" });
     });
@@ -58,33 +60,33 @@ App.Router.map(function() {
 });
 ```
 
-In the `postIndex` template:
+In the `photoIndex` template:
 
 ```handlebars
-<div class="post">
+<div class="photo">
   {{body}}
 </div>
 
-<p>{{#linkTo post.comment primaryComment}}Main Comment{{/linkTo}}</p>
+<p>{{#linkTo photo.comment primaryComment}}Main Comment{{/linkTo}}</p>
 ```
 
 Since only a single model was supplied, the link will inherit the
-current post for the dynamic segment `:post_id`. The `primaryComment`
+current photo for the dynamic segment `:photo_id`. The `primaryComment`
 will become the new model for the `comment` route handler.
 
-Alternatively, you could pass both a post and a comment to the helper:
+Alternatively, you could pass both a photo and a comment to the helper:
 
 ```handlebars
 <p>
-  {{#linkTo post.comment nextPost primaryComment}}
-    Main Comment for the Next Post
+  {{#linkTo photo.comment nextPhoto primaryComment}}
+    Main Comment for the Next Photo
   {{/linkTo}}
 </p>
 ```
 
-In this case, the models specified will populate both the `:post_id`
-and `:comment_id`. The specified `nextPost` will become the new
-model for the `post` handler and the `primaryComment` will become the
+In this case, the models specified will populate both the `:photo_id`
+and `:comment_id`. The specified `nextPhoto` will become the new
+model for the `photo` handler and the `primaryComment` will become the
 new model for the `comment` handler.
 
 When transitioning to a new URL, the router will only execute the


### PR DESCRIPTION
this page used to say

`<li>{{#linkTo posts.post post}}{{post.title}}{{/linkTo}}</li>`

now it says

`<li>{{#linkTo photos.edit photo}}{{photo.title}}{{/linkTo}}</li>`

I first read this page in the late afternoon after many hours of work. I
found `posts.post post}}{{post.title` confusing, given that `post` can
be either a noun or a verb in the example (and given that it can also be
an HTTP verb).
