### PR TITLE
Fixed a broken link in modeling-data.md of the getting started guide

### DIFF
--- a/source/guides/getting-started/modeling-data.md
+++ b/source/guides/getting-started/modeling-data.md
@@ -30,5 +30,5 @@ Reload your web browser to ensure that all files have been referenced correctly 
 ### Additional Resources
 
   * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/a1ccdb43df29d316a7729321764c00b8d850fcd1)
-  * [Defining A Store Guide](/guides/models/defining-a-store)
+  * [Using A Store Guide](/guides/models/using-the-store)
   * [Defining Models Guide](/guides/models/defining-models)


### PR DESCRIPTION
The link was to a existent page.  I changed it to where (I think) it should be going.
