### PR TITLE
Modify top section of /builds to use buttons instead of info.

### DIFF
--- a/source/builds/index.html.erb
+++ b/source/builds/index.html.erb
@@ -84,16 +84,19 @@ title: Builds
 </script>
 
 <script type="text/x-handlebars" data-template-name="_files_table">
-  <h2 class="project-name">{{projectName}}</h2>
+  <h2 class="project-name">{{projectName}} Downloads</h2>
   {{#if lastRelease}}
   <div id="download">
     <div id="download-ember">
-      <a class="orange button" {{bind-attr href=lastReleaseDebugUrl}}>Download {{lastRelease}}</a>
-      <div class="info">
-        {{lastRelease}}:
-        <a class="debug" {{bind-attr href=lastReleaseProdUrl}}>production</a>
-        <a class="debug" {{bind-attr href=lastReleaseMinUrl}}>(min)</a> |
-        <a class="debug" {{bind-attr href=lastReleaseDebugUrl}}>debug</a>
+      <a class="orange button" {{bind-attr href=lastReleaseProdUrl}}>
+        Production {{lastRelease}}
+      </a>
+      <a class="orange button" {{bind-attr href=lastReleaseMinUrl}}>
+        Prod(minified) {{lastRelease}}
+      </a>
+      <a class="orange button" {{bind-attr href=lastReleaseDebugUrl}}>
+        Development {{lastRelease}}
+      </a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Old Version: 

![2013-09-16--1379355034_679x186_scrot](https://f.cloud.github.com/assets/632060/1151602/8e7f5276-1efd-11e3-920e-5c5bab51cc4a.png)

New Version:

![2013-09-16--1379355305_722x254_scrot](https://f.cloud.github.com/assets/632060/1151603/9350dc16-1efd-11e3-8670-16d450f3f4f9.png)

1) Added two buttons (for a total of three) to initiate downloading
Ember.js.
2) Removed the info line that was below the single button before.
3) Change the word "debug" to "development".

I always thought that it was "kinda" confusing that the one button
didn't really say which version you would be downloading if you clicked
the button.

Change number 3 may be backed out by the maintainers of Ember if they
believe
the title "debug" is the accepted title for this but again, I think it
is "misleading" in that it sounds like "Download this version if you are
having problems and need to debug" when it really is "Use this version
for application development because it has additional functionallity to
help you debug your code if you need to".
