### PR TITLE
Remove reference to `routeTo`

### DIFF
--- a/source/blog/2013-05-28-ember-1-0-rc4.markdown
+++ b/source/blog/2013-05-28-ember-1-0-rc4.markdown
@@ -126,14 +126,6 @@ reliable. Additionally, you can now implement this hook in the
 
 Props to Tom Dale for this work.
 
-#### linkTo now generates routeTo events
-
-Previously, the `{{linkTo}}` helper caused the router to transition without
-any hooks to affect that behavior. Thanks to the work of Alex Matchneer,
-the `{{linkTo}}` helper now generates a routeTo event that can be handled
-just like any other event in a controller or a route's `events` object. The
-default behavior of transitioning to the specified route remains unchanged.
-
 #### ember-testing Improvements
 
 The `ember-testing` package, included in Ember.js, is the


### PR DESCRIPTION
`routeTo` is likely not going to survive the router facelift. It was experimental, and is still is on the `ENV.ENABLE_ROUTE_TO` flag, which wasn't mentioned in this blog, but given that it likely won't stick around, I'd rather remove it than clarify about the flag.
