### PR TITLE
Add newline before code block for the syntax highlighting to work properly.

### DIFF
--- a/source/guides/cookbook/working_with_objects/incrementing_or_decrementing_a_property.md
+++ b/source/guides/cookbook/working_with_objects/incrementing_or_decrementing_a_property.md
@@ -5,19 +5,21 @@ You want to increment or decrement a property.
 Use the `incrementProperty` or `decrementProperty` methods of `Ember.Object`.
 
 To increment:
-```js
+
+```javascript
 person.incrementProperty('age');
 ```
 
 To decrement:
-```js
+
+```javascript
 person.decrementProperty('age');
 ```
 
 ### Discussion
 You can optionally specify a value to increment or decrement by:
 
-```js
+```javascript
 person.incrementProperty('age', 10);
 ```
 


### PR DESCRIPTION
Before:
![screen shot 2013-11-22 at 13 41 13](https://f.cloud.github.com/assets/148708/1600262/8aea23c8-536b-11e3-8bc3-ab074c30f082.png)

After:
![screen shot 2013-11-22 at 13 41 21](https://f.cloud.github.com/assets/148708/1600264/906bb85c-536b-11e3-8d39-81a5c90f89e6.png)
