### PR TITLE
Adding instructions that should make the guide more clear

### DIFF
--- a/source/guides/getting-started/displaying-the-number-of-incomplete-todos.md
+++ b/source/guides/getting-started/displaying-the-number-of-incomplete-todos.md
@@ -12,6 +12,8 @@ Next we'll update our template's hard-coded count of completed todos to reflect 
 
 Implement these properties as part of this template's controller, the `Todos.TodosController`:
 
+*Note:*do not forget to add a coma after the last bracket of the `createTodo` function.
+
 ```javascript
 // ... additional lines truncated for brevity ...
 remaining: function () {


### PR DESCRIPTION
The code given does not tell the reader to add a coma after the last bracket of the createTodo function of the todos_controller (the code does not work without the coma).
