### PR TITLE
Add explicit identifier blurb to links.md

### DIFF
--- a/source/guides/templates/links.md
+++ b/source/guides/templates/links.md
@@ -44,6 +44,17 @@ The `{{link-to}}` helper takes:
   value of the corresponding object's `id` property.
 * An optional title which will be bound to the `a` title attribute
 
+If there is no model to pass to the helper, you can provide an explicit identifier value instead.
+The value will be filled into the [dynamic segment](/guides/routing/defining-your-routes/#toc_dynamic-segments)
+of the route, and will make sure that the `model` hook is triggered.
+```handlebars
+<!-- photos.handlebars -->
+
+{{#link-to 'photo.edit' 1}}
+  First Photo Ever
+{{/link-to}}
+```
+
 ### Example for Multiple Segments
 
 If the route is nested, you can supply a model for each dynamic


### PR DESCRIPTION
Just a short blurb about linking to routes by passing IDs explicitly rather than providing a model context. This tripped me up, and I think it could be helpful to people who are not using Ember Data and have a REST API that isn't very nice.
