### PR TITLE
Typo in routing guide. Small css fix.

### DIFF
--- a/source/guides/routing/defining-your-routes.md
+++ b/source/guides/routing/defining-your-routes.md
@@ -269,7 +269,7 @@ App.PostRoute = Ember.Route.extend({
 
   serialize: function(model) {
     // this will make the URL `/posts/foo-post`
-    return { post_slug: model.slug };
+    return { post_slug: model.get('slug') };
   }
 });
 ```
@@ -419,6 +419,7 @@ This router creates following routes:
     </tr>
   </table>
 </div>
+
 
 ### Initial routes
 

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -581,7 +581,8 @@ ol {
   }
 
   ol + h2, ul + h2, p + h2,
-  ol + h3, ul + h3, p + h3 {
+  ol + h3, ul + h3, p + h3,
+  div + h3 {
     margin-top: 1.5em;
   }
 


### PR DESCRIPTION
You can see the css problem at the new 'Initial Routes' `h3` tag, under the table. There's no css rule to give it a `margin-top`.
