### PR TITLE
invalid json, missing comma

### DIFF
--- a/source/guides/models/connecting-to-an-http-server.md
+++ b/source/guides/models/connecting-to-an-http-server.md
@@ -74,7 +74,7 @@ return the JSON in the following format:
 ```js
 {
   "post": {
-    "id": 1
+    "id": 1,
     "title": "Rails is omakase",
     "comments": ["1", "2"],
     "user" : "dhh"


### PR DESCRIPTION
json in the "connecting to an http server" example is invalid: missing a comma
