### PR TITLE
Remove reference to `template` helper.

### DIFF
--- a/source/guides/templates/rendering-with-helpers.md
+++ b/source/guides/templates/rendering-with-helpers.md
@@ -30,8 +30,6 @@ Ember provides several helpers that allow you to render other views and template
 
 The partial's `data-template-name` must start with an underscore (e.g. `data-template-name='_author'` or `data-template-name='foo/_bar'`)
 
-Note: in cases where you may have used `{{template}}` in the past, you should likely use `{{partial}}` instead.
-
 ### The `{{view}}` Helper
 
 This helper works like the partial helper, except instead of providing a template to be rendered within the current template, you provide a view class.  The view controls what template is rendered.


### PR DESCRIPTION
Seems unnecessary. Plus, if you use `template`, you'll get
an Ember.warn
