### PR TITLE
Add install instructions for required Ruby version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Then visit [http://localhost:4567/](http://localhost:4567/)
 
 ### Requirements
 
-If the `bundle` command fails to run, you may need to upgrade your Ruby version. The Ember.js website build requires 1.9.3 or newer. You can use [RVM](https://rvm.io/) to install it:
+If the `bundle` command fails to run, you may need to upgrade your Ruby version. The Ember.js website build requires 1.9.3 or newer (2.0.0 recommended). You can use [RVM](https://rvm.io/) to install it:
 
 ```
 curl -L https://get.rvm.io | bash -s stable
-rvm install 1.9.3
-rvm use 1.9.3
+rvm install 2.0.0
+rvm use 2.0.0
 ```


### PR DESCRIPTION
I'm not a Ruby developer, so I had to do a little bit of learning before I could get the `bundle` command to run successfully (my Mac was using the stock 1.8.3 Ruby). This addition to the README might help someone else in my boat get going a little faster.
