### PR TITLE
Controllers are no more instantiated on application namespace

### DIFF
--- a/source/guides/views/built-in-views.md
+++ b/source/guides/views/built-in-views.md
@@ -15,7 +15,7 @@ They are:
 
 ```javascript
 App.MyText = Ember.TextField.extend({
-  formBlurredBinding: 'App.adminController.formBlurred',
+  formBlurred: null, // passed to the view helper as formBlurred=controllerPropertyName
   change: function(evt) {
     this.set('formBlurred', true);
   }
@@ -26,11 +26,11 @@ App.MyText = Ember.TextField.extend({
 
 ```handlebars
 {{view Ember.Select viewName="select"
-                    contentBinding="App.peopleController"
+                    contentBinding="people"
                     optionLabelPath="model.fullName"
                     optionValuePath="model.id"
                     prompt="Pick a person:"
-                    selectionBinding="App.selectedPersonController.person"}}
+                    selectionBinding="selectedPerson"}}
 ```
 
 #### Ember.TextArea


### PR DESCRIPTION
So maybe the guides shouldn't use that approach in the examples.
