### PR TITLE
Removed superfluous repetition and redundancy in titles

### DIFF
--- a/source/guides/concepts/core-concepts.md
+++ b/source/guides/concepts/core-concepts.md
@@ -1,5 +1,3 @@
-## Core Concepts
-
 To get started with Ember.js, there are a few core concepts you
 should understand. 
 

--- a/source/guides/concepts/naming-conventions.md
+++ b/source/guides/concepts/naming-conventions.md
@@ -1,5 +1,3 @@
-## Naming Conventions
-
 Ember.js uses naming conventions to wire up your objects without a
 lot  of boilerplate. You will want to  use the conventional names
 for your routes, controllers and templates.

--- a/source/guides/configuring-ember/disabling-prototype-extensions.md
+++ b/source/guides/configuring-ember/disabling-prototype-extensions.md
@@ -1,5 +1,3 @@
-## Disabling Prototype Extensions
-
 By default, Ember.js will extend the prototypes of native JavaScript
 objects in the following ways:
 

--- a/source/guides/configuring-ember/embedding-applications.md
+++ b/source/guides/configuring-ember/embedding-applications.md
@@ -1,5 +1,3 @@
-## Embedding Applications
-
 In most cases, your application's entire UI will be created by templates
 that are managed by the router.
 

--- a/source/guides/controllers/dependencies-between-controllers.md
+++ b/source/guides/controllers/dependencies-between-controllers.md
@@ -1,5 +1,3 @@
-## Managing Dependencies Between Controllers
-
 Sometimes, especially when nesting resources, we find ourselves needing
 to have some kind of connection between two controllers. Let's take this
 router as an example:

--- a/source/guides/controllers/representing-a-single-model-with-objectcontroller.md
+++ b/source/guides/controllers/representing-a-single-model-with-objectcontroller.md
@@ -1,5 +1,3 @@
-## Representing a Single Model
-
 Use `Ember.ObjectController` to represent a single model. To tell an
 `ObjectController` which model to represent, set its `model`
 property in your route's `setupController` method.

--- a/source/guides/controllers/representing-multiple-models-with-arraycontroller.md
+++ b/source/guides/controllers/representing-multiple-models-with-arraycontroller.md
@@ -1,5 +1,3 @@
-## Representing Multiple Models
-
 You can use `Ember.ArrayController` to represent an array of models. To tell an
 `ArrayController` which model to represent, set its `model` property
 in your route's `setupController` method.

--- a/source/guides/getting-started/accepting-edits.md
+++ b/source/guides/getting-started/accepting-edits.md
@@ -1,5 +1,3 @@
-## Accepting Edits
-
 In the previous step we updated TodoMVC to allow a user to toggle the display of a text `<input>` for editing a todo's title. Next, we'll add the behavior that immediately focuses the `<input>` when it appears, accepts user input and, when the user presses the `<enter>` key or moves focus away from the editing `<input>` element, persists these changes, then redisplays the todo with its newly updated text.
 
 Create a new file `js/views/edit_todo_view.js`. You may place this file anywhere you like (even just putting all code into the same file), but this guide will assume you have created the file and named it as indicated.

--- a/source/guides/getting-started/adding-a-route-and-template.md
+++ b/source/guides/getting-started/adding-a-route-and-template.md
@@ -1,5 +1,3 @@
-## Adding the First Route and Template
-
 Next, we will create an Ember.js application, a route ('`/`'), and convert our static mockup into a Handlebars template.
 
 Inside your `js` directory, add a file for the application at `js/application.js` and a file for the router at `js/router.js`. You may place these files anywhere you like (even just putting all code into the same file), but this guide will assume you have separated them into their own files and named them as indicated.

--- a/source/guides/getting-started/adding-child-routes.md
+++ b/source/guides/getting-started/adding-child-routes.md
@@ -1,5 +1,3 @@
-## Adding Child Routes
-
 Next we will split our single template into a set of nested templates so we can transition between different lists of todos in reaction to user interaction.
 
 In `index.html` move the entire `<ul>` of todos into a new template named `todos/index` by adding a new Handlebars template `<script>` tag inside the `<body>` of the document:

--- a/source/guides/getting-started/creating-a-new-model.md
+++ b/source/guides/getting-started/creating-a-new-model.md
@@ -1,5 +1,3 @@
-## Creating New Model Instance
-
 Next we'll update our static HTML `<input>` to an Ember view that can expose more complex behaviors.  Update `index.html` to replace the new todo `<input>` with an `Ember.TextField`:
 
 ```handlebars

--- a/source/guides/getting-started/creating-a-static-mockup.md
+++ b/source/guides/getting-started/creating-a-static-mockup.md
@@ -1,5 +1,3 @@
-## Creating a Static Mockup
-
 Before adding any code, we can roughly sketch out the layout of our application. In your text editor, create a new file and name it `index.html`. This file will contain the HTML templates of our completed application and trigger requests for the additional image, stylesheet, and JavaScript resources.
 
 To start, add the following text to `index.html`:

--- a/source/guides/getting-started/deleting-todos.md
+++ b/source/guides/getting-started/deleting-todos.md
@@ -1,5 +1,3 @@
-## Deleting A Model
-
 TodoMVC displays a button for removing todos next to each todo when its `<li>` is hovered. Clicking this button will remove the todo and update the display of remaining incomplete todos and remaining completed todos appropriately.
 
 In `index.html` update the static `<button>` element to include an `{{action}}` Handlebars helper:

--- a/source/guides/getting-started/display-a-button-to-remove-completed-todos.md
+++ b/source/guides/getting-started/display-a-button-to-remove-completed-todos.md
@@ -1,5 +1,3 @@
-## Displaying a Button to Remove All Completed Todos
-
 TodoMVC allows users to delete all completed todos at once by clicking a button. This button is visible only when there are any completed todos, displays the number of completed todos, and removes all todos from the application when clicked.
 
 In this step, we'll implement that behavior. In `index.html` update the static `<button>` for clearing all completed todos:

--- a/source/guides/getting-started/displaying-a-models-completeness.md
+++ b/source/guides/getting-started/displaying-a-models-completeness.md
@@ -1,5 +1,3 @@
-## Displaying a Model's Complete State
-
 TodoMVC strikes through completed todos by applying a CSS class `completed` to the `<li>` element. Update `index.html` to apply a CSS class to this element when a todo's `isCompleted` property is true:
 
 ```handlebars

--- a/source/guides/getting-started/displaying-model-data.md
+++ b/source/guides/getting-started/displaying-model-data.md
@@ -1,5 +1,3 @@
-## Displaying Model Data
-
 Next we'll update our application to display dynamic todos, replacing our hard coded section in the `todos` template.
 
 Inside the file `js/router.js` implement a `TodosRoute` object with a `model` function that returns all the existing todos:

--- a/source/guides/getting-started/displaying-the-number-of-incomplete-todos.md
+++ b/source/guides/getting-started/displaying-the-number-of-incomplete-todos.md
@@ -1,5 +1,3 @@
-## Displaying the number of incomplete todos
-
 Next we'll update our template's hard-coded count of completed todos to reflect the actual number of completed todos. Update `index.html` to use two properties:
 
 ```handlebars

--- a/source/guides/getting-started/marking-a-model-as-complete-incomplete.md
+++ b/source/guides/getting-started/marking-a-model-as-complete-incomplete.md
@@ -1,5 +1,3 @@
-## Marking a Model as Complete or Incomplete
-
 In this step we'll update our application to allow a user to mark a todo as complete or incomplete and persist the updated information.
 
 In `index.html` update your template to wrap each todo in its own controller by adding an `itemController` argument to the `{{each}}` Handlebars helper. Then convert our static `<input type="checkbox">` into an `Ember.Checkbox`:

--- a/source/guides/getting-started/modeling-data.md
+++ b/source/guides/getting-started/modeling-data.md
@@ -1,5 +1,3 @@
-## Modeling Your Data
-
 Next we will create a model class to describe todo items and a data store to track them locally. 
 
 Create a file at `js/models/todo.js` and put the following code inside:

--- a/source/guides/getting-started/obtaining-emberjs-and-dependencies.md
+++ b/source/guides/getting-started/obtaining-emberjs-and-dependencies.md
@@ -1,5 +1,3 @@
-## Obtaining Ember.js and Dependencies
-
 The version of Ember.js used in this guide (RC 3.1) can be downloaded directly from [the Ember.js build site](http://builds.emberjs.com.s3.amazonaws.com/ember-1.0.0-rc.3.1.js).  Ember.js has two dependencies: jQuery and Handlebars. jQuery can be downloaded from [http://jquery.com/](http://jquery.com/) and Handlebars can be downloaded at [http://handlebarsjs.com/](http://handlebarsjs.com/). This guide uses `ember-data` for managing model data. The latest development builds of Ember data can be downloaded at [http://builds.emberjs.com/](http://builds.emberjs.com/). The build compatible [with RC3 has the SHA `e324f0e`](http://builds.emberjs.com.s3.amazonaws.com/ember-data-e324f0e582fe180bb577f648b1b7247958db21d9.js).
 
 For this example, all of these resources should be stored in the folder `js/libs` located in the same location as `index.html`. Update your `index.html` to load these files by placing `<script>` tags just before your closing `</body>` tag in the following order:

--- a/source/guides/getting-started/planning-the-application.md
+++ b/source/guides/getting-started/planning-the-application.md
@@ -1,5 +1,3 @@
-## Planning The Application
-
 TodoMVC, despite its small size, contains most of the behaviors typical in modern single page applications. Before continuing, take a moment to understand how TodoMVC works from the user's perspective.
 
 TodoMVC has the following main features:

--- a/source/guides/getting-started/show-all-todos-again.md
+++ b/source/guides/getting-started/show-all-todos-again.md
@@ -1,5 +1,3 @@
-## Transitioning back to showing all todos
-
 Next we can update the application to allow navigating back to the list of all todos. 
 
 In `index.html` convert the `<a>` tag for 'All' todos into a Handlebars `{{link-to}}` helper:

--- a/source/guides/getting-started/show-only-complete-todos.md
+++ b/source/guides/getting-started/show-only-complete-todos.md
@@ -1,5 +1,3 @@
-## Transitioning to show only complete todos
-
 Next we'll update the application so a user can navigate to a url where only todos that have already been completed are displayed.
 
 In `index.html` convert the `<a>` tag for 'Completed' todos into a Handlebars `{{link-to}}` helper:

--- a/source/guides/getting-started/show-only-incomplete-todos.md
+++ b/source/guides/getting-started/show-only-incomplete-todos.md
@@ -1,5 +1,3 @@
-## Transitioning to show only incomplete todos
-
 Next we'll update the application so a user can navigate to a url where only todos that are not complete are displayed.
 
 In `index.html` convert the `<a>` tag for 'Active' todos into a Handlebars `{{link-to}}` helper:

--- a/source/guides/getting-started/show-when-all-todos-are-complete.md
+++ b/source/guides/getting-started/show-when-all-todos-are-complete.md
@@ -1,5 +1,3 @@
-## Indicating When All Todos Are Complete
-
 Next we'll update our template to indicate when all todos have been completed. In `index.html` replace the static checkbox `<input>` with `Ember.Checkbox`:
 
 ```handlebars

--- a/source/guides/getting-started/toggle-all-todos.md
+++ b/source/guides/getting-started/toggle-all-todos.md
@@ -1,5 +1,3 @@
-## Toggling All Todos Between Complete and Incomplete
-
 TodoMVC allows user to toggle all existing todos into either a complete or incomplete state. It uses the same checkbox that becomes checked when all todos are completed and unchecked when one or more todos remain incomplete.
 
 To implement this behavior update the `allAreDone` property in `js/controllers/todos_controller.js` to handle both getting and setting behavior:

--- a/source/guides/getting-started/toggle-todo-editing-state.md
+++ b/source/guides/getting-started/toggle-todo-editing-state.md
@@ -1,5 +1,3 @@
-## Toggling between showing and editing states
-
 TodoMVC allows users to double click each todo to display a text `<input>` element where the todo's title can be updated. Additionally the `<li>` element for each todo obtains the CSS class `editing` for style and positioning.
 
 We'll update the application to allow users to toggle into this editing state for a todo. In `index.html` update the contents of the `{{each}}` Handlebars helper to:

--- a/source/guides/getting-started/using-fixutres.md
+++ b/source/guides/getting-started/using-fixutres.md
@@ -1,5 +1,3 @@
-## Using Fixtures
-
 Now we'll add fixture data. Fixtures are a way to put sample data into an application before connecting the application to long-term persistence.
 
 Update the file at `js/models/todo.js` to include the following fixture data:

--- a/source/guides/getting-started/using-other-adapters.md
+++ b/source/guides/getting-started/using-other-adapters.md
@@ -1,5 +1,3 @@
-## Replacing the Fixture Adapter with Another Adapter
-
 Finally we'll replace our fixture data with real persistence so todos will remain between application loads by replacing the fixture adapter with a `localstorage`-aware adapter instead.
 
 Change `js/models/store.js` to:

--- a/source/guides/models/defining-a-store.md
+++ b/source/guides/models/defining-a-store.md
@@ -1,5 +1,3 @@
-## Defining a Store
-
 Every application using Ember Data has a store. The store is the
 repository that holds loaded models, and is responsible for retrieving
 models that have not yet been loaded.

--- a/source/guides/models/defining-models.md
+++ b/source/guides/models/defining-models.md
@@ -1,5 +1,3 @@
-## Defining Models
-
 For every type of model you'd like to represent, create a new subclass of
 `DS.Model`:
 

--- a/source/guides/models/finding-models.md
+++ b/source/guides/models/finding-models.md
@@ -1,5 +1,3 @@
-## Finding Models
-
 You can retrieve a record by passing its unique ID to the `find()` method:
 
 ```js

--- a/source/guides/models/model-lifecycle.md
+++ b/source/guides/models/model-lifecycle.md
@@ -1,5 +1,3 @@
-## Model Lifecycle
-
 Since models must be loaded and saved asynchronously, there are several
 possible states that a record may be in at a given time. Each instance
 of `DS.Model` has a set of Boolean properties that you can use to

--- a/source/guides/models/modifying-attributes.md
+++ b/source/guides/models/modifying-attributes.md
@@ -1,5 +1,3 @@
-## Modifying Attributes
-
 Once a record has been loaded, you can begin making changes to its
 attributes. Attributes behave just like normal properties in Ember.js
 objects. Making changes is as simple as setting the attribute you

--- a/source/guides/models/the-basic-adapter.md
+++ b/source/guides/models/the-basic-adapter.md
@@ -1,5 +1,3 @@
-## The Basic Adapter
-
 The most basic way to use Ember Data is to make your own Ajax requests
 using jQuery's Ajax helpers and process the data yourself before loading
 it into your records.

--- a/source/guides/models/the-fixture-adapter.md
+++ b/source/guides/models/the-fixture-adapter.md
@@ -1,5 +1,3 @@
-## The Fixture Adapter
-
 When developing client-side applications, your server may not have an API ready
 to develop against. The FixtureAdapter allows you to begin developing Ember.js
 apps now, and switch to another adapter when your API is ready to consume

--- a/source/guides/models/the-rest-adapter.md
+++ b/source/guides/models/the-rest-adapter.md
@@ -1,5 +1,3 @@
-## The REST Adapter
-
 By default, your store will use `DS.RESTAdapter` to load and save
 records. The REST adapter assumes that the URLs and JSON associated with
 each model are conventional; this means that, if you follow the rules,

--- a/source/guides/object-model/bindings.md
+++ b/source/guides/object-model/bindings.md
@@ -1,5 +1,3 @@
-## Bindings
-
 A binding creates a link between two properties such that when one changes, the
 other one is updated to the new value automatically. Bindings can connect
 properties on the same object, or across two different objects. Unlike most other

--- a/source/guides/object-model/classes-and-instances.md
+++ b/source/guides/object-model/classes-and-instances.md
@@ -1,5 +1,3 @@
-## Classes and Instances
-
 To define a new Ember _class_, call the `extend()` method on
 `Ember.Object`:
 

--- a/source/guides/object-model/computed-properties-and-aggregate-data.md
+++ b/source/guides/object-model/computed-properties-and-aggregate-data.md
@@ -1,5 +1,3 @@
-## Computed Properties and Aggregate Data
-
 Often, you may have a computed property that relies on all of the items in an
 array to determine its value. For example, you may want to count all of the
 todo items in a controller to determine how many of them are completed.

--- a/source/guides/object-model/computed-properties.md
+++ b/source/guides/object-model/computed-properties.md
@@ -1,5 +1,3 @@
-## Computed Properties
-
 Often, you will want a property that is computed based on other
 properties. Ember's object model allows you to define computed
 properties easily in a normal class definition.

--- a/source/guides/object-model/observers.md
+++ b/source/guides/object-model/observers.md
@@ -1,5 +1,3 @@
-## Observers
-
 Ember supports observing any property, including computed properties.
 You can set up an observer on an object by using the `addObserver`
 method.

--- a/source/guides/object-model/reopening-classes-and-instances.md
+++ b/source/guides/object-model/reopening-classes-and-instances.md
@@ -1,5 +1,3 @@
-### Reopening Classes and Instances
-
 You don't need to define a class all at once. You can reopen a class and
 define new properties using the `reopen` method.
 

--- a/source/guides/object-model/what-do-i-use-when.md
+++ b/source/guides/object-model/what-do-i-use-when.md
@@ -1,5 +1,3 @@
-## What Do I Use When?
-
 Sometimes new users are confused about when to use computed properties,
 bindings and observers. Here are some guidelines to help:
 

--- a/source/guides/routing/defining-your-routes.md
+++ b/source/guides/routing/defining-your-routes.md
@@ -1,5 +1,3 @@
-## Defining Your Routes
-
 When your application starts, the router is responsible for displaying
 templates, loading data, and otherwise setting up application state.
 It does so by matching the current URL to the _routes_ that you've

--- a/source/guides/routing/generated-objects.md
+++ b/source/guides/routing/generated-objects.md
@@ -1,5 +1,3 @@
-## Generated Objects
-
 As explained in the [routing guide][1], whenever you define a new route,
 Ember.js attempts to find corresponding Route, Controller, View, and Template
 classes named according to naming conventions. If an implementation of any of

--- a/source/guides/routing/redirection.md
+++ b/source/guides/routing/redirection.md
@@ -1,5 +1,3 @@
-## Redirecting to a Different URL
-
 If you want to redirect from one route to another, simply implement the
 `redirect` hook in your route handler.
 

--- a/source/guides/routing/rendering-a-template.md
+++ b/source/guides/routing/rendering-a-template.md
@@ -1,5 +1,3 @@
-## Rendering a Template
-
 One of the most important jobs of a route handler is rendering the
 appropriate template to the screen.
 

--- a/source/guides/routing/sending-events-from-templates.md
+++ b/source/guides/routing/sending-events-from-templates.md
@@ -1,5 +1,3 @@
-## Sending Router Events from Templates
-
 Use the `{{action}}` helper to attach a handler in your view class to an event triggered on an element.
 
 To attach an element's `click` event to the `edit()` handler in the current view:

--- a/source/guides/routing/setting-up-a-controller.md
+++ b/source/guides/routing/setting-up-a-controller.md
@@ -1,5 +1,3 @@
-## Setting Up a Controller
-
 Changing the URL may also change which template is displayed on
 screen. Templates, however, are usually only useful if they have some
 source of information to display.

--- a/source/guides/routing/specifying-a-routes-model.md
+++ b/source/guides/routing/specifying-a-routes-model.md
@@ -1,5 +1,3 @@
-## Specifying a Route's Model
-
 In the router, each URL is associated with one or more _route handlers_.
 The route handler is responsible for converting the URL into a model
 object, telling a controller to represent that model, then rendering a

--- a/source/guides/routing/specifying-the-location-api.md
+++ b/source/guides/routing/specifying-the-location-api.md
@@ -1,5 +1,3 @@
-## Specifying the location API
-
 By default the Router uses the browser's hash to load the starting state of your
 application and will keep it in sync as you move around. At present, this relies
 on a [hashchange](http://caniuse.com/hashchange) event existing in the browser.

--- a/source/guides/templates/actions.md
+++ b/source/guides/templates/actions.md
@@ -1,4 +1,4 @@
-## Actions (The `{{action}}` Helper)
+## The `{{action}}` Helper
 
 Your app will often need a way to let users interact with controls that
 change application state. For example, imagine that you have a template

--- a/source/guides/templates/binding-element-attributes.md
+++ b/source/guides/templates/binding-element-attributes.md
@@ -1,5 +1,3 @@
-## Binding Element Attributes
-
 In addition to normal text, you may also want to have your templates
 contain HTML elements whose attributes are bound to the controller.
 

--- a/source/guides/templates/binding-element-class-names.md
+++ b/source/guides/templates/binding-element-class-names.md
@@ -1,5 +1,3 @@
-## Binding Element Class Names
-
 An HTML element's `class` attribute can be bound like any other
 attribute:
 

--- a/source/guides/templates/changing-scope.md
+++ b/source/guides/templates/changing-scope.md
@@ -1,5 +1,3 @@
-## Changing Scope
-
 Sometimes you may want to invoke a section of your template with a
 different context.
 

--- a/source/guides/templates/conditionals.md
+++ b/source/guides/templates/conditionals.md
@@ -1,5 +1,3 @@
-## Conditionals
-
 Sometimes you may only want to display part of your template if a property
 exists.
 

--- a/source/guides/templates/displaying-a-list-of-items.md
+++ b/source/guides/templates/displaying-a-list-of-items.md
@@ -1,5 +1,3 @@
-## Displaying a List of Items
-
 If you need to enumerate over a list of objects, use Handlebars' `{{#each}}` helper:
 
 ```handlebars

--- a/source/guides/templates/handlebars-basics.md
+++ b/source/guides/templates/handlebars-basics.md
@@ -1,5 +1,3 @@
-## Handlebars Basics
-
 Ember.js uses the [Handlebars templating library](http://www.handlebarsjs.com)
 to power your app's user interface. Handlebars templates are just like
 regular HTML, but also give you the ability to embed expressions that

--- a/source/guides/templates/links.md
+++ b/source/guides/templates/links.md
@@ -1,4 +1,4 @@
-## Links (The `{{link-to}}` Helper)
+## The `{{link-to}}` Helper
 
 You create a link to a route using the `{{link-to}}` helper.
 

--- a/source/guides/templates/rendering-with-helpers.md
+++ b/source/guides/templates/rendering-with-helpers.md
@@ -1,5 +1,3 @@
-## Rendering with Helpers
-
 Ember provides several helpers that allow you to render other views and templates in different ways.
 
 ### The `{{partial}}` Helper

--- a/source/guides/templates/the-application-template.md
+++ b/source/guides/templates/the-application-template.md
@@ -1,5 +1,3 @@
-## The Application Template
-
 The application template is the default template that is rendered when
 your application starts. 
 

--- a/source/guides/templates/writing-helpers.md
+++ b/source/guides/templates/writing-helpers.md
@@ -1,5 +1,3 @@
-## Writing Custom Helpers
-
 Sometimes, you may use the same HTML in your application multiple times. In those case, you can register a custom helper that can be invoked from any Handlebars template.
 
 For example, imagine you are frequently wrapping certain values in a `<span>` tag with a custom class. You can register a helper from your JavaScript like this:

--- a/source/guides/understanding-ember/keeping-templates-up-to-date.md
+++ b/source/guides/understanding-ember/keeping-templates-up-to-date.md
@@ -1,5 +1,3 @@
-## Keeping Templates Up-to-Date
-
 In order to know which part of your HTML to update when an underlying property changes, Handlebars will insert marker elements with a unique ID. If you look at your application while it's running, you might notice these extra elements:
 
 ```html

--- a/source/guides/understanding-ember/managing-asynchrony.md
+++ b/source/guides/understanding-ember/managing-asynchrony.md
@@ -1,5 +1,3 @@
-## Managing Asynchrony in Ember
-
 Many Ember concepts, like bindings and computed properties, are designed
 to help manage asynchronous behavior.
 

--- a/source/guides/understanding-ember/the-view-layer.md
+++ b/source/guides/understanding-ember/the-view-layer.md
@@ -1,5 +1,3 @@
-## The Ember.js View Layer
-
 This guide goes into extreme detail about the Ember.js view layer. It is
 intended for an experienced Ember developer, and includes details that
 are unnecessary for getting started with Ember.

--- a/source/guides/views/adding-layouts-to-views.md
+++ b/source/guides/views/adding-layouts-to-views.md
@@ -1,5 +1,3 @@
-## Adding Layouts to Views
-
 Views can have a secondary template that wraps their main template. Like templates,
 layouts are Handlebars templates that will be inserted inside the
 view's tag.

--- a/source/guides/views/built-in-views.md
+++ b/source/guides/views/built-in-views.md
@@ -1,5 +1,3 @@
-## Built-in Views
-
 Ember comes pre-packaged with a set of views for building a few basic controls like text inputs, check boxes, and select lists.
 
 They are:

--- a/source/guides/views/customizing-a-views-element.md
+++ b/source/guides/views/customizing-a-views-element.md
@@ -1,5 +1,3 @@
-## Customizing a View's Element
-
 A view is represented by a single DOM element on the page. You can change what kind of element is created by
 changing the `tagName` property.
 

--- a/source/guides/views/defining-a-view.md
+++ b/source/guides/views/defining-a-view.md
@@ -1,5 +1,3 @@
-## Defining a View
-
 You can use `Ember.View` to render a Handlebars template and insert it into the DOM.
 
 To tell the view which template to use, set its `templateName` property. For example, if I had a `<script>` tag like this:

--- a/source/guides/views/handling-events.md
+++ b/source/guides/views/handling-events.md
@@ -1,5 +1,3 @@
-## Handling Events
-
 Instead of having to register event listeners on elements you'd like to
 respond to, simply implement the name of the event you want to respond to
 as a method on your view.

--- a/source/guides/views/index.md
+++ b/source/guides/views/index.md
@@ -1,5 +1,3 @@
-## Introduction to Views
-
 Because Handlebars templates in Ember.js are so powerful, the majority
 of your application's user interface will be described using them. If
 you are coming from other JavaScript libraries, you may be surprised at

--- a/source/guides/views/inserting-views-in-templates.md
+++ b/source/guides/views/inserting-views-in-templates.md
@@ -1,5 +1,3 @@
-## Inserting Views in Templates
-
 So far, we've discussed writing templates for a single view. However, as your application grows, you will often want to create a hierarchy of views to encapsulate different areas on the page. Each view is responsible for handling events and maintaining the properties needed to display it.
 
 ### {{view}}

--- a/source/guides/views/manually-managing-view-hierarchy.md
+++ b/source/guides/views/manually-managing-view-hierarchy.md
@@ -1,4 +1,4 @@
-## Manually Managed Views with Ember.ContainerView
+## Ember.ContainerView
 
 As you probably know by now, views usually create their child views
 by using the `{{view}}` helper. However, it is sometimes useful to


### PR DESCRIPTION
There's a lot of this sort of thing all over the guides, and I removed
them where appropriate:

Before:

![before](http://f.cl.ly/items/2c1S1F2c36030H3U1e2A/stork.jpg)

After:

![after](http://f.cl.ly/items/0Z3w2N3f0L1k1c3r2v1d/nork.jpg)
