### PR TITLE
Remove debugging tips for using a record's stateManager

### DIFF
--- a/source/guides/understanding-ember/debugging.md
+++ b/source/guides/understanding-ember/debugging.md
@@ -96,18 +96,6 @@ window.App = Ember.Application.create({
 
 ## Ember Data
 
-#### Get the state history of an ember-data record
-
-```javascript
-record.stateManager.get('currentPath')
-```
-
-#### Log state transitions
-
-```javascript
-record.set("stateManager.enableLogging", true)
-```
-
 #### View ember-data's identity map
 
 ```javascript


### PR DESCRIPTION
These two tips no longer work, since the stateManager was removed from Ember Data.

http://emberjs.com/guides/understanding-ember/debugging/#toc_get-the-state-history-of-an-ember-data-record
