### PR TITLE
Fix typo about checkbox

### DIFF
--- a/source/blog/2013-04-21-ember-1-0-rc3.markdown
+++ b/source/blog/2013-04-21-ember-1-0-rc3.markdown
@@ -70,7 +70,7 @@ can now be expressed as:
 
 ```handlebars
   {{input value=name}}
-  {{input checked=isActive}}
+  {{input type=checkbox checked=isActive}}
   {{textarea value=name}}
 ```
 


### PR DESCRIPTION
To render checkbox, `type=checkbox` is required.
