### PR TITLE
Changed hbs to html with script and template-name for clarification

### DIFF
--- a/source/guides/views/inserting-views-in-templates.md
+++ b/source/guides/views/inserting-views-in-templates.md
@@ -22,15 +22,19 @@ App.InfoView = Ember.View.extend({
 });
 ```
 
-```handlebars
-User: {{view.firstName}} {{view.lastName}}
-{{view App.InfoView}}
+```html
+<script type="text/x-handlebars" data-template-name="user">
+  User: {{view.firstName}} {{view.lastName}}
+  {{view App.InfoView}}
+</script>
 ```
 
-```handlebars
-<b>Posts:</b> {{view.posts}}
-<br>
-<b>Hobbies:</b> {{view.hobbies}}
+```html
+<script type="text/x-handlebars" data-template-name="info">
+  <b>Posts:</b> {{view.posts}}
+  <br>
+  <b>Hobbies:</b> {{view.hobbies}}
+</script>
 ```
 
 If we were to create an instance of `App.UserView` and render it, we would get


### PR DESCRIPTION
It was confusing to have two unnamed example hbs-templates without context to clarify which is which.

As it's done in other parts of the documentation. I changed the hbs it to html and added <script type="text/x-handlebars" data-template-name="XXX" to clarify it.
