### PR TITLE
Fix the shorthand access to another controller through needs

### DIFF
--- a/source/guides/controllers/dependencies-between-controllers.md
+++ b/source/guides/controllers/dependencies-between-controllers.md
@@ -47,6 +47,7 @@ or want the `Post` instance directly).
 
 ```javascript
 App.CommentsController = Ember.ArrayController.extend({
+  post: null,
   needs: "post",
   postBinding: "controllers.post"
 });


### PR DESCRIPTION
Without initiating the controller property, it is considered as a proxy access to the underlying object (in the case of an `ObjectController`) or array (in the case of an `ArrayController`). It results in an error in both cases:

```
    Uncaught TypeError: Object [object Object] has no method 'addArrayObserver'
```

```
    Uncaught Error: assertion failed: Cannot delegate set('auth',  <App.AuthController:ember340>) to the 'content' property of object proxy <App.IdeaController:ember447>: its 'content' is undefined.
```
