### PR TITLE
Preloading in ApplicationRoute#activate doesn't make sense

### DIFF
--- a/source/guides/models/pushing-records-into-the-store.md
+++ b/source/guides/models/pushing-records-into-the-store.md
@@ -25,7 +25,7 @@ For example, imagine we want to preload some data into the store when
 the application boots for the first time.
 
 We can use the `ApplicationRoute` to do so. The `ApplicationRoute` is
-the top-most route in the route hierarchy, and its `activate` hook gets
+the top-most route in the route hierarchy, and its `model` hook gets
 called once when the app starts up.
 
 ```js
@@ -38,7 +38,7 @@ App.Album = DS.Model.extend({
 });
 
 App.ApplicationRoute = Ember.Route.extend({
-  activate: function() {
+  model: function() {
     var store = this.get('store'); 
 
     store.push('album', {


### PR DESCRIPTION
`model` hooks for all routes run before any of the `activate` hooks.

Consequently this preload code only runs after all of the required models are fetched which more or less defeats the purpose of preloading.

I don't know if it is a good idea to recommend preloading in the `model` hook or somewhere else. If anyone wants to suggest a different place I can update.
