### PR TITLE
Configure S3-based deployments via s3cmd

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require 'yaml'
+load 'lib/tasks/s3.rake'
 
 def git_initialize(repository)
   unless File.exist?(".git")

--- a/config.rb
+++ b/config.rb
@@ -1,7 +1,7 @@
 require 'redcarpet'
 require 'active_support/core_ext'
 
-Dir['./lib/*'].each { |f| require f }
+Dir['./lib/*'].reject{|path| path.split("/").include?("tasks") }.each { |f| require f }
 
 # Debugging
 set(:logging, ENV['RACK_ENV'] != 'production')

--- a/lib/tasks/s3.rake
+++ b/lib/tasks/s3.rake
@@ -1,0 +1,60 @@
+require 'shellwords'
+require 'tempfile'
+
+def run_s3cmd(subcmd, *args)
+  cmd = ["s3cmd"]
+  cmd << subcmd
+
+  cmd.concat(args)
+
+  cmd = Shellwords.join(cmd)
+
+  puts "Running command: #{cmd.inspect}"
+  result = system cmd
+
+  puts "Error running command" unless result
+end
+
+namespace :s3 do
+
+  task :setup => [:create_bucket, :create_website, :create_policy, :deploy]
+
+  task :create_bucket do
+    run_s3cmd "mb",  ENV['BUCKET_URL']
+  end
+
+  task :create_website do
+    run_s3cmd "ws-create", ENV['BUCKET_URL']
+  end
+
+  task :create_policy do
+    Tempfile.open('emberjs-policy.json') do |f|
+      f.write BUCKET_POLICY
+      f.rewind
+      run_s3cmd "setpolicy",  f.path, ENV['BUCKET_URL']
+    end
+  end
+
+  task :deploy do
+    run_s3cmd "sync", "--delete-removed", "build/", ENV['BUCKET_URL']
+  end
+end
+
+BUCKET_POLICY = <<-EOS
+{
+  "Version": "2008-10-17",
+  "Id": "Policy1337995845252",
+  "Statement": [
+    {
+      "Sid": "Stmt1337995842373",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::#{ENV['BUCKET_URL'].sub(%r{^s3:\/\/}, '')}/*"
+    }
+  ]
+}
+EOS
+


### PR DESCRIPTION
This completes part of the infrastructure requirements for implementing automated website deployments via travis as discussed in #237.

This PR contains all commands necessary to create the bucket, setup the website configuration, set the bucket policy (ensuring that all files will be world-readable) and perform the first deploy. You can run this via: `rake s3:setup`. Subsequent deploys can be run vai `rake s3:deploy`. You will need 3 environment variables set:
- S3_ACCESS_KEY_ID
- S3_SECRET_ACCESS_KEY
- BUCKET_URL

The `BUCKET_URL` must be in the form of s3://{BUCKET_NAME}.

To run the initial setup commands you must have the latest alpha of s3cmd installed (on a Mac via Homebrew `brew install --dev s3cmd`). For other platforms, make sure you install at least 1.5.0-alpha3.

To run the deploys via Travis, we should be able to add:

```
install:
  - sudo apt-get install s3cmd
```

to our .travis.yml and get access to s3cmd that way.

I tested all of this (minus travis integration) using my own S3 account, you can see the site running at http://emberjs.joefiorini.com/.
