### PR TITLE
Fix `chapter_links` to be shown at '/guides/enumerables'

### DIFF
--- a/lib/toc.rb
+++ b/lib/toc.rb
@@ -100,7 +100,8 @@ module TOC
       section_prefix = section_slug + "/"
       data.guides.find do |section, entries|
         entries.find do |entry|
-          entry.url.starts_with? section_prefix
+          url = entry.url
+          url.starts_with?(section_prefix) || url == section_slug
         end
       end
     end


### PR DESCRIPTION
`chapter_links` wasn't rendered at `/guides/enumerables/`.
This cause is:
This section name is 'enumerables'.
But `chapter_links` would match it with 'enumerables/' (end with `/`).

So I fixed to match url to section slug.

before:
![2013-05-05 18 29 56](https://f.cloud.github.com/assets/290782/463481/6c26f418-b567-11e2-942c-57b925181242.png)

After:
![2013-05-05 18 30 08](https://f.cloud.github.com/assets/290782/463482/70c0632e-b567-11e2-94a4-2a35aea1f1c9.png)
