### PR TITLE
Fix failing TOC specs, update next_chapter_link for guides/index.html

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,8 +12,8 @@ gem "rack"
 gem "listen"
 gem "builder"
 
-group :development do
-  gem "pry"
+group :development, :test do
+  gem 'pry'
 end
 
 group :test do
@@ -21,3 +21,4 @@ group :test do
   gem "capybara"
   gem "poltergeist"
 end
+

--- a/lib/toc.rb
+++ b/lib/toc.rb
@@ -166,11 +166,19 @@ module TOC
       }
       elsif whats_next = next_guide
         next_chapter = whats_next[1][0]
-        %Q{
-          <a class="next-guide" href="/guides/#{next_chapter.url}">
-             We're done with #{current_section[0]}. Next up: #{whats_next[0]} - #{next_chapter.title} \u2192
-          </a>
-        }
+        if section_slug == 'index.html'
+          %Q{
+            <a class="next-guide" href="/guides/#{next_chapter.url}">
+              #{next_chapter.title} \u2192
+            </a>
+          }
+        else
+          %Q{
+            <a class="next-guide" href="/guides/#{next_chapter.url}">
+               We're done with #{current_section[0]}. Next up: #{whats_next[0]} - #{next_chapter.title} \u2192
+            </a>
+          }
+        end
       else
         ''
       end

--- a/spec/toc_spec.rb
+++ b/spec/toc_spec.rb
@@ -2,6 +2,7 @@
 
 require 'capybara/rspec'
 require 'capybara/poltergeist'
+require 'pry'
 
 unless `which phantomjs`.empty?
   Capybara.register_driver :poltergeist do |app|
@@ -24,8 +25,8 @@ describe "TOC", :type => :feature do
   end
 
   it "Within-guide page link" do
-    visit "/guides/models/finding-models"
-    find('a.next-guide').text.should =~ /Modifying Attributes/
+    visit "/guides/models/finding-records"
+    find('a.next-guide').text.should =~ /Working with Records/
   end
 
   it "Another within-guide page link " do
@@ -36,8 +37,9 @@ describe "TOC", :type => :feature do
   it "Shows next section link" do
     visit "/guides/views/manually-managing-view-hierarchy"
     find('a.next-guide').text.should =~ /We're done with Views/
-    find('a.next-guide').text.should =~ /The Object Model/
-    find('a.next-guide').text.should =~ /Classes and Instances/
+    find('a.next-guide').text.should =~ /Next up: /
+    find('a.next-guide').text.should =~ /Enumerables/
+    find('a.next-guide').text.should =~ /Introduction/
   end
 
   it "Shows previous section link" do
@@ -46,27 +48,17 @@ describe "TOC", :type => :feature do
   end
 
   it "Chills on the first page" do
-    # Note: "/guides/concepts/core-concepts" isn't the first page
     visit "/guides/index.html"
     page.should_not have_css('a.previous-guide')
   end
 
   it "First page should have a link to the first guide" do
     visit "/guides/index.html"
-    find('a.next-guide').text.should =~ /Core Concepts/
+    find('a.next-guide').text.should =~ /Getting Started/
   end
 
   it "Chills on the last page" do
-    visit "/guides/understanding-ember/keeping-templates-up-to-date"
+    visit "/guides/contributing/adding-new-features"
     page.should_not have_css('a.next-guide')
   end
-
-  it "should have an ember-data warning on model pages but not on other pages" do
-    visit "/guides/models"
-    find('.under_construction_warning').text.should =~
-        /WARNING: EMBER-DATA IS A WORK IN PROGRESS AND UNDER RAPID DEVELOPMENT. USE WITH CAUTION!!!/
-    visit "/guides/views"
-    page.should_not have_css('.under_construction_warning')
-  end
-
 end


### PR DESCRIPTION
I was trying to make a separate pull request for some stuff I was testing out using the toc.rb file and I noticed the specs were failing. A few were failing because content has since been rearranged, so I simply updated the specs to reflect that. There was also a spec about showing "WARNING: EMBER-DATA IS A WORK IN PROGRESS AND UNDER RAPID DEVELOPMENT. USE WITH CAUTION!!!", but that has since been removed from the models guide, so I simply removed that spec.

The only gotcha I noticed was that when you visit /guides (which is /guides/index.html), you see as the 'next' link as: 
![We're done with Ember.js Guides. Next up: Getting Started - Getting Started →](https://f.cloud.github.com/assets/2406167/1651270/0b7b1e94-5acd-11e3-9b4f-476ff41e5a0e.png)

Based on what I could infer from the tests (the fact that it does not share the "Shows next section link" example that checks for "We're done with"), I figured that it would probably be better to update the code to just show 'Getting Started'. This updated branch:

![screen shot 2013-12-01 at 3 13 02 pm](https://f.cloud.github.com/assets/2406167/1651280/6069c658-5acd-11e3-9836-7aa89eb8663b.png)

Just check next_chapter_link and if the section_slug is index.html (a pattern repeated elsewhere in toc.rb), only show the title. 

Now all specs pass! (I also added pry to the test group and included in toc_spec.rb because I ended up using it and figured it would be helpful for others down the line)
