### PR TITLE
Fix incorrect Ember Data 1.0 DS.attr type assignment in guides

### DIFF
--- a/source/guides/models/defining-models.md
+++ b/source/guides/models/defining-models.md
@@ -78,11 +78,11 @@ Properties](/guides/object-model/computed-properties).
 
 If you don't specify the type of the attribute, it will be whatever was
 provided by the server. You can make sure that an attribute is always
-coerced into a particular type by passing a `type` option to `attr`:
+coerced into a particular type by passing a `type` to `attr`:
 
 ```js
 App.Person = DS.Model.extend({
-  birthday: attr({ type: Date })
+  birthday: DS.attr('date')
 });
 ```
 


### PR DESCRIPTION
`DS.attr({ type: Date })` gives the following error:

`Cannot call method 'deserialize' of undefined`

This is because the `tranformFor` method is expecting a string value for type, however it is receiving the supplied hash `{ type: Date }`.

I've looked at the code for master, beta1 and beta2 and it seems that all versions post 1.0 of ember data will not accept the guide's stated syntax.

Looks like the correct syntax for ember 1.0 should be as it was before. e.g. `DS.attr('type')`
