### PR TITLE
Add note about serialize hook to router guide

### DIFF
--- a/source/guides/routing/defining-your-routes.md
+++ b/source/guides/routing/defining-your-routes.md
@@ -248,6 +248,30 @@ Not coincidentally, this is exactly what Ember Data expects. So if you
 use the Ember router with Ember Data, your dynamic segments will work
 as expected out of the box.
 
+If your model does not use the `id` property in the url, you should
+define a serialize method on your route:
+
+```javascript
+App.Router.map(function() {
+  this.resource('post', {path: '/posts/:post_slug'});
+});
+
+App.PostRoute = Ember.Route.extend({
+  model: function(params) {
+    // the server returns `{ slug: 'foo-post' }`
+    return jQuery.getJSON("/posts/" + params.post_slug);
+  },
+
+  serialize: function(model) {
+    // this will make the URL `/posts/foo-post`
+    return { post_slug: model.slug };
+  }
+});
+```
+
+The default `serialize` method inserts the model's `id` into the route's
+dynamic segment (in this case, `:post_id`).
+
 ### Nested Resources
 
 You cannot nest routes, but you can nest resources:


### PR DESCRIPTION
I was helping someone on IRC who was confused by this, I agreed that it's confusing not to be mentioned in the router guide.

I copied it mainly from the router api doc but changed it to slug rather than id, because I think that it's confusing to give an example that shows the default behaviour, which you'd never actually need to implement as that's what happens anyway.
