### PR TITLE
Update testing guide: add test adapters note, clarify the ending note

### DIFF
--- a/source/guides/testing/integration.md
+++ b/source/guides/testing/integration.md
@@ -111,4 +111,7 @@ Ember.Test.registerHelper('dblclick', function(app, selector, context) {
 });
 ```
 
-**(Please note: Only development builds of Ember include the testing package.)**
+### Test adapters for other libraries
+If you use a library other than QUnit, your test adapter will need to provide methods for `asyncStart` and `asyncEnd`. To facilitate asynchronous testing, the default test adapter for QUnit uses methods that QUnit provides: (globals) `stop()` and `start()`.
+
+**(Please note: Only development builds of Ember include the testing package. The ember-testing package is not included in the production build of Ember. The package can be loaded in your dev or qa builds to facilitate testing your application. By not including the ember-testing package in production, your tests will not be executable in a production environment.)**


### PR DESCRIPTION
Added a section to callout that the default test adapter relies on (QUnit) `start` and `stop` methods. I think this will help others make an informed choice when selecting a testing library other than QUnit.

The note about ember-testing package only available in development build needed clarification, some may read into that statement that the testing package is not usable or stable.
