### PR TITLE
Remove "Rendering Warning" information

### DIFF
--- a/source/guides/routing/rendering-a-template.md
+++ b/source/guides/routing/rendering-a-template.md
@@ -90,19 +90,3 @@ App.PostRoute = App.Route.extend({
   }
 });
 ```
-
-## Rendering Warning
-
-When a template tries to render, and the parent route did not render a
-template, then you will see this warning:
-
-"The immediate parent route did not render into the main outlet ..."
-
-This means that the current route tried to render into the parent
-route's template, but the parent route didn't render a template, or, if
-it did, that the template which the parent route provided did not render
-into the main template (i.e., a default `{{outlet}}`).
-
-Ember provides this warning because it expects that you will want to
-render into the main template.
-


### PR DESCRIPTION
This .assert was never written in a clear way that people
understood, so we removed it hoping someone would repost
the issue with steps to reproduce so we could write a better
message.

We never have. It appears the cause of this isn't common any longer.
