### PR TITLE
Update links.md to display Handlebars code snippet correctly on website

### DIFF
--- a/source/guides/templates/links.md
+++ b/source/guides/templates/links.md
@@ -47,6 +47,7 @@ The `{{link-to}}` helper takes:
 If there is no model to pass to the helper, you can provide an explicit identifier value instead.
 The value will be filled into the [dynamic segment](/guides/routing/defining-your-routes/#toc_dynamic-segments)
 of the route, and will make sure that the `model` hook is triggered.
+
 ```handlebars
 {{! photos.handlebars }}
 


### PR DESCRIPTION
Adds an extra line to allow website to display Handlebars code snippet correctly.
