### PR TITLE
Reverse order of one-to-many relationship setup code to reflect paragrap...

### DIFF
--- a/source/guides/models/index.md
+++ b/source/guides/models/index.md
@@ -107,12 +107,12 @@ example, an `Order` may have many `LineItems`, and a `LineItem` may
 belong to a particular `Order`.
 
 ```js
-App.LineItem = DS.Model.extend({
-	orders: DS.hasMany('order')
+App.Order = DS.Model.extend({
+  lineItems: DS.hasMany('lineItem')
 });
 
-App.Order = DS.Model.extend({
-  lineItems: DS.belongsTo('lineItem')
+App.LineItem = DS.Model.extend({
+  order: DS.belongsTo('order')
 });
 ```
 


### PR DESCRIPTION
...h description.

Someone please double check this as I have never used ember-data but in trying to read the docs I was very confused by this section as the code seems to be the reverse of the preceding paragraph describing the relationship.  I tried to validate this with the API docs and I think that what I have changed here is actually correct but it needs to be confirmed by someone with actual experience using ember-data.

In the very next section about defining models there is a post -> comments example that is similar to what I have here so either this example is currently wrong or in the defining models section that code is wrong.

Sorry I can't verify this myself but I don't have an ember-data project yet.
