### PR TITLE
JSBin/fiddle links on community go directly to starter

### DIFF
--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -23,8 +23,8 @@ title: "Community"
     <a href="https://github.com/emberjs/ember.js/issues">issue tracker</a> and create a new
     issue. Great bug reports include a clear description of what is not happening and what
     you expected to happen. Issues that include a failing test or a reduced test case
-    created on <a href="http://jsfiddle.net">JSFiddle</a> or
-    <a href="http://jsbin.com">JSBin</a> are much more likely to receive attention.
+    created on <a href="http://jsfiddle.net/6Evrq/">JSFiddle</a> or
+    <a href="http://emberjs.jsbin.com/">JSBin</a> are much more likely to receive attention.
     See the <a href="https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md">full guidelines</a>
     for more information.</p>
 


### PR DESCRIPTION
I always expected this to go to a starter project for tossing together quick
bug demos; now it does.
