### PR TITLE
Use meetup.com for ATX meetup

### DIFF
--- a/data/meetups.yml
+++ b/data/meetups.yml
@@ -24,7 +24,7 @@
     url:      http://www.meetup.com/Ember-js-Seattle-Meetup/
     image:    08seattle.png
   - location: Austin, TX
-    url:      http://emberatx.org/
+    url:      http://www.meetup.com/Ember-ATX/
     image:    16austin.png
   - location: Washington, DC
     url: http://www.meetup.com/Ember-JS-DC/


### PR DESCRIPTION
The [meetup.com](http://www.meetup.com/Ember-ATX/) page seems to be kept up to date more than the [website](http://www.emberatx.org/).
