### PR TITLE
Adjust explanation to example.

### DIFF
--- a/source/guides/models/handling-metadata.md
+++ b/source/guides/models/handling-metadata.md
@@ -9,7 +9,7 @@ this.get("store").findQuery("post", {
 });
 ```
 
-To get different *pages* of data, you'd simply change your offset in increments of 100. So far, so good. But how do you know how many pages of data you have? Your server would need to return the total number of records as a piece of metadata.
+To get different *pages* of data, you'd simply change your offset in increments of 10. So far, so good. But how do you know how many pages of data you have? Your server would need to return the total number of records as a piece of metadata.
 
 By default, Ember Data's JSON deserializer looks for a `meta` key:
 
@@ -46,7 +46,7 @@ You can also customize metadata extraction by overriding the `extractMeta` metho
   "post": [
     // ...
   ],
-  "total": 10
+  "total": 100
 }
 ```
 


### PR DESCRIPTION
The first code example limits the result to 10 records per page. To get different pages, the offset should change in increments of 10 as well, not in increments of 100.

The two different JSON response examples are now more consistent by both having a total of 100.
