### PR TITLE
Fix paragraph spacing in api docs

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -1505,6 +1505,7 @@ a.edit-page {
     p {
       font-family: 'Helvetica Neue';
       font-weight: 200;
+      margin: 1.5em 0;
     }
   }
 


### PR DESCRIPTION
Looks like this commit https://github.com/emberjs/website/commit/37a0b005663486e48dce1c42a839ffa4bfbcb47f removed a global styling rule:

``` css
p {
  margin: 1.5em 0;
}
```

The styling rule was re-scoped to the guides page, however, this styling is still missing from the api page. This makes it difficult to read function descriptions with multiple paragraphs. This pull request adds the `margin: 1.5em 0;` rule back to `p` tags on the api page and scopes the rule to be within `.description` blocks. 
### Current site:

![screen shot 2013-09-01 at 1 17 00 pm](https://f.cloud.github.com/assets/54056/1064384/9dc21c5c-132a-11e3-9278-88e2266a48c2.png)
### Margin styling re-added to p tags:

![screen shot 2013-09-01 at 1 16 49 pm](https://f.cloud.github.com/assets/54056/1064383/9b5012d0-132a-11e3-81b4-7d739f6406b1.png)
