### PR TITLE
Clarify View events documentation in Guides

### DIFF
--- a/source/guides/views/index.md
+++ b/source/guides/views/index.md
@@ -24,9 +24,10 @@ a button to delete that item:
 ![Todo List](/guides/views/images/todo-list.png)
 
 The view is responsible for turning a _primitive event_ (a click) into a
-_semantic event_: delete this todo! These semantic events are sent to
-your application's router, which is responsible for reacting to the
-event based on the current state of the application.
+_semantic event_: delete this todo! These semantic events are first sent 
+up to the controller, or if no method is defined there, your application's 
+router, which is responsible for reacting to the event based on the 
+current state of the application.
 
 
 ![Todo List](/guides/views/images/primitive-to-semantic-event.png)


### PR DESCRIPTION
Make guides documentation consistent about what happens to View events. Closes emberjs/ember.js#2115

/cc @igorT @trek
