### PR TITLE
Changed 'blog_posts' references to 'posts'

### DIFF
--- a/source/guides/routing/defining-your-routes.md
+++ b/source/guides/routing/defining-your-routes.md
@@ -202,22 +202,22 @@ modifying those nouns.
 One of the responsibilities of a resource's route handler is to convert a URL
 into a model.
 
-For example, if we have the resource `this.resource('/blog_posts');`, our
+For example, if we have the resource `this.resource('posts');`, our
 route handler might look like this:
 
 ```js
-App.BlogPostsRoute = Ember.Route.extend({
+App.PostsRoute = Ember.Route.extend({
   model: function() {
-    return this.get('store').find('blogPost');
+    return this.get('store').find('posts');
   }
 });
 ```
 
-The `blog_posts` template will then receive a list of all available posts as
+The `posts` template will then receive a list of all available posts as
 its context.
 
-Because `/blog_posts` represents a fixed model, we don't need any
-additional information to know what to use.  However, if we want a route
+Because `/posts` represents a fixed model, we don't need any
+additional information to know what to retrieve.  However, if we want a route
 to represent a single post, we would not want to have to hardcode every
 possible post into the router.
 


### PR DESCRIPTION
It seems as if the uses of 'blog_posts'/'blogPost', etc. are old--everywhere else
in the guides, 'posts' and 'post' are used. I think it's clearer to use examples
similar to the rest of the guides.

WDYT?
