### PR TITLE
adds link to list of event names that a View responds to

### DIFF
--- a/source/guides/views/handling-events.md
+++ b/source/guides/views/handling-events.md
@@ -64,3 +64,5 @@ App.PlaybackRoute = Ember.Route.extend({
 });
 ````
 
+To see a full listing of the `Ember.View` built-in events, see the
+documentation section on [Event Names](/api/classes/Ember.View.html#toc_event-names).


### PR DESCRIPTION
Since the guides are probably the first impact the user has, I think it is useful to link the event list here.
