### PR TITLE
Add @import so `rake build` can pass

### DIFF
--- a/source/stylesheets/builds.css.scss
+++ b/source/stylesheets/builds.css.scss
@@ -1,3 +1,5 @@
+@import "compass";
+
 #builds-application {
   #sidebar {
     $sidebar-width: 140px;


### PR DESCRIPTION
`builds.css.scss` had a compass mixin without the `@import` declaration so `rake build` would error out trying to compile it.
