### PR TITLE
Remove duplicate Yahoo! user logo.

### DIFF
--- a/data/users.yml
+++ b/data/users.yml
@@ -235,8 +235,6 @@
   image: rankinity.png
 - url: http://swink.tv
   image: swinktv.png
-- url: http://yahoo.com
-  image: yahoo.png
 - url: https://beta.bondable.com
   image: bondable.png
 - url: https://asknative.com


### PR DESCRIPTION
Yahoo! was listed twice on the "Who's Using Ember.js?" page. This commit removes the duplicate Yahoo! logo.
