### PR TITLE
Update redirection.md

### DIFF
--- a/source/guides/routing/redirection.md
+++ b/source/guides/routing/redirection.md
@@ -10,7 +10,7 @@ App.Router.map(function() {
 
 App.IndexRoute = Ember.Route.extend({
   redirect: function() {
-    this.transitionTo('posts');
+    this.transitionToRoute('posts');
   }
 });
 ```
@@ -31,7 +31,7 @@ App.Router.map(function() {
 App.TopChartsChooseRoute = Ember.Route.extend({
   redirect: function() {
     var lastFilter = this.controllerFor('application').get('lastFilter');
-    this.transitionTo('topCharts.' + lastFilter || 'songs');
+    this.transitionToRoute('topCharts.' + lastFilter || 'songs');
   }
 });
 


### PR DESCRIPTION
transitionTo is deprecated, updating to transitionToRoute for Ember 1.0.0-rc.6.x
![2013-08-05-110818_1439x294_scrot](https://f.cloud.github.com/assets/339040/912082/0c4a3218-fdfa-11e2-8b17-ae7e8678f736.png)
