### PR TITLE
Stringifying linkTo args to prep for push for path lookups

### DIFF
--- a/source/guides/getting-started/show-all-todos-again.md
+++ b/source/guides/getting-started/show-all-todos-again.md
@@ -7,13 +7,13 @@ In `index.html` convert the `<a>` tag for 'All' todos into a Handlebars `{{linkT
 ```handlebars
 <!--- ... additional lines truncated for brevity ... -->
 <li>
-  {{#linkTo todos.index activeClass="selected"}}All{{/linkTo}}
+  {{#linkTo 'todos.index' activeClass="selected"}}All{{/linkTo}}
 </li>
 <li>
-  {{#linkTo todos.active activeClass="selected"}}Active{{/linkTo}}
+  {{#linkTo 'todos.active' activeClass="selected"}}Active{{/linkTo}}
 </li>
 <li>
-  {{#linkTo todos.completed activeClass="selected"}}Completed{{/linkTo}}
+  {{#linkTo 'todos.completed' activeClass="selected"}}Completed{{/linkTo}}
 </li>
 <!--- ... additional lines truncated for brevity ... -->
 ```

--- a/source/guides/getting-started/show-only-complete-todos.md
+++ b/source/guides/getting-started/show-only-complete-todos.md
@@ -10,10 +10,10 @@ In `index.html` convert the `<a>` tag for 'Completed' todos into a Handlebars `{
   <a href="all" class="selected">All</a>
 </li>
 <li>
-  {{#linkTo todos.active activeClass="selected"}}Active{{/linkTo}}
+  {{#linkTo 'todos.active' activeClass="selected"}}Active{{/linkTo}}
 </li>
 <li>
-  {{#linkTo todos.completed activeClass="selected"}}Completed{{/linkTo}}
+  {{#linkTo 'todos.completed' activeClass="selected"}}Completed{{/linkTo}}
 </li>
 <!--- ... additional lines truncated for brevity ... -->
 ```

--- a/source/guides/getting-started/show-only-incomplete-todos.md
+++ b/source/guides/getting-started/show-only-incomplete-todos.md
@@ -10,7 +10,7 @@ In `index.html` convert the `<a>` tag for 'Active' todos into a Handlebars `{{li
   <a href="all" class="selected">All</a>
 </li>
 <li>
-  {{#linkTo todos.active activeClass="selected"}}Active{{/linkTo}}
+  {{#linkTo 'todos.active' activeClass="selected"}}Active{{/linkTo}}
 </li>
 <li>
   <a href="completed">Completed</a>

--- a/source/guides/routing/defining-your-routes.md
+++ b/source/guides/routing/defining-your-routes.md
@@ -31,11 +31,11 @@ routes, using the name that you provided to the `route` method (or, in
 the case of `/`, the name `index`).
 
 ```handlebars
-{{#linkTo "index"}}<img class="logo">{{/linkTo}}
+{{#linkTo 'index'}}<img class="logo">{{/linkTo}}
 
 <nav>
-  {{#linkTo "about"}}About{{/linkTo}}
-  {{#linkTo "favorites"}}Favorites{{/linkTo}}
+  {{#linkTo 'about'}}About{{/linkTo}}
+  {{#linkTo 'favorites'}}Favorites{{/linkTo}}
 </nav>
 ```
 

--- a/source/guides/templates/links.md
+++ b/source/guides/templates/links.md
@@ -15,7 +15,7 @@ App.Router.map(function() {
 
 <ul>
 {{#each photo in photos}}
-  <li>{{#linkTo photos.edit photo}}{{photo.title}}{{/linkTo}}</li>
+  <li>{{#linkTo 'photos.edit' photo}}{{photo.title}}{{/linkTo}}</li>
 {{/each}}
 </ul>
 ```
@@ -67,7 +67,7 @@ App.Router.map(function() {
   {{body}}
 </div>
 
-<p>{{#linkTo photo.comment primaryComment}}Main Comment{{/linkTo}}</p>
+<p>{{#linkTo 'photo.comment' primaryComment}}Main Comment{{/linkTo}}</p>
 ```
 
 If you specify only one model, it will represent the innermost dynamic segment `:comment_id`.
@@ -77,7 +77,7 @@ Alternatively, you could pass both a photo and a comment to the helper:
 
 ```handlebars
 <p>
-  {{#linkTo photo.comment nextPhoto primaryComment}}
+  {{#linkTo 'photo.comment' nextPhoto primaryComment}}
     Main Comment for the Next Photo
   {{/linkTo}}
 </p>


### PR DESCRIPTION
We'll be making {{linkTo foo}} perform a lookup of the target
path on the present context for the 'foo' property, and we have
lot of references in the guides that advertise the incorrect
(albeit prettier) format of omitting the strings.
