### PR TITLE
Update the-rest-adapter.md

### DIFF
--- a/source/guides/models/the-rest-adapter.md
+++ b/source/guides/models/the-rest-adapter.md
@@ -41,7 +41,8 @@ API:
 
 ```js
 DS.RESTAdapter.configure("plurals", {
-  person: "people"
+  person: "people",
+  owner_reply: "owner_replies"
 });
 ```
 


### PR DESCRIPTION
Plurals dealing with an API need to be underscored.

After looking around for a while today we found that this information would have been helpful.

Cheers
