### PR TITLE
[DOCS] Add clarifying sentence to defining routes guide

### DIFF
--- a/source/guides/routing/defining-your-routes.md
+++ b/source/guides/routing/defining-your-routes.md
@@ -195,7 +195,10 @@ then render the `posts/new` template into its outlet.
 
 NOTE: You should use `this.resource` for URLs that represent a **noun**,
 and `this.route` for URLs that represent **adjectives** or **verbs**
-modifying those nouns.
+modifying those nouns. For example, in the code sample above, when
+specifying URLs for posts (a noun), the route was defined with
+`this.resource('posts')`. However, when defining the `new` action
+(a verb), the route was defined with `this.route('new')`.
 
 ### Dynamic Segments
 


### PR DESCRIPTION
In reading this guide, I had to reread the sentence about using `this.resource` for nouns and `this.route` for adjectives or verbs several times before getting what it actually meant. This commit adds a clarifying sentence, pointing to the previous example as an illustration.
