### PR TITLE
Remove spurious script tag.

### DIFF
--- a/source/guides/getting-started/creating-a-new-model.md
+++ b/source/guides/getting-started/creating-a-new-model.md
@@ -48,7 +48,6 @@ In `index.html` include `js/controllers/todos_controller.js` as a dependency:
 
 ```html
 <!--- ... additional lines truncated for brevity ... -->
-   <script src="js/models/store.js"></script>
    <script src="js/models/todo.js"></script>
    <script src="js/controllers/todos_controller.js"></script>
  </body>


### PR DESCRIPTION
The js/models/store.js file referenced here has not (yet?) appeared in the getting started guide, and does not appear in the associated diff for this step:

https://github.com/emberjs/quickstart-code-sample/commit/60feb5f369c8eecd9df3f561fbd01595353ce803

Thus, it should probably be removed from the code listing, since it'll just 404.
