### PR TITLE
Add that templates without name will be used as application template

### DIFF
--- a/source/guides/templates/the-application-template.md
+++ b/source/guides/templates/the-application-template.md
@@ -30,7 +30,7 @@ For more information about how outlets are filled in by the router, see
 [Routing](/guides/routing).
 
 If you are keeping your templates in HTML, create a `<script>` tag
-without a template name. It will automatically be compiled and appended
+without a template name. Ember will use the template without a name as the application template and it will automatically be compiled and appended
 to the screen.
 
 ```html


### PR DESCRIPTION
Just added explicitly that Ember will use the template without a name as the application template. That was a small source of confusion to me initially as i started with Ember.
