### PR TITLE
Fix html/handlebars example code block on home page

### DIFF
--- a/source/about.html.erb
+++ b/source/about.html.erb
@@ -90,7 +90,7 @@ App.IndexRoute = Ember.Route.extend({
 
 <% end %>
 
-<% highlight :handlebars, :right do %>
+<% highlight :html, :right do %>
 <script type="text/x-handlebars">
   {{outlet}}
 </script>


### PR DESCRIPTION
The handlebars scanner should only be used when the content is entirely a handlebars template. When content is html, with handlebars templates embedded, we should mark the block as `html`.

Note the problems within the `index` template, with `People` and `ul` highlighted incorrectly:

![screen shot 2013-06-25 at 3 25 46 pm](https://f.cloud.github.com/assets/29122/705010/401ee018-ddcd-11e2-8e5b-b223e4559f96.png)

This is the same block marked as `html`:

![screen shot 2013-06-25 at 3 26 00 pm](https://f.cloud.github.com/assets/29122/705011/45f7c16c-ddcd-11e2-853b-bad8166cd47f.png)

The handlebars templates may not be highlighted, but it's probably better than incorrect highlighting.
