### PR TITLE
Fix typo in blog post

### DIFF
--- a/source/blog/2013-12-07-core-team-meeting-minutes-2013-12-05.md
+++ b/source/blog/2013-12-07-core-team-meeting-minutes-2013-12-05.md
@@ -1,13 +1,13 @@
---- 
+---
 title: Core Team Meeting Minutes - 2013/12/06
 author: Trek Glowacki
 tags: Core Team Meeting Minutes
 ---
 
-Although most of our collaboration takes place on Github, IRC 
+Although most of our collaboration takes place on Github, IRC
 (`#emberjs` on freenode.net), and our [Discourse site](http://discuss.emberjs.com/)
-the [Ember.js Core Team](/team) meets privately every 
-Friday at 2pm EST/11am PST through Google Hangout for a weekly 
+the [Ember.js Core Team](/team) meets privately every
+Friday at 2pm EST/11am PST through Google Hangout for a weekly
 discussion of all things Ember.
 
 We want to ensure that our process and thinking is totally transparent
@@ -25,7 +25,7 @@ core team member and let them know!
 #### Transparency
 We've heard a few comments that people would like greater Core Team transparency.
 Since the weekly meetings are the only significant group communication that isn't
-public, we'll being posting notes from these meetings.
+public, we'll be posting notes from these meetings.
 
 Resolutions:
 
@@ -34,10 +34,10 @@ Resolutions:
     to contact individual core team members if they have issued they’d like raised.
 
 #### HTMLBars
-@wycats says it’s ready to hand off to someone else. 
+@wycats says it’s ready to hand off to someone else.
 
 Resolutions:
-  
+
   * @kselden will come a bit early to the face to face to get mind-dumped. @machty
     is already familiar with writing Handlebars runtime compatible template languages
     from his work on [Emblem.js](http://emblemjs.com/) so can also help get this


### PR DESCRIPTION
"be" instead of "being" 
cc @trek
