### PR TITLE
Add links in cookbook for continuous_redrawing_of_views content

### DIFF
--- a/data/guides.yml
+++ b/data/guides.yml
@@ -333,6 +333,9 @@ Cookbook:
   - title: "Setting Multiple Properties At Once"
     url: "cookbook/working_with_objects/setting_multiple_properties_at_once"
     skip_sidebar_item: true
+  - title: "Continuous Redrawing of Views"
+    url: "cookbook/working_with_objects/continuous_redrawing_of_views"
+    skip_sidebar_item: true
   # - title: "Continuous Redrawing of Views"
   #   url: "cookbook/working_with_objects/continuous_redrawing_of_views"
   #   skip_sidebar_item: true

--- a/source/guides/cookbook/index.md
+++ b/source/guides/cookbook/index.md
@@ -32,6 +32,7 @@ Here are all of the available recipes:
 
 1. [Incrementing Or Decrementing A Property](/guides/cookbook/working_with_objects/incrementing_or_decrementing_a_property)
 1. [Setting Multiple Properties At Once](/guides/cookbook/working_with_objects/setting_multiple_properties_at_once)
+1. [Continuous Redrawing of Views](/guides/cookbook/working_with_objects/continuous_redrawing_of_views)
 
 
 If you would like to see more recipes, take a look at the <a href="/guides/cookbook/contributing/suggesting_a_recipe">Suggesting A Recipe</a> section.

--- a/source/guides/cookbook/working_with_objects/index.md
+++ b/source/guides/cookbook/working_with_objects/index.md
@@ -2,3 +2,4 @@ Here are some recipes to help you understand working with Ember Objects.
 
 1. [Incrementing Or Decrementing A Property](/guides/cookbook/working_with_objects/incrementing_or_decrementing_a_property)
 1. [Setting Multiple Properties At Once](/guides/cookbook/working_with_objects/setting_multiple_properties_at_once)
+1. [Continuous Redrawing of Views](/guides/cookbook/working_with_objects/continuous_redrawing_of_views)


### PR DESCRIPTION
PR: https://github.com/emberjs/website/pull/728 was missing the links to the cookbook content (for continuous_redrawing_of_views) 

PR #728 was originally created from the cookbook branch and merged to master, so the links in the sidebar and on the guides/cookbook/working_with_objects page were not present in the master branch.

This change adds the links in the sidebar and on the index page: `guides/cookbook/working_with_objects` for the content
"Continuous Redrawing of Views" at: "cookbook/working_with_objects/continuous_redrawing_of_views"
