### PR TITLE
Fix another typo in the 1.2 blog post.

### DIFF
--- a/source/blog/2013-12-04-ember-1-2-0-and-ember-1-3-0-beta-released.md
+++ b/source/blog/2013-12-04-ember-1-2-0-and-ember-1-3-0-beta-released.md
@@ -54,7 +54,7 @@ In the non-block form, the first argument is the text to wrap in an
 
 All objects that implement the `Ember.Enumerable` protocol now have a
 `sortBy` method that sorts the enumerable based on a property of each
-ot the members.
+of the members.
 
 For an example, see [this JSBin](http://emberjs.jsbin.com/OFozANOz/1/).
 


### PR DESCRIPTION
Should be "each of the members." instead of "each ot the members."
