### PR TITLE
Update for new asset structure.

### DIFF
--- a/source/about.html.erb
+++ b/source/about.html.erb
@@ -28,13 +28,13 @@ title: "About"
     </a>
     <div class="info">
       1.0.0-rc.7:
-      <a class="debug" href="http://builds.emberjs.com/ember-1.0.0-rc.7.prod.js">
+      <a class="debug" href="http://builds.emberjs.com/tags/v1.0.0-rc.7/ember.prod.js">
         production
       </a>
-      <a class="debug" href="http://builds.emberjs.com/ember-1.0.0-rc.7.min.js">
+      <a class="debug" href="http://builds.emberjs.com/tags/v1.0.0-rc.7/ember.min.js">
         (min + gzip 56kb)
       </a> |
-      <a class="debug" href="http://builds.emberjs.com/ember-1.0.0-rc.7.js">
+      <a class="debug" href="http://builds.emberjs.com/tags/v1.0.0-rc.7/ember.js">
         debug
       </a> |
       <a href="http://builds.emberjs.com/handlebars-1.0.0.js">

--- a/source/blog/2013-04-21-ember-1-0-rc3.markdown
+++ b/source/blog/2013-04-21-ember-1-0-rc3.markdown
@@ -52,7 +52,7 @@ will be our official library.
 
 Each successful [CI](https://travis-ci.org/emberjs/ember.js) run now publishes its build results to
 [http://builds.emberjs.com/](http://builds.emberjs.com/). This should make
-it much simpler to reference and use the [the latest ember build](http://builds.emberjs.com/ember-latest.js).
+it much simpler to reference and use the [the latest ember build](http://builds.emberjs.com/latest/ember.js).
 
 Thanks to Stanley Stuart, Luke Melia, Erik Bryn and others for getting this set up.
 

--- a/source/guides/models/index.md
+++ b/source/guides/models/index.md
@@ -29,5 +29,5 @@ passing build from the "master" branch from [builds.emberjs.com][builds]:
 
 [emberdata]: https://github.com/emberjs/data
 [builds]: http://builds.emberjs.com
-[development-build]: http://builds.emberjs.com.s3.amazonaws.com/ember-data-latest.js
-[minified-build]: http://builds.emberjs.com.s3.amazonaws.com/ember-data-latest.min.js
+[development-build]: http://builds.emberjs.com/latest/ember-data.js
+[minified-build]: http://builds.emberjs.com/latest/ember-data.min.js


### PR DESCRIPTION
This PR updates the `about` page (and a few others) to use the new asset structure from https://github.com/emberjs/ember-dev/pull/24. 

This PR cannot be merged until the next tagged release (since `v1.0.0-rc.7` wasn't built with the new structure).
