### PR TITLE
RC8 Blog - fix typo

### DIFF
--- a/source/blog/2013-08-25-ember-1-0-rc8.md
+++ b/source/blog/2013-08-25-ember-1-0-rc8.md
@@ -191,9 +191,6 @@ that the observer should also run after `init` by using
 App.Person = Ember.Object.extend({
   init: function() {
     this.set('salutation', "Mr/Ms");
-
-    // You must now do this:
-    this.salutationDidChange();
   },
 
   salutationDidChange: function() {


### PR DESCRIPTION
Not sure if this is correct or not.
The solution should be calling `salutationDidChange` from `init` OR adding `.on('init')`. Not Both. c/d?
