### PR TITLE
Remove `everyProperty` and `someProperty` references.

### DIFF
--- a/source/guides/enumerables/index.md
+++ b/source/guides/enumerables/index.md
@@ -224,10 +224,10 @@ people.some(function(person, index, self) {
 // returns true
 ```
 
-Just like the filtering methods, the `every` and `some` methods have analogous `everyProperty` and `someProperty` methods.
+Just like the filtering methods, the `every` and `some` methods have analogous `everyBy` and `anyBy` methods.
 
 ```javascript
-people.everyProperty('isHappy', true) // false
-people.someProperty('isHappy', true)  // true
+people.everyBy('isHappy', true) // false
+people.anyBy('isHappy', true)  // true
 ```
 

--- a/source/guides/getting-started/show-when-all-todos-are-complete.md
+++ b/source/guides/getting-started/show-when-all-todos-are-complete.md
@@ -16,7 +16,7 @@ In `js/controllers/todos_controller.js` implement the matching `allAreDone` prop
 ```javascript
 // ... additional lines truncated for brevity ...
 allAreDone: function (key, value) {
-  return !!this.get('length') && this.everyProperty('isCompleted', true);
+  return !!this.get('length') && this.everyBy('isCompleted', true);
 }.property('@each.isCompleted')
 // ... additional lines truncated for brevity ...
 ```


### PR DESCRIPTION
These methods have been deprecated in favor of `everyBy` and `anyBy`.

Resolves #980
