### PR TITLE
Added scroll support for code examples. Most helpful for mobile devises.

### DIFF
--- a/lib/highlighter.rb
+++ b/lib/highlighter.rb
@@ -13,11 +13,12 @@ module Highlighter
     def _highlight(string, language, class_name=nil)
       result = %Q{<div class="highlight #{language} #{class_name}">}
       result += '<div class="ribbon"></div>'
+      result += '<div class="scroller">'
       code = CodeRay.scan(string, language)
       result += code.div css: :class,
                       line_numbers: :table,
                       line_number_anchors: false
-
+      result += '</div>'
       result += %Q{</div>}
       result
     end

--- a/source/stylesheets/highlight.css.scss
+++ b/source/stylesheets/highlight.css.scss
@@ -18,6 +18,10 @@ $green:  #007700;
   margin: 2em 0;
   @include box-shadow(0 1px #ffffff, inset -1px 1px 4px rgba(0, 0, 0, 0.1));
 
+  .scroller {
+    overflow: auto;
+  }
+
   table {
     margin: 0 0;
   }


### PR DESCRIPTION
I had to add another div around the code examples to keep the ribbon in place on the right hand side because you can't add an the css 'overflow: auto' to a table.

Cheers
