### PR TITLE
Small build page fixes

### DIFF
--- a/source/builds/index.html.erb
+++ b/source/builds/index.html.erb
@@ -30,21 +30,21 @@
 <script type="text/x-handlebars" data-template-name="index">
   <div class="features section">
     <div class="feature">
-      {{#link-to 'release'}}
+      {{#link-to 'release.latest'}}
       <img class="tomster" src="/images/tomster-sm.png" alt="Release Builds">
       {{/link-to}}
       <h2>Release</h2>
       <p>Release builds have been hardened through our multi-tiered release process. These builds are perfect for use in production environments.</p>
     </div>
     <div class="feature">
-      {{#link-to 'beta'}}
+      {{#link-to 'beta.latest'}}
       <img class="tomster" src="/images/tomster-beta-sm.png" alt="Beta Builds">
       {{/link-to}}
       <h2>Beta</h2>
       <p>Beta builds will incorporate new features that are ready for more review. They will include new features that have been more thoroughly tested. We do not recommend using Beta builds in production.</p>
     </div>
     <div class="feature">
-      {{#link-to 'canary'}}
+      {{#link-to 'canary.latest'}}
       <img class="tomster" src="/images/tomster-under-construction-sm.png" alt="Canary Builds">
       {{/link-to}}
       <h2>Canary</h2>

--- a/source/javascripts/app/builds/app.js
+++ b/source/javascripts/app/builds/app.js
@@ -52,7 +52,9 @@ App.S3Bucket = Ember.Object.extend({
   }.property('useSSL'),
 
   hostname: function(){
-    return (!this.get('bucket')) ? this.get('endpoint') : this.get('bucket') + '.' + this.get('endpoint');
+    // Since the bucket has periods, the s3 wildcard cert won't work. Have to
+    // use a subdirectory.
+    return (!this.get('bucket')) ? this.get('endpoint') : this.get('endpoint') + '/' + this.get('bucket');
   }.property('bucket','endpoint'),
 
   delimiterParameter: function(){
@@ -76,6 +78,11 @@ App.S3Bucket = Ember.Object.extend({
     return this.get('protocol') + this.get('hostname');
   }.property('protocol', 'hostname'),
 
+  objectBaseUrl: function(){
+    return this.get('protocol') + this.get('bucket');
+  }.property('protocol', 'bucket'),
+
+
   queryParams: function(){
     return this.get('delimiterParameter')  + '&' +
       this.get('markerParameter')     + '&' +
@@ -93,7 +100,7 @@ App.S3Bucket = Ember.Object.extend({
 
   load: function(){
     var self = this,
-    baseUrl = this.get('baseUrl');
+    baseUrl = this.get('objectBaseUrl');
 
     this.set('isLoading', true);
     Ember.$.get(this.get('url'), function(data){
@@ -139,6 +146,9 @@ App.S3File = Ember.Object.extend({
   }.property('baseUrl', 'relativePath')
 });
 
+App.BetaRoute = Ember.Route.extend({
+  redirect: function() { this.transitionTo('beta.latest'); }
+});
 App.BetaLatestRoute = Ember.Route.extend({
   model: function() {
     return App.S3Bucket.create({title: 'Beta Builds', prefix: 'beta/'});
@@ -156,6 +166,9 @@ App.BetaDailyRoute = Ember.Route.extend({
   }
 });
 
+App.CanaryRoute = Ember.Route.extend({
+  redirect: function() { this.transitionTo('canary.latest'); }
+});
 App.CanaryLatestRoute = Ember.Route.extend({
   model: function() {
     return App.S3Bucket.create({title: 'Canary Builds', prefix: 'latest/',});
@@ -173,6 +186,9 @@ App.CanaryDailyRoute = Ember.Route.extend({
   }
 });
 
+App.ReleaseRoute = Ember.Route.extend({
+  redirect: function() { this.transitionTo('release.latest'); }
+});
 App.ReleaseLatestRoute = Ember.Route.extend({
   model: function() {
     return App.S3Bucket.create({title: 'Release Builds', prefix: 'stable/'});


### PR DESCRIPTION
Links on the build page are broken for me. Changed them to reference .latest, which seems in line with the links in the sidebar.

If you have HTTPS everywhere installed, it tries to connect to AWS via https even if using the regular http URL. Since the bucket name has period characters, the wildcard certificate is invalid. Using a subdirectory for the bucket name fixes it.
