### PR TITLE
Remove nightly warning from Handling Metadata guide

### DIFF
--- a/data/guides.yml
+++ b/data/guides.yml
@@ -176,7 +176,6 @@ Models:
     url: "models/connecting-to-an-http-server"
   - title: "Handling Metadata"
     url: "models/handling-metadata"
-    warning: "canary-data"
   - title: "Frequently Asked Questions"
     url: "models/frequently-asked-questions"
 


### PR DESCRIPTION
It's in the current beta now, so the warning is no longer needed
