### PR TITLE
Work-around for ember-data fixtures "limitation"

### DIFF
--- a/source/guides/getting-started/using-fixtures.md
+++ b/source/guides/getting-started/using-fixtures.md
@@ -16,17 +16,17 @@ Next, update the file at `js/models/todo.js` to include the following fixture da
 // ... additional lines truncated for brevity ...
 Todos.Todo.FIXTURES = [
  {
-   id: 1,
+   id: 1001,
    title: 'Learn Ember.js',
    isCompleted: true
  },
  {
-   id: 2,
+   id: 1002,
    title: '...',
    isCompleted: false
  },
  {
-   id: 3,
+   id: 1003,
    title: 'Profit!',
    isCompleted: false
  }


### PR DESCRIPTION
Defines the fixtures in an ID range that's unlikely to collide with todos generated by hand.

Given that the `ember-data` fixtures adapter provides a `generateIdForRecord` method that uses a private `counter` variable, initialized to 0, that's incremented for each fixture created.

Given that the the Getting Started | Using Fixtures guide defines three Todo fixtures with IDs 1, 2, and 3.

When the user completes the Getting Started | Creating a New Model Instance guide, they can create one new Todo, which is given an ID of 0 by `generateIdForRecord`.

When the user tries to create a second Todo, BOOM!

This is the easiest work-around that I can think of for this problem.

Another, more-permanent fix would be to modify `DS.FixtureAdapter#fixturesForType` to make sure that `counter` is always larger than the largest numerical ID in a Fixtures file. But I don't know if that would mesh with the philosophy of `DS.FixtureAdapter`.
