### PR TITLE
Remove trailing newline from links to releases

### DIFF
--- a/source/about.html.erb
+++ b/source/about.html.erb
@@ -14,18 +14,10 @@ title: "About"
     </a>
     <div class="info">
       1.0.0:
-      <a class="debug" href="http://builds.emberjs.com/tags/v1.0.0/ember.prod.js">
-        production
-      </a>
-      <a class="debug" href="http://builds.emberjs.com/tags/v1.0.0/ember.min.js">
-        (min + gzip  64kb)
-      </a> |
-      <a class="debug" href="http://builds.emberjs.com/tags/v1.0.0/ember.js">
-        debug
-      </a> |
-      <a href="http://builds.emberjs.com/handlebars-1.0.0.js">
-        Handlebars
-      </a>
+      <a class="debug" href="http://builds.emberjs.com/tags/v1.0.0/ember.prod.js">production</a>
+      <a class="debug" href="http://builds.emberjs.com/tags/v1.0.0/ember.min.js">(min + gzip  64kb)</a> |
+      <a class="debug" href="http://builds.emberjs.com/tags/v1.0.0/ember.js">debug</a> |
+      <a href="http://builds.emberjs.com/handlebars-1.0.0.js">Handlebars</a>
     </div>
   </div>
 

--- a/source/builds/index.html.erb
+++ b/source/builds/index.html.erb
@@ -88,20 +88,12 @@ title: Builds
   {{#if lastRelease}}
   <div id="download">
     <div id="download-ember">
-      <a class="orange button" {{bind-attr href=lastReleaseDebugUrl}}>
-        Download {{lastRelease}}
-      </a>
+      <a class="orange button" {{bind-attr href=lastReleaseDebugUrl}}>Download {{lastRelease}}</a>
       <div class="info">
         {{lastRelease}}:
-        <a class="debug" {{bind-attr href=lastReleaseProdUrl}}>
-          production
-        </a>
-        <a class="debug" {{bind-attr href=lastReleaseMinUrl}}>
-          (min)
-        </a> |
-        <a class="debug" {{bind-attr href=lastReleaseDebugUrl}}>
-          debug
-        </a>
+        <a class="debug" {{bind-attr href=lastReleaseProdUrl}}>production</a>
+        <a class="debug" {{bind-attr href=lastReleaseMinUrl}}>(min)</a> |
+        <a class="debug" {{bind-attr href=lastReleaseDebugUrl}}>debug</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Links with a trailing newline/space in them are rendered weirdly, especially when you display `border-bottom` on hover.
#### Before

![screen shot 2013-09-15 at 19 51 26](https://f.cloud.github.com/assets/315596/1145659/7aa918a8-1e27-11e3-9332-081efd459b3f.png)
#### After

![screen shot 2013-09-15 at 19 51 37](https://f.cloud.github.com/assets/315596/1145660/80a8d694-1e27-11e3-87d9-c4a1a2cb6236.png)
