### PR TITLE
Customizing URL prefix now matches api docs

### DIFF
--- a/source/guides/models/connecting-to-an-http-server.md
+++ b/source/guides/models/connecting-to-an-http-server.md
@@ -106,11 +106,11 @@ you can set a prefix that will be added to all requests.
 For example, if you are using a versioned JSON API, a request for a
 particular person might go to `/api/v1/people/1`.
 
-In that case, set `namespace` property to `/api/v1`.
+In that case, set `namespace` property to `api/v1`.
 
 ```js
 App.ApplicationAdapter = DS.RESTAdapter.extend({
-  namespace: '/api/v1'
+  namespace: 'api/v1'
 });
 ```
 


### PR DESCRIPTION
DS:RESTAdapter namespace property should not have a leading forward slash.
