### PR TITLE
Update /builds to group projects and show last release.

### DIFF
--- a/source/builds/index.html.erb
+++ b/source/builds/index.html.erb
@@ -84,7 +84,28 @@ title: Builds
 </script>
 
 <script type="text/x-handlebars" data-template-name="_files_table">
-  <h2 class="project-name">{{projectName}}</h2>
+  <h3 class="project-name">{{projectName}}</h3>
+  {{#if lastRelease}}
+  <div id="download">
+    <div id="download-ember">
+      <a class="orange button" {{bind-attr href=lastReleaseDebugUrl}}>
+        Download {{lastRelease}}
+      </a>
+      <div class="info">
+        {{lastRelease}}:
+        <a class="debug" {{bind-attr href=lastReleaseProdUrl}}>
+          production
+        </a>
+        <a class="debug" {{bind-attr href=lastReleaseMinUrl}}>
+          (min)
+        </a> |
+        <a class="debug" {{bind-attr href=lastReleaseDebugUrl}}>
+          debug
+        </a>
+      </div>
+    </div>
+  </div>
+  {{/if}}
   <p>{{description}}</p>
   <table class="table">
     <thead>

--- a/source/javascripts/app/builds/app.js
+++ b/source/javascripts/app/builds/app.js
@@ -184,7 +184,7 @@ App.Project.reopenClass({
     }, {
       projectName: "Ember",
       projectFilter: "ember",
-      lastRelease: "",
+      lastRelease: "1.1.0-beta.1",
       futureVersion: "1.1.0",
       channel: "beta",
       date: "2013-09-10"
@@ -276,6 +276,9 @@ App.ProjectsMixin = Ember.Mixin.create({
     projects.forEach(function(project){
       project.files = bucket.filterFiles(project.projectFilter);
       project.description = self.description(project);
+      project.lastReleaseDebugUrl = self.lastReleaseUrl(project.projectFilter, project.lastRelease, '.js');
+      project.lastReleaseProdUrl  = self.lastReleaseUrl(project.projectFilter, project.lastRelease, '.prod.js');
+      project.lastReleaseMinUrl   = self.lastReleaseUrl(project.projectFilter, project.lastRelease, '.min.js');
     });
 
     return projects;
@@ -289,8 +292,7 @@ App.ProjectsMixin = Ember.Mixin.create({
     if (this.get('channel') === 'tagged') {
       value = '';
     } else if (lastRelease) {
-      value = 'These builds are incremental improvements made since ' + lastRelease + ' and may become ' + futureVersion + '. ' +
-        'The most recent tagged version can be downloaded from <a href="#/tagged">here</a>.' ;
+      value = 'These builds are incremental improvements made since ' + lastRelease + ' and may become ' + futureVersion + '.'
     } else if (futureVersion) {
       value = 'These builds are not based on a tagged release. Upon the next release cycle they will become ' + futureVersion + '.';
     } else {
@@ -298,6 +300,10 @@ App.ProjectsMixin = Ember.Mixin.create({
     }
 
     return new Handlebars.SafeString(value);
+  },
+
+  lastReleaseUrl: function(project, lastRelease, extension){
+    return 'http://builds.emberjs.com/tags/v' + lastRelease + '/' + project + extension;
   }
 });
 

--- a/source/stylesheets/builds.css.scss
+++ b/source/stylesheets/builds.css.scss
@@ -56,6 +56,7 @@
 
   .project-name {
     margin-top: 1.5em;
+    float: left;
   }
 
   .table {


### PR DESCRIPTION
This makes a few specific changes:
- Remove Project based filtering.
- Group files listed by project.
- Show last release / future release description details for each channel.

Screenshots:

Tagged Releases:
![/tagged](https://monosnap.com/image/9OqaWwRLAtxruZgayK3C82l3J.png)

Release Channel:
![/release](https://www.monosnap.com/image/pFSXV2cGbnelLcQcjIF1VGdpe.png)

Beta Channel:
![/beta](https://www.monosnap.com/image/8GyQDXm5AHo5ICBP05XWu0ebl.png)

Canary Channel:
![/canary](https://www.monosnap.com/image/FwhvFnAW4KPZDNBCstPS9HJfe.png)

@twokul - Thanks for pairing up on this!
