### PR TITLE
Fixing typo gte to get

### DIFF
--- a/source/guides/cookbook/event_handling_and_data_binding/binding_properties_of_an_object_to_its_own_properties.md
+++ b/source/guides/cookbook/event_handling_and_data_binding/binding_properties_of_an_object_to_its_own_properties.md
@@ -9,7 +9,7 @@ App.Person = Ember.Object.extend({
 	firstName : null,
 	lastName : null,
 	surname : Ember.computed.alias("lastName"),
-	eligibleForRetirement: Ember.computed.gte("age", 65)
+	eligibleForRetirement: Ember.computed.get("age", 65)
 });
 ```
 


### PR DESCRIPTION
Fixing typo.
was "gte" instead of "get"
