### PR TITLE
Remove mention to helper {{control}} in helpers section.

### DIFF
--- a/source/guides/templates/rendering-with-helpers.md
+++ b/source/guides/templates/rendering-with-helpers.md
@@ -4,7 +4,7 @@ Ember provides several helpers that allow you to render other views and template
 
 `{{partial}}` takes the template to be rendered as an argument, and renders that template in place.
 
-`{{partial}}` does not change context or scope.  It simply drops the given template into place with the current scope.  
+`{{partial}}` does not change context or scope.  It simply drops the given template into place with the current scope.
 
 ```handlebars
 <script type="text/x-handlebars" data-template-name='_author'>
@@ -37,7 +37,7 @@ App.AuthorView = Ember.View.extend({
   // We are setting templateName manually here to the default value
   templateName: "author",
 
-  // A fullName property should probably go on App.Author, 
+  // A fullName property should probably go on App.Author,
   // but we're doing it here for the example
   fullName: (function() {
     return this.get("author").get("firstName") + " " + this.get("author").get("lastName");
@@ -89,13 +89,13 @@ For more information, see [Inserting Views in Templates](/guides/views/inserting
 * When no model is provided it gets the singleton instance of the corresponding controller
 * When a model is provided it gets a unique instance of the corresponding controller
 * Renders the named template using this controller
-* Sets the model of the corresponding controller 
+* Sets the model of the corresponding controller
 
 Modifying the post / author example slightly:
 
 ```handlebars
 <script type="text/x-handlebars" data-template-name='author'>
-  Written by {{firstName}} {{lastName}}. 
+  Written by {{firstName}} {{lastName}}.
   Total Posts: {{postCount}}
 </script>
 
@@ -108,7 +108,7 @@ Modifying the post / author example slightly:
 
 ```javascript
 App.AuthorController = Ember.ObjectController.extend({
-  postCount: function() { 
+  postCount: function() {
     return App.Post.countForAuthor(this.get("model"));
   }.property("model","App.Post.@each.author")
 })
@@ -122,7 +122,7 @@ In this example, render will:
 * Set the AuthorController's model to the 2nd argument passed to render, here the author field on the post
 * Render the template in place, with the context created in the previous steps.
 
-`{{render}}` does not require the presence of a matching route.  
+`{{render}}` does not require the presence of a matching route.
 
 `{{render}}` is similar to `{{outlet}}`. Both tell Ember to devote this portion of the page to something.
 
@@ -131,15 +131,7 @@ In this example, render will:
 
 
 
-Note: `{{render}}` cannot be called multiple times for the same route when not specifying a model.  For that you'll need `{{control}}`.
-
-### The `{{control}}` Helper
-
-`{{control}}` works like render, except it uses a new controller instance for every call, instead of reusing the singleton controller.
-
-This helper is currently under heavy development, and will likely change soon.
-
-Note: The `{{control}}` helper is currently disabled by default. To enable it set `ENV.EXPERIMENTAL_CONTROL_HELPER = true` before requiring Ember.
+Note: `{{render}}` cannot be called multiple times for the same route when not specifying a model.
 
 ### Comparison Table
 


### PR DESCRIPTION
The {{control}} handlebars helper didn't make it to 1.0. Removing from docs.

Also could someone explain why "`{{render}}` cannot be called multiple times for the same route when not specifying a model."

It would be good not to say just "don't do it" but explain why.
