### PR TITLE
Added meetup group in Gothenburg

### DIFF
--- a/data/meetups.yml
+++ b/data/meetups.yml
@@ -45,3 +45,6 @@
   - location: Ottawa, Canada
     url:      http://www.meetup.com/Ember-js-Ottawa/
     image:    13ottawa.png
+  - location: Gothenburg, Sweden
+    url:      http://www.meetup.com/ember-js-goteborg/
+    image:    16gothenburg.png


### PR DESCRIPTION
Added a new meetup group in Gothenburg. The image property seems unused, just set it to the next number in the series along with the city name. 
