### PR TITLE
Use border, not outline, for left nav

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -202,10 +202,14 @@ ol {
         > a {
           display: block;
           color: #443331;
-          outline: 1px solid #d5ccc8;
+          border-top: 1px solid #d5ccc8;
+          border-bottom: 1px solid #d5ccc8;
           padding: 12px 12px 10px 12px;
-          margin-top: 1px;
           background-color: rgb(244, 236, 233);
+        }
+
+        & + .level-1 > a {
+          margin-top: -1px;
         }
 
         &.selected > a {


### PR DESCRIPTION
Using `outline` causes some of the `li`s to appear with a double border. This commit replaces the `outline` with a `border-top` and `border-bottom` and uses `margin-top: -1px` to collapse the two on all but the first `li`.

I had initially tried adding the `border-top` only for the first `li`, but that meant that when the inner levels were expanded, there was no border between the nth inner content and the n+1st main nav.
### Before:

![ember website nav - before](https://f.cloud.github.com/assets/2406/1063507/a1752afe-12c3-11e3-8be8-35bbbf4f497b.png)
### After:

![ember website nav - after](https://f.cloud.github.com/assets/2406/1063506/a164e6e4-12c3-11e3-9e19-3ae60289404f.png)
