### PR TITLE
Added heads up about computed properties to  'marking a model as complet...

### DIFF
--- a/source/guides/getting-started/marking-a-model-as-complete-incomplete.md
+++ b/source/guides/getting-started/marking-a-model-as-complete-incomplete.md
@@ -37,7 +37,7 @@ Todos.TodoController = Ember.ObjectController.extend({
 });
 ```
 
-When called from the template to display the current `isCompleted` state of the todo, this property will proxy that question to its underlying `model`. When called with a value because a user has toggled the checkbox in the template, this property will set the `isCompleted` property of its `model` to the passed value (`true` or `false`), persist the model update, and return the passed value so the checkbox will display correctly.
+When called from the template to display the current `isCompleted` state of the todo, this property will proxy that question to its underlying `model`. When called with a value because a user has toggled the checkbox in the template, this property will set the `isCompleted` property of its `model` to the passed value (`true` or `false`), persist the model update, and return the passed value so the checkbox will display correctly. Notice that `isCompleted` function calls `property`. By doing this it declares itself as a [computed property](/guides/object-model/computed-properties/) and that it depends upon the attribute `model.isCompleted`.
 
 In `index.html` include `js/controllers/todo_controller.js` as a dependency:
 


### PR DESCRIPTION
...e-incomplete' page.

When a person reads this for the first time, he is left wondering why this function calls `property`. Even if there's a resource link in the bottom, it would nice to give a small heads up of whats going on up there.
