### PR TITLE
Incorporate latest and daily into channels routes.

### DIFF
--- a/source/builds/index.html.erb
+++ b/source/builds/index.html.erb
@@ -12,12 +12,11 @@
       <li class="level-1">
         <a>Channels</a>
         <ol style="display:block">
-          <li class="level-3">{{#link-to 'release'}}Release{{/link-to}}</li>
-          <li class="level-3">{{#link-to 'beta'}}Beta{{/link-to}}</li>
-          <li class="level-3">{{#link-to 'canary'}}Canary{{/link-to}}</li>
+          <li class="level-3">{{#link-to 'release.latest'}}Release{{/link-to}}</li>
+          <li class="level-3">{{#link-to 'beta.latest'}}Beta{{/link-to}}</li>
+          <li class="level-3">{{#link-to 'canary.latest'}}Canary{{/link-to}}</li>
         </ol>
       </li>
-      <li class="level-1">{{#link-to 'daily'}}Daily Builds{{/link-to}}</li>
     </ol>
   </div>
 
@@ -86,18 +85,70 @@
   {{/if}}
 </script>
 
-<script type="text/x-handlebars" data-template-name="release">
+<script type="text/x-handlebars" data-template-name="release/latest">
   <h2>{{title}}</h2>
+  <div class="tabs">
+    <ul>
+      <li class="active">{{#link-to 'release.latest'}}Latest{{/link-to}}</li>
+      <li>{{#link-to 'release.daily' }}Daily{{/link-to}}</li>
+    </ul>
+  </div>
   {{partial 'fileListing'}}
 </script>
 
-<script type="text/x-handlebars" data-template-name="beta">
+<script type="text/x-handlebars" data-template-name="release/daily">
   <h2>{{title}}</h2>
+  {{build-type-selector latest="release.latest" daily="release.daily"}}
+  <div class="tabs">
+    <ul>
+      <li>{{#link-to 'release.latest'}}Latest{{/link-to}}</li>
+      <li class="active">{{#link-to 'release.daily' }}Daily{{/link-to}}</li>
+    </ul>
+  </div>
   {{partial 'fileListing'}}
 </script>
 
-<script type="text/x-handlebars" data-template-name="canary">
+<script type="text/x-handlebars" data-template-name="beta/latest">
   <h2>{{title}}</h2>
+  <div class="tabs">
+    <ul>
+      <li class="active">{{#link-to 'beta.latest'}}Latest{{/link-to}}</li>
+      <li>{{#link-to 'beta.daily' }}Daily{{/link-to}}</li>
+    </ul>
+  </div>
+  {{partial 'fileListing'}}
+</script>
+
+<script type="text/x-handlebars" data-template-name="beta/daily">
+  <h2>{{title}}</h2>
+  <div class="tabs">
+    <ul>
+      <li>{{#link-to 'beta.latest'}}Latest{{/link-to}}</li>
+      <li class="active">{{#link-to 'beta.daily' }}Daily{{/link-to}}</li>
+    </ul>
+  </div>
+  {{partial 'fileListing'}}
+</script>
+
+<script type="text/x-handlebars" data-template-name="canary/latest">
+  <h2>{{title}}</h2>
+  <div class="tabs">
+    <ul>
+      <li class="active">{{#link-to 'canary.latest'}}Latest{{/link-to}}</li>
+      <li>{{#link-to 'canary.daily' }}Daily{{/link-to}}</li>
+    </ul>
+  </div>
+  {{partial 'fileListing'}}
+</script>
+
+<script type="text/x-handlebars" data-template-name="canary/daily">
+  <h2>{{title}}</h2>
+  <div class="tabs">
+    <ul>
+      <li>{{#link-to 'canary.latest'}}Latest{{/link-to}}</li>
+      <li class="active">{{#link-to 'canary.daily' }}Daily{{/link-to}}</li>
+    </ul>
+  </div>
   {{partial 'fileListing'}}
 </script>
 

--- a/source/stylesheets/builds.css.scss
+++ b/source/stylesheets/builds.css.scss
@@ -45,5 +45,22 @@
       border-top: 1px solid #dddddd;
     }
   }
-}
 
+  .tabs {
+    ul {
+      border-bottom: none;
+
+      li.active {
+        border-right: 1px solid #f67862;
+      }
+    }
+    a.active {
+      background-color: #f67862;
+      @include background-image(linear-gradient(0deg, #e7624b, #f67862));
+      border-right: 1px solid #f67862;
+      border-top: none;
+      color: white;
+      border-top: 1px solid rgba(255, 255, 255, 0.4);
+    }
+  }
+}


### PR DESCRIPTION
This PR dovetails with the new asset structure incorporated here:

https://github.com/emberjs/ember-dev/commit/921dc4ec825917ad5363edbf2213667fd2e9d7ee

Screenshots:

https://www.monosnap.com/image/UZopR7EXDhcLkivMoe2XmAtcY - /builds
https://www.monosnap.com/image/mADVz6UN4tSDKy0nETYiSquyp - /builds#/tagged
https://www.monosnap.com/image/qkIxH0n71TC7U26aCYMgLVOsN - /builds#/release/latest
https://www.monosnap.com/image/8L9W4N305maNcQpDlkSwW03dL - /builds#/release/daily

**Please note**

The Ember stable branch is not yet using the latest ember-dev version which publishes to the new structure (it is still publishing to builds.emberjs.com/stable/ instead of builds.emberjs.com/release).

The Ember Data repo is not using the latest version of ember-dev.  https://github.com/emberjs/data/pull/1156 has been created to correct this.

Special thanks to @twokul for his help on this feature.
