### PR TITLE
Route.redirect is deprecated, replacing by afterModel

### DIFF
--- a/source/guides/routing/redirection.md
+++ b/source/guides/routing/redirection.md
@@ -7,7 +7,7 @@ App.Router.map(function() {
 });
 
 App.IndexRoute = Ember.Route.extend({
-  redirect: function() {
+  afterModel: function() {
     this.transitionTo('posts');
   }
 });
@@ -27,7 +27,7 @@ App.Router.map(function() {
 });
 
 App.TopChartsChooseRoute = Ember.Route.extend({
-  redirect: function() {
+  afterModel: function() {
     var lastFilter = this.controllerFor('application').get('lastFilter');
     this.transitionTo('topCharts.' + lastFilter || 'songs');
   }


### PR DESCRIPTION
`redirect:` is not working with nested routes right now. I was digging the documentation and noted it was deprecated. I could not find why, so I did a blame and found this out:

https://github.com/emberjs/ember.js/commit/5e7a2636bf9e842b8a9c64d291c6408f3fab0eab

Using `afterModel` instead of `redirect` makes it possible to work with nested routes. I don't know why the auto generated API docs don't mention `afterModel` anymore, but this seems to fix the problem to me and it removes a deprecated method from the examples on the site.
