### PR TITLE
[cookbook] Clarified component class name bindings

### DIFF
--- a/source/guides/cookbook/user_interface_and_interaction/displaying_formatted_dates_with_moment_js.md
+++ b/source/guides/cookbook/user_interface_and_interaction/displaying_formatted_dates_with_moment_js.md
@@ -57,7 +57,7 @@ App.ApplicationController = Ember.Controller.extend({
     var date = this.get('date'),
         format = this.get('format');
     return moment(date).format(format);
-  }.property('format')
+  }.property('date', 'format')
 });
 ```
 


### PR DESCRIPTION
The initial example was using an isEnabled in the class name binding even though "isRelatedBinding" was used below.

Also, clarified what this meant and the possible alternative of passing the value directly without requiring "isRelatedBinding".

Signed-off-by: danjamin e051ba3be@gmail.com
