### PR TITLE
Fix overflowing links on api page

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -1539,6 +1539,14 @@ a.edit-page {
     }
   }
 
+  ol#toc-list {
+    li a {
+      display: block;
+      overflow: hidden;
+      @include ellipsis;
+    }
+  }
+
   div.method, div.property, div.event {
     padding-bottom: 1em;
     border-bottom: solid 1px #e0e0e0;


### PR DESCRIPTION
Old definition (ul.index-list on line 1528 of site.css.scss) must have been broken down the line, just a simple fix. 
