### PR TITLE
Update computed-properties-and-aggregate-data.md

### DIFF
--- a/source/guides/object-model/computed-properties-and-aggregate-data.md
+++ b/source/guides/object-model/computed-properties-and-aggregate-data.md
@@ -7,7 +7,7 @@ todo items in a controller to determine how many of them are completed.
 Here's what that computed property might look like:
 
 ```javascript
-App.todosController = Ember.Object.create({
+App.TodosController = Ember.Object.extend({
   todos: [
     Ember.Object.create({ isDone: false })
   ],
@@ -31,6 +31,7 @@ this computed property when one of the following four events occurs:
 In the example above, the `remaining` count is `1`:
 
 ```javascript
+App.todosController = App.TodosController.create();
 App.todosController.get('remaining');
 // 1
 ```


### PR DESCRIPTION
Extend class first, then instantiate an object. Without this an exception will be thrown: `Ember.Object.create no longer supports defining computed properties.`
