### PR TITLE
Update defining-models.md be consistent with capitalization of Attr type...

### DIFF
--- a/source/guides/models/defining-models.md
+++ b/source/guides/models/defining-models.md
@@ -86,8 +86,8 @@ App.Person = DS.Model.extend({
 });
 ```
 
-The default adapter supports attribute types of `String`,
-`Number`, `Boolean`, and `Date`. Custom adapters may offer additional
+The default adapter supports attribute types of `string`,
+`number`, `boolean`, and `date`. Custom adapters may offer additional
 attribute types, and new types can be registered as transforms. See the
 [documentation section on the REST Adapter](/guides/models/the-rest-adapter).
 


### PR DESCRIPTION
...s

SHould these be titlecased or lower case?
`string`, `number`, `boolean`, and `date`.

Here they are Capitalized but in 
CREATING CUSTOM TRANSFORMATIONS
section they are lower case.
