### PR TITLE
Makes builds page look consistent across retina/normal screens

### DIFF
--- a/source/builds/index.html.erb
+++ b/source/builds/index.html.erb
@@ -81,11 +81,13 @@ title: Builds
         The {{finalVersion}} beta cycle began on {{cycleStartDate}} with a final release planned for {{cycleEstimatedFinishDate}}.
       </p>
       <div class="beta-image" title="Beta"></div>
-      <div {{bind-attr class=":progress-circle beta1Completed:completed"}}></div>
-      <div {{bind-attr class=":progress-circle beta2Completed:completed"}}></div>
-      <div {{bind-attr class=":progress-circle beta3Completed:completed"}}></div>
-      <div {{bind-attr class=":progress-circle beta4Completed:completed"}}></div>
-      <div {{bind-attr class=":progress-circle beta5Completed:completed"}}></div>
+      <div class="float-left-container">
+        <div {{bind-attr class=":progress-circle beta1Completed:completed"}}></div>
+        <div {{bind-attr class=":progress-circle beta2Completed:completed"}}></div>
+        <div {{bind-attr class=":progress-circle beta3Completed:completed"}}></div>
+        <div {{bind-attr class=":progress-circle beta4Completed:completed"}}></div>
+        <div {{bind-attr class=":progress-circle beta5Completed:completed"}}></div>
+      </div>
       <div class="release-image" title="Release"></div>
       <div class="clear"></div>
     </div>

--- a/source/stylesheets/builds.css.scss
+++ b/source/stylesheets/builds.css.scss
@@ -12,6 +12,10 @@
     }
   }
 
+  .float-left-container {
+    float: left;
+  }
+
   @media (-webkit-min-device-pixel-ratio: $hidpi-min-pixel-ratio), (min-resolution: $hidpi-min-pixel-ratio), (min-resolution: $hidpi-min-pixel-ratio) {
     .feature .release {
       background-size: 198px 263px !important;
@@ -22,36 +26,28 @@
     .feature .canary {
       background-size: 198px 263px !important;
     }
-
-    .beta-image {
-      background-size: 112px 150px !important;
-    }
-    .release-image {
-      background-size: 112px 150px !important;
-    }
   }
+
   .beta-image {
     @include hidpi('builds/beta', 'png');
-    width: 112px;
-    height: 150px;
+    width: 198px;
+    height: 263px;
     margin: 0 auto;
     float: left;
   }
 
   .release-image {
     @include hidpi('builds/release', 'png');
-    width: 112px;
-    height: 150px;
+    width: 198px;
+    height: 263px;
     margin: 0 auto;
     float: right;
-  }
-
-  .release-progress {
   }
 
   .clear {
     clear: both;
   }
+
   .feature .release {
     @include hidpi('builds/release', 'png');
     width: 198px;
@@ -117,13 +113,14 @@
   }
 
   .progress-circle {
-    width: 20px;
-    height: 20px;
+    width: 15px;
+    height: 15px;
     @include border-radius(10px);
     background: transparent;
     border:1px solid #C4C4C4;
-    margin-top: 75px;
-    margin-right: 70px;
+    margin-top: 50%;
+    margin-right: 20px;
+    margin-left: 20px;
     float: left;
   }
 


### PR DESCRIPTION
Before:

![ember js - builds 2013-12-22 21-42-19](https://f.cloud.github.com/assets/1131196/1798936/d89b8fb2-6b7b-11e3-8ccb-e7bc42ac0a58.jpg)

![ember js - builds 2013-12-22 21-42-40](https://f.cloud.github.com/assets/1131196/1798939/e4d29384-6b7b-11e3-8c2f-ff750d85bec6.jpg)

After:

![ember js - builds 2013-12-22 21-43-02](https://f.cloud.github.com/assets/1131196/1798940/f1fb33e0-6b7b-11e3-9551-731d8caee24e.jpg)
