### PR TITLE
Fix enter/return consistency in the Getting Started guide.

### DIFF
--- a/source/guides/getting-started/planning-the-application.md
+++ b/source/guides/getting-started/planning-the-application.md
@@ -7,7 +7,7 @@ TodoMVC has the following main features:
 
   1. It displays a list of todos for a user to see. This list will grow and shrink as the user adds and removes todos.
 
-  1. It accepts text in an `<input>` for entry of new todos. Hitting `<return>` creates the new item and displays it in the list below.
+  1. It accepts text in an `<input>` for entry of new todos. Hitting the `<enter>` key creates the new item and displays it in the list below.
 
   1. It provides a checkbox to toggle between complete and incomplete states for each todo. New todos start as incomplete.
 
@@ -21,7 +21,7 @@ TodoMVC has the following main features:
 
   1. It provides a checkbox to toggle all existing todos between complete and incomplete states. Further, when all todos are completed this checkbox becomes checked without user interaction.
 
-  1. It allows a user to double click to show a textfield for editing a single todo. Hitting `<enter>` or moving focus outside of this textfield will persist the changed text.
+  1. It allows a user to double click to show a textfield for editing a single todo. Hitting the `<enter>` key or moving focus outside of this textfield will persist the changed text.
 
   1. It retains a user's todos between application loads by using the browser's `localstorage` mechanism.
 


### PR DESCRIPTION
I noticed some inconsistency with how the enter key is referred to on this one page of the Getting Started guide, so I changed it to match the rest of the guide.
