### PR TITLE
Fix allAreDone code for guide

### DIFF
--- a/source/guides/getting-started/toggle-all-todos.md
+++ b/source/guides/getting-started/toggle-all-todos.md
@@ -9,7 +9,7 @@ allAreDone: function (key, value) {
     return !!this.get('length') && this.everyProperty('isCompleted', true);
   } else {
     this.setEach('isCompleted', value);
-    this.get('store').save();
+    this.invoke('save');
     return value;
   }
 }.property('@each.isCompleted')


### PR DESCRIPTION
In the guide, `this.get('store').save()` is in the allAreDone function, but it outputs an error for me. In the JSBin, `this.invoke('save')` is written in the same place and it works.
