### PR TITLE
Incorrect JSON format shown for belongsTo relationship

### DIFF
--- a/source/guides/models/connecting-to-an-http-server.md
+++ b/source/guides/models/connecting-to-an-http-server.md
@@ -77,9 +77,7 @@ return the JSON in the following format:
     "id": 1
     "title": "Rails is omakase",
     "comments": ["1", "2"],
-    "_links": {
-      "user": "/people/dhh"
-    },
+    "user" : "dhh"
   },
 
   "comments": [{


### PR DESCRIPTION
The documentation for the chapter "Connecting to an HTTP Server" shows an incorrect JSON format for the belongsTo relationship.  Currently has the relationship in a `_links` property, but Ember Data is actually expecting the id for the user against the `user` property.
