### PR TITLE
Builds: show loading instead of no builds

### DIFF
--- a/source/builds/index.html.erb
+++ b/source/builds/index.html.erb
@@ -78,7 +78,11 @@
     </table>
   {{ else }}
     <br/>
-    <p>There are currently no builds for {{title}}. Please check back soon.</p>
+    {{#if isLoading}}
+      Loading...
+    {{else}}
+      <p>There are currently no builds for {{title}}. Please check back soon.</p>
+    {{/if}}
   {{/if}}
 </script>
 

--- a/source/javascripts/app/builds/app.js
+++ b/source/javascripts/app/builds/app.js
@@ -27,6 +27,7 @@ App.CopyClipboardComponent = Ember.Component.extend({
 App.S3Bucket = Ember.Object.extend({
 
   files: [],
+  isLoading: false,
 
   protocol: function() {
     return this.get('useSSL') ? 'https://' : 'http://';
@@ -76,7 +77,9 @@ App.S3Bucket = Ember.Object.extend({
     var self = this,
     baseUrl = this.get('baseUrl');
 
+    this.set('isLoading', true);
     Ember.$.get(this.get('url'), function(data){
+      self.set('isLoading', false);
       self.set('response', data);
 
       var contents = data.getElementsByTagName('Contents'),
@@ -189,7 +192,7 @@ App.DailyRoute = Ember.Route.extend({
   }
 });
 
-/* 
+/*
  * Handlebars Helpers
  */
 Ember.Handlebars.helper('format-bytes', function(bytes){


### PR DESCRIPTION
The builds section currently says "There are currently no builds. Please check back soon." while loading (before the builds arrive).  This is misleading, especially on slow connections.
