### PR TITLE
Fix double 'the' typo in planning-application.md

### DIFF
--- a/source/guides/getting-started/planning-the-application.md
+++ b/source/guides/getting-started/planning-the-application.md
@@ -23,4 +23,4 @@ TodoMVC has the following main features:
 
   1. It retains a user's todos between application loads by using the browser's `localstorage` mechanism.
 
-You can interact with a completed version of the application by visiting the [the TodoMVC site](http://addyosmani.github.com/todomvc/).
+You can interact with a completed version of the application by visiting the [TodoMVC site](http://addyosmani.github.com/todomvc/).


### PR DESCRIPTION
I just saw the typo while I was translating the guides and thought I'd change it. Also, five of these list items use the word 'provide' and the explicit subject 'it' comes across as repetitive, which makes the whole thing hard to understand, though that's another issue.
