### PR TITLE
Increase logo hover scale to fix visual artifact. Fixes #1037

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -353,7 +353,7 @@ p {
     @include transition(0.2s);
 
     &:hover, &:focus {
-      @include transform(scale(1.05));
+      @include transform(scale(1.06));
       border: 0;
     }
   }


### PR DESCRIPTION
Not sure if this is a Chrome bug or what, but increasing the transform scale to `1.06` resolves #1037. Looks the same in Safari and Firefox, which don't have this rendering issue.

`1.05`
![screen shot 2013-10-28 at 6 47 37 pm](https://f.cloud.github.com/assets/602654/1425474/5fae4a14-403c-11e3-85d1-c35d58bbde82.png)
`1.06`
![screen shot 2013-10-28 at 6 46 30 pm](https://f.cloud.github.com/assets/602654/1425475/60fc4844-403c-11e3-84e8-9e0aa50502b5.png)
