### PR TITLE
[Getting Started Guide] - Update deleting-todos.md

### DIFF
--- a/source/guides/getting-started/deleting-todos.md
+++ b/source/guides/getting-started/deleting-todos.md
@@ -16,7 +16,6 @@ actions: {
   removeTodo: function () {
     var todo = this.get('model');
     todo.deleteRecord();
-    todo.save();
   },
 }
 // ... additional lines truncated for brevity ...


### PR DESCRIPTION
Calling todo.save() after removing a completed item, updated both the remaining counter and the inflection with incorrect values. It also caused errors to occur when double clicking the next list item.