### PR TITLE
Add a github-style no-flash fallback for quick copy

### DIFF
--- a/source/builds/index.html.erb
+++ b/source/builds/index.html.erb
@@ -146,5 +146,9 @@ title: Builds
 </script>
 
 <script type="text/x-handlebars" data-template-name="components/copy-clipboard">
-  <button {{bind-attr data-clipboard-text=text}} {{bind-attr data-label=label}}>{{label}}</button>
+  {{#if hasFlash}}
+    <button {{bind-attr data-clipboard-text=text}} {{bind-attr data-label=label}}>{{label}}</button>
+  {{else}}
+    <input type="text" class="name-input" readonly="readonly" {{bind-attr value=text}}>
+  {{/if}}
 </script>

--- a/source/javascripts/app/builds/app.js
+++ b/source/javascripts/app/builds/app.js
@@ -23,6 +23,7 @@ App.Router.map(function() {
 
 App.CopyClipboardComponent = Ember.Component.extend({
   tagName: 'span',
+  hasFlash: ZeroClipboard.detectFlashSupport(),
 
   didInsertElement: function () {
     var clip = new ZeroClipboard(this.$('button'), {
@@ -42,6 +43,10 @@ App.CopyClipboardComponent = Ember.Component.extend({
         $(this).addClass('loading');
         $(this).attr('disabled', 'disabled');
       });
+    });
+
+    this.$('input').on('click', function() {
+      $(this).select();
     });
   }
 });


### PR DESCRIPTION
Basically, if the browser doesn't support flash, the button to copy is still shown currently and clicking on it obviously does nothing.

With this PR, `CopyClipboardComponent` will show a text field with the text to copy instead of a button if flash isn't supported. Clicking anywhere on this input will select all of its content and the user will be copy manually then (like on GitHub).

![screen shot 2013-09-15 at 19 34 19](https://f.cloud.github.com/assets/315596/1145624/df012b68-1e24-11e3-8d2a-3769961e0887.png)
