### PR TITLE
The posts url in the XML feed need to include the domain name

### DIFF
--- a/source/blog/feed.xml.builder
+++ b/source/blog/feed.xml.builder
@@ -10,9 +10,11 @@ xml.feed "xmlns" => "http://www.w3.org/2005/Atom" do
 
   blog.articles[0..5].each do |article|
     xml.entry do
+      entry_url = "http://emberjs.com#{article.url}"
+
       xml.title article.title
-      xml.link "rel" => "alternate", "href" => article.url
-      xml.id article.url
+      xml.link "rel" => "alternate", "href" => entry_url
+      xml.id entry_url
       xml.published article.date.to_time.iso8601
       xml.updated article.date.to_time.iso8601
       xml.author { xml.name "Ember" }


### PR DESCRIPTION
Without including the domain name, feed readers can't properly link to the post.
