### PR TITLE
Add keyDown helper to testing guide

### DIFF
--- a/source/guides/testing/integration.md
+++ b/source/guides/testing/integration.md
@@ -43,6 +43,8 @@ module("Integration Tests", {
  - Fills in the selected input with the given text and returns a promise that fulfills when all resulting async behavior is complete.
 * `click(selector)`
   - Clicks an element and triggers any actions triggered by the element's `click` event and returns a promise that fulfills when all resulting async behavior is complete.
+* `keyDown(selector, type, keyCode)`
+  - Simulates a key event type, e.g. `keypress`, `keydown`, `keyup` with the desired keyCode on element found by the selector.
 * `wait()`
   - Returns a promise that fulfills when all async behavior is complete.
 


### PR DESCRIPTION
This adds the new keyDown helper to the testing guide. This helper was added today, I think, so if this was pushed to the website, the website would be ahead of RC6, dunno how problems like that are handled.
