### PR TITLE
Update fixture adapter docs to work with ember-data.beta.3

### DIFF
--- a/source/guides/models/the-fixture-adapter.md
+++ b/source/guides/models/the-fixture-adapter.md
@@ -15,11 +15,11 @@ Using the fixture adapter entails three very simple setup steps:
 
 Simply attach it to your instance of `Ember.Store`:
 
-```
+```JavaScript
 var App = Ember.Application.create();
 App.Store = DS.Store.extend({
   revision: 13,
-  adapter: DS.FixtureAdapter.create()
+  adapter: DS.FixtureAdapter
 });
 ```
 
@@ -29,7 +29,7 @@ You should refer to [Defining a Model][1] for a more in-depth guide on using
 Ember Data Models, but for the purposes of demonstration we'll use an example
 modeling people who document Ember.js.
 
-```
+```JavaScript
 App.Documenter = DS.Model.extend({
   firstName: DS.attr( 'string' ),
   lastName: DS.attr( 'string' )
@@ -41,7 +41,7 @@ App.Documenter = DS.Model.extend({
 Attaching fixtures couldn't be simpler. Just attach a collection of plain
 JavaScript objects to your Model's class under the `FIXTURES` property:
 
-```
+```JavaScript
 App.Documenter.FIXTURES = [
   { id: 1, firstName: 'Trek', lastName: 'Glowacki' },
   { id: 2, firstName: 'Tom' , lastName: 'Dale'     }
@@ -51,8 +51,14 @@ App.Documenter.FIXTURES = [
 That's it! You can now use all of methods for [Finding Models][2] in your
 application. For example:
 
-```
-App.Documenter.find(1); // returns the record representing Trek Glowacki
+```JavaScript
+App.DocumenterRoute = Ember.Route.extend({
+  model: function() {
+    var store = this.get('store');
+    return store.find('documenter', 1); // returns a promise that will resolve
+                                        // with the record representing Trek Glowacki
+  }
+});
 ```
 
 #### Naming Conventions


### PR DESCRIPTION
I realize the fixture adapter docs are not linked to anywhere on the current website but I managed to stumble across them via a google search for "ember fixture data" when I was attempting to debug an unrelated issue. The example code in the current docs throws errors when used with the latest release of ember data `v1.0.0-beta.3`. This pr updates the examples to work with the latest version of ember data.

My replacement example for `App.Documenter.find(1)` is not as concise as the original example. If anyone has a better suggestion I'd love to hear it.
