### PR TITLE
Fix error in REST adapter documentation

### DIFF
--- a/source/guides/models/the-rest-adapter.md
+++ b/source/guides/models/the-rest-adapter.md
@@ -59,11 +59,11 @@ Requests for `App.Person` would now target `/api/1/people/1`.
 
 #### Host Customization
 
-An adapter can target other hosts by setting the `url` property.
+An adapter can target other hosts by setting the `host` property.
 
 ```js
 DS.RESTAdapter.reopen({
-  url: 'https://api.example.com'
+  host: 'https://api.example.com'
 });
 ```
 


### PR DESCRIPTION
The property to change host is `host` not `url`.
