### PR TITLE
Added hint on inserting code in tutorial

### DIFF
--- a/source/guides/getting-started/displaying-the-number-of-incomplete-todos.md
+++ b/source/guides/getting-started/displaying-the-number-of-incomplete-todos.md
@@ -11,6 +11,8 @@ Next we'll update our template's hard-coded count of completed todos to reflect 
 Implement these properties as part of this template's controller, the `Todos.TodosController`:
 
 ```javascript
+// Hint: these lines must not go into the 'actions' object.
+
 // ... additional lines truncated for brevity ...
 remaining: function () {
   return this.filterProperty('isCompleted', false).get('length');


### PR DESCRIPTION
Added hint on inserting code in tutorial.

I inserted the remaining() and inflection() in the action object and nothing worked (there was no number shown left to 'remaining' in the app).
The problem was that no error occurred in the dev console, therefore, I think that it would helpful to leave a hint in the docs.
