### PR TITLE
Fixes incorrect and missing titles in blog pages

### DIFF
--- a/source/blog/tag.html.erb
+++ b/source/blog/tag.html.erb
@@ -2,6 +2,8 @@
 pageable: true
 per_page: 12
 ---
+<% @title = tagname %>
+
 <% partial_for :sidebar, 'sidebar' %>
 
 <h1><%= tagname %></h1>

--- a/source/layout.erb
+++ b/source/layout.erb
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Ember.js - <%= data.page.title || @title %></title>
+    <title>Ember.js - <%= current_page.data.title || @title %></title>
     <link rel="shortcut icon" href="/images/favicon.png" />
     <!--[if lte IE 7 ]><%= stylesheet_link_tag "fonts/fontello-ie7" %><![endif]-->
     <%= stylesheet_link_tag "site" %>


### PR DESCRIPTION
The title on the blog home page was the title of the oldest post. The title on the pages listing all posts under a tag was missing. This commit fixes those issues.
