### PR TITLE
Remove unecessary return statements

### DIFF
--- a/source/javascripts/app/examples/routing/app.js
+++ b/source/javascripts/app/examples/routing/app.js
@@ -15,8 +15,8 @@ App.Mailbox.reopenClass({
 // Routes
 
 App.Router.map(function() {
-  return this.resource('mailbox', { path: '/:mailbox_id' }, function() {
-    return this.resource('mail', { path: '/:message_id' });
+  this.resource('mailbox', { path: '/:mailbox_id' }, function() {
+    this.resource('mail', { path: '/:message_id' });
   });
 });
 


### PR DESCRIPTION
This example was ported from coffeescript, although minor these return statements are unnecessary and could be confusing (especially as the whole point of the example is demonstrating nested routing).
