### PR TITLE
Cleanup unquoted action usage.

### DIFF
--- a/source/blog/2013-03-30-ember-1-0-rc2.markdown
+++ b/source/blog/2013-03-30-ember-1-0-rc2.markdown
@@ -69,7 +69,7 @@ If you have a template like this:
 
 <ul>
 {{#each controller itemController='postItem'}}
-  <li><button {{action selectPost this}}>{{name}}</button></li>
+  <li><button {{action 'selectPost' this}}>{{name}}</button></li>
 {{/each}}
 </ul>
 ```

--- a/source/guides/controllers/index.md
+++ b/source/guides/controllers/index.md
@@ -51,12 +51,12 @@ new `isExpanded` property is true.
 <hr>
 
 {{#if isExpanded}}
-  <button {{action toggleProperty 'isExpanded'}}>Hide Body</button>
+  <button {{action 'toggleProperty' 'isExpanded'}}>Hide Body</button>
   <div class='body'>
     {{body}}
   </div>
 {{else}}
-  <button {{action toggleProperty 'isExpanded'}}>Show Body</button>
+  <button {{action 'toggleProperty' 'isExpanded'}}>Show Body</button>
 {{/if}}
 ```
 

--- a/source/guides/cookbook/working_with_objects/continuous_redrawing_of_views.md
+++ b/source/guides/cookbook/working_with_objects/continuous_redrawing_of_views.md
@@ -137,7 +137,7 @@ A template for a list of comments
 
 ```handlebars
 <input type="text" id="comment" />
-<button {{action add}}>Add Comment</button>
+<button {{action 'add'}}>Add Comment</button>
 <ul>
   {{#each}}
     <li>{{comment}} ({{digital_clock clock.pulse}})</li>

--- a/source/guides/routing/sending-events-from-templates.md
+++ b/source/guides/routing/sending-events-from-templates.md
@@ -3,19 +3,19 @@ Use the `{{action}}` helper to attach a handler in your view class to an event t
 To attach an element's `click` event to the `edit()` handler in the current view:
 
 ```handlebars
-<a href="#" {{action edit on="click"}}>Edit</a>
+<a href="#" {{action 'edit' on="click"}}>Edit</a>
 ```
 
 Because the default event is `click`, this could be written more concisely as:
 
 ```handlebars
-<a href="#" {{action edit}}>Edit</a>
+<a href="#" {{action 'edit'}}>Edit</a>
 ```
 
 Although the view containing the `{{action}}` helper will be targeted by default, it is possible to target a different view:
 
 ```handlebars
-<a href="#" {{action edit target="parentView"}}>Edit</a>
+<a href="#" {{action 'edit' target="parentView"}}>Edit</a>
 ```
 
 The action handler can optionally accept a jQuery event object, which will be extended to include `view` and `context` properties. These properties can be useful when targeting a different view with your action. For instance:

--- a/source/guides/templates/actions.md
+++ b/source/guides/templates/actions.md
@@ -162,7 +162,7 @@ to specify which keys should not be ignored.
 
 ```handlebars
 <script type="text/x-handlebars" data-template-name='a-template'>
-  <div {{action anActionName allowedKeys="alt"}}>
+  <div {{action 'anActionName' allowedKeys="alt"}}>
     click me
   </div>
 </script>
@@ -184,7 +184,7 @@ clicked.
 ```handlebars
 {{#link-to 'post'}}
   Post
-  <button {{action close bubbles=false}}>✗</button>
+  <button {{action 'close' bubbles=false}}>✗</button>
 {{/link-to}}
 ```
 

--- a/source/guides/understanding-ember/the-view-layer.md
+++ b/source/guides/understanding-ember/the-view-layer.md
@@ -218,7 +218,7 @@ please use the form below to submit a complaint to the FDA.
 
   {{#if controller.allowComplaints}}
     {{view Ember.TextArea valueBinding="controller.complaint"}}
-    <button {{action submitComplaint}}>Submit</button>
+    <button {{action 'submitComplaint'}}>Submit</button>
   {{/if}}
 {{/view}}
 ```

--- a/source/guides/wip/outlets.md
+++ b/source/guides/wip/outlets.md
@@ -55,7 +55,7 @@ The template will look like this:
 
 ```handlebars
 {{#each post in controller}}
-<h1><a {{action showPost post href=true}}>{{post.title}}</a></h1>
+<h1><a {{action 'showPost' post href=true}}>{{post.title}}</a></h1>
 <div>{{post.intro}}</div>
 {{/each}}
 ```
@@ -219,7 +219,7 @@ current template.
 
 ```handlebars
 {{#each post in controller}}
-  <h1><a {{action showPost post href=true}}>{{post.title}}</a></h1>
+  <h1><a {{action 'showPost' post href=true}}>{{post.title}}</a></h1>
 {{/each}}
 ```
 
@@ -332,8 +332,8 @@ Here's the template for an individual post.
 </div>
 
 <p>
-  <a {{action showComments href=true}}>Comments</a> |
-  <a {{action showTrackbacks href=true}}>Trackbacks</a>
+  <a {{action 'showComments' href=true}}>Comments</a> |
+  <a {{action 'showTrackbacks' href=true}}>Trackbacks</a>
 </p>
 
 {{outlet}}

--- a/source/guides/wip/rails.md
+++ b/source/guides/wip/rails.md
@@ -355,8 +355,8 @@ Let's create the `_form` template in `app/assets/javascripts/templates/photos/_f
 <label for="title-field">Title:</label>{{view Ember.TextField id="title-field" valueBinding="controller.model.title"}}
 <label for="url-field">URL:</label>{{view Ember.TextField id="url-field" valueBinding="controller.model.url"}}
 
-<button {{action save target="Photoblog.stateManager"}}>Save</button>
-<button {{action cancel target="Photoblog.stateManager"}}>Cancel</button>
+<button {{action 'save' target="Photoblog.stateManager"}}>Save</button>
+<button {{action 'cancel' target="Photoblog.stateManager"}}>Cancel</button>
 ```
 
 We create two Ember.TextField views, and we bind the value property (which will be the text in the text field) to that of our controllers' model's title and url objects, respectively. The controller is is the PhotoController, which we created above. Its model will be a photo object.
@@ -457,7 +457,7 @@ Now we define the `save` and `cancel` actions we referenced in our create view t
 Finally, we will add a button to the index template, at the very bottom, which tells our state manager to show the create view.
 
 ```handlebars
-<button {{action showCreate target="Photoblog.stateManager"}}>Add Photo</button>
+<button {{action 'showCreate' target="Photoblog.stateManager"}}>Add Photo</button>
 ```
 
 With all of this in place, ensure your server is running, and reload the index page. You should see a button at the bottom which takes you to our new create view and lets you add photos!
@@ -531,7 +531,7 @@ Ensure that you add a comma to the previous `showCreate`. In this action, we're 
 Lastly, lets add an edit button to each photo on the page. Below the `<img>` tag, add the following button, which targets our state manager's new `showEdit` action.
 
 ```handlebars
-<a href="#" {{action showEdit target="Photoblog.stateManager"}}>Edit Photo</a>
+<a href="#" {{action 'showEdit' target="Photoblog.stateManager"}}>Edit Photo</a>
 ```
 
 Reload the page. There should now be an "Edit Photo" link below each photo that will take you to our new Edit Photo view.


### PR DESCRIPTION
The `{{action}}` helper will soon have the ability to do bound property
lookups when used with unqouted strings. This PR cleans up any unquoted
usage in the examples and guides.
