### PR TITLE
Website versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+---
+before_install:
+- sudo apt-get update -qq
+- sudo apt-get install -qq s3cmd
+script: bundle exec rake build
+after_success: bundle exec rake versions:deploy_edge
+env:
+  global:
+  - S3_ACCESS_KEY_ID: "fPQRYdwg/FBa+UVocY9gfr3M/wyteRT/xo0haWXb/JZ8yXGhH++NTjvUMkCK\n4BN0gOm7FIVqQ8fqhnAYc9uhprOZec1qQa4u534a8oH8t/8bHb4XpEuz1qvX\nAIylV44qqdCsezRRjQsNA8xndxnRfywhEx4gjZ4sGbZU26Lsy9U="
+  - S3_SECRET_ACCESS_KEY: "aA0dO8u24fyYu+kakO+Gxnbkt6jjqWn+5z+w55iCJ1fReCpGQfz3vXYxDunW\n+rJeYdFNjxPOISTIpk49LY6981hP6jxuWZHR8VVO+dOx9N25CCqVMJSLqCU6\nLJ1R6cxc1ZnCKLksWiSJ/bs4SXqlj6Nnsb6bTz/zKmJFBPUskTo="
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@
 before_install:
 - sudo apt-get update -qq
 - sudo apt-get install -qq s3cmd
-script: bundle exec rake build
+script: bundle exec rake checkout_ember build
 after_success: bundle exec rake versions:deploy_edge
 env:
   global:
-  - S3_ACCESS_KEY_ID: "fPQRYdwg/FBa+UVocY9gfr3M/wyteRT/xo0haWXb/JZ8yXGhH++NTjvUMkCK\n4BN0gOm7FIVqQ8fqhnAYc9uhprOZec1qQa4u534a8oH8t/8bHb4XpEuz1qvX\nAIylV44qqdCsezRRjQsNA8xndxnRfywhEx4gjZ4sGbZU26Lsy9U="
-  - S3_SECRET_ACCESS_KEY: "aA0dO8u24fyYu+kakO+Gxnbkt6jjqWn+5z+w55iCJ1fReCpGQfz3vXYxDunW\n+rJeYdFNjxPOISTIpk49LY6981hP6jxuWZHR8VVO+dOx9N25CCqVMJSLqCU6\nLJ1R6cxc1ZnCKLksWiSJ/bs4SXqlj6Nnsb6bTz/zKmJFBPUskTo="
-
+  - secure: "cDzdsDPvC6YmYzuOsYXcXXRRadXLGIki6WuuaV6IuVTv0V+x+qSFNZ/KLk97\n4HOmklgM+ub0Nwxs+JhL2sh1ElhXi9hdXMFkSqIYutL6iJwJs6XA89Xfw5wu\nAxSeMzRMQHFugpEMC3Z/Q0G41C5N/bFCX3H2cNdmpFc86qQDZEs="
+  - secure: "BtJpzh/QjoWue6NXg3nJQcPOfJ19V3Xp0o66hyO3YQphQ1xgKTxIlJSANYDV\nEtzIqUhtvEdeT+WP7btcssjSX+xVh/rhU+iHo5jcIAC+i5mHzOK+FFeZ9Wbu\nkItX3qPxwE+82SotO9jyWaECE/QjpmKlhB54nR0TvgVCdWHhSBI="
+  

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem "thin"
 gem "rack"
 gem "listen"
 gem "builder"
+gem 'website_versions', :github => "mharris717/website_versions"
 
 group :development do
   gem "pry"

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem "thin"
 gem "rack"
 gem "listen"
 gem "builder"
-gem 'website_versions', :github => "mharris717/website_versions"
+gem 'website_versions', :github => "mharris717/website_versions", :branch => "master"
 
 group :development do
   gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,8 @@ GIT
 
 GIT
   remote: git://github.com/mharris717/website_versions.git
-  revision: 843fdd6ee15d113b4e419c17cafa613af3740e4f
+  revision: ac6f59d0ca6c726ee8b1ceaa05c8caa683a56be3
+  branch: master
   specs:
     website_versions (0.1.0)
       grit
@@ -43,6 +44,10 @@ GEM
     faye-websocket (0.4.7)
       eventmachine (>= 0.12.0)
     fssm (0.2.10)
+    grit (2.5.0)
+      diff-lcs (~> 1.1)
+      mime-types (~> 1.15)
+      posix-spawn (~> 0.3.6)
     haml (4.0.3)
       tilt
     highline (1.6.19)
@@ -107,6 +112,7 @@ GEM
       capybara (~> 2.1.0)
       faye-websocket (>= 0.4.4, < 0.5.0)
       http_parser.rb (~> 0.5.3)
+    posix-spawn (0.3.6)
     pry (0.9.6)
       coderay (>= 0.9.8)
       method_source (>= 0.6.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ GIT
 
 GIT
   remote: git://github.com/mharris717/website_versions.git
-  revision: 3b14920dce20a34ae7f98fc4c7d38851ac61024d
+  revision: 843fdd6ee15d113b4e419c17cafa613af3740e4f
   specs:
     website_versions (0.1.0)
       grit

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,14 @@ GIT
   specs:
     coderay (1.1.0.rc1)
 
+GIT
+  remote: git://github.com/mharris717/website_versions.git
+  revision: 3b14920dce20a34ae7f98fc4c7d38851ac61024d
+  specs:
+    website_versions (0.1.0)
+      grit
+      rake
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -174,3 +182,4 @@ DEPENDENCIES
   redcarpet
   rspec
   thin
+  website_versions!

--- a/Rakefile
+++ b/Rakefile
@@ -21,6 +21,11 @@ def ember_path
   File.expand_path(ENV['EMBER_PATH'] || File.expand_path("../../ember.js", __FILE__))
 end
 
+task :checkout_ember do
+  repo = "git://github.com/emberjs/ember.js.git"
+  system "git clone #{repo} #{ember_path}"
+end
+
 def generate_docs
   print "Generating docs data from #{ember_path}... "
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,6 @@
 require "bundler/setup"
 require 'yaml'
+load 'lib/versions.rb'
 
 def git_initialize(repository)
   unless File.exist?(".git")

--- a/lib/versions.rb
+++ b/lib/versions.rb
@@ -1,0 +1,2 @@
+require 'website_versions'
+WebsiteVersions.tags = %w(v0.9.1 v0.9.5 v1.0.0-pre.4 v1.0.0-pre.2 v1.0.0-rc.2)

--- a/source/layout.erb
+++ b/source/layout.erb
@@ -86,6 +86,7 @@
           <%= link_to_page "api", "/api" %>
           <%= link_to_page "community", "/community" %>
           <%= link_to_page "blog", "/blog" %>
+          <%= link_to_page "Old Docs", "/versioned_docs" %>
 
           <li id="search">
             <form>

--- a/source/versioned_docs/index.html.erb
+++ b/source/versioned_docs/index.html.erb
@@ -1,0 +1,10 @@
+<br>
+<h1>Ember.js Versioned Documentation</h1>
+
+<ul>
+  <% WebsiteVersions.each_tag do |version,bucket,url| %>
+    <li>
+      <a href="<%= url %>">Version <%= version %></a>
+    </li>
+  <% end %>
+</ul>


### PR DESCRIPTION
This PR does several things:

* Incorporates @joefiorini's PR to add S3 uploads of built docs.
* Adds ability to build docs for previous versions and upload to S3
* Adds .travis.yml file for travis builds
* Pushes latest docs to an edge S3 bucket on successful travis build.
* Adds page on emberjs.com with links to old docs.

Much of this functionality is in a gem, ```website_versions```, that is now included in website.  Obviously we'll want to move this gem over to the emberjs account.

https://github.com/mharris717/website_versions.

Notes:
* Tags to show on "old docs" page are in lib/versions.rb
* Currently the .travis.yml file has my encrypted S3 creds in it, they'll need to be changed. 
* Build and push old docs with ```bundle exec rake versions:deploy_version REF=v0.9.7 S3_ACCESS_KEY_ID=abc S3_SECRET_ACCESS_KEY=xyz```
* Build and push edge with ```bundle exec rake build versions:deploy_edge S3_ACCESS_KEY_ID=abc S3_SECRET_ACCESS_KEY=xyz```
* The buckets all follow the same format.  http://emberdocsv097.s3-website-us-east-1.amazonaws.com for tag v0.9.7.  
* I don't believe the build and s3 commands are throwing proper non-0 error codes on failure, so the travis build doesn't die when something goes wrong.  

There is certainly other stuff I need to say, it's not coming to me right now.

All feedback strongly encouraged.

Mike  



