### PR TITLE
Show timestamp in Blog post pages

### DIFF
--- a/source/layouts/blog.erb
+++ b/source/layouts/blog.erb
@@ -5,7 +5,7 @@
   <article class="blog-post">
     <h1><%= current_article.title %></h1>
     <% if current_page.data.author %>
-      <h3 class="blog-post-author">Posted By: <%= current_page.data.author %></h3>
+      <h3 class="blog-post-author">Posted By: <%= current_page.data.author %> &ndash; <time><%= current_article.date.strftime('%b %d, %Y') %></time></h3>
     <% end %>
 
     <%= yield %>


### PR DESCRIPTION
When reading the blog, it is confusing not to see the date when a post was written. 

For instance [this post](http://emberjs.com/blog/2013/05/03/ember-data-progress-update.html) starts with this text "Just over a month ago, we told you about".
Having the timestamp at the top of the post can be helpful to understand exactly what the post is talking about.
