### PR TITLE
Update displaying_formatted_dates_with_moment_js.md

### DIFF
--- a/source/guides/cookbook/user_interface_and_interaction/displaying_formatted_dates_with_moment_js.md
+++ b/source/guides/cookbook/user_interface_and_interaction/displaying_formatted_dates_with_moment_js.md
@@ -22,11 +22,13 @@ Ember.Handlebars.registerBoundHelper('currentDate', function() {
 ```
 
 Your template will look like:
+
 ```html
 Today's date: {{currentDate}}  // Today's date: August 30 2013
 ```
 
 You can even enhance your code and pass in the date format to the helper:
+
 ```javascript
 Ember.Handlebars.registerBoundHelper('currentDate', function(format) {
   return moment().format(format);
@@ -34,6 +36,7 @@ Ember.Handlebars.registerBoundHelper('currentDate', function(format) {
 ```
 
 Now you would need to pass an additional parameter to the helper:
+
 ```html
 Today's date: {{currentDate 'LL'}}  // Today's date: August 30 2013
 ```


### PR DESCRIPTION
Fenced code blocks are being rendered like inline code. Seems like the difference is a newline. If that doesn't fix it, still nice to have it in the markdown.
