### PR TITLE
Add missing modal dialogs link to cookbook index

### DIFF
--- a/source/guides/cookbook/index.md
+++ b/source/guides/cookbook/index.md
@@ -18,6 +18,7 @@ Here are all of the available recipes:
 1. [Focusing a Textfield after It's Been Inserted](/guides/cookbook/user_interface_and_interaction/focusing_a_textfield_after_its_been_inserted)
 1. [Displaying Formatted Dates With Moment.js](/guides/cookbook/user_interface_and_interaction/displaying_formatted_dates_with_moment_js)
 1. [Specifying Data-Driven Areas of Templates That Do Not Need To Update](/guides/cookbook/user_interface_and_interaction/specifying_data_driven_areas_of_templates_that_do_not_need_to_update)
+1. [Using Modal Dialogs](/guides/cookbook/user_interface_and_interaction/using_modal_dialogs)
 
 ### Event Handling &amp; Data Binding
 


### PR DESCRIPTION
This change just adds a missing link to the cookbook index.
