### PR TITLE
Fix error in guides/templates/rendering-with-helpers.md

### DIFF
--- a/source/guides/templates/rendering-with-helpers.md
+++ b/source/guides/templates/rendering-with-helpers.md
@@ -49,7 +49,7 @@ App.AuthorView = Ember.View.extend({
 
 ```handlebars
 <script type="text/x-handlebars" data-template-name='author'>
-  Written by {{fullName}}
+  Written by {{view.fullName}}
 </script>
 
 <script type="text/x-handlebars" data-template-name='post'>


### PR DESCRIPTION
Currently the guide is using the old context-changing view. I added 'view.' to fix the problem.
