### PR TITLE
Fix error thrown during `middleman build`.

### DIFF
--- a/lib/toc.rb
+++ b/lib/toc.rb
@@ -121,6 +121,8 @@ module TOC
     end
 
     def current_guide
+      return unless current_section
+
       if guide_slug == '' && section_slug == 'index.html'
         current_section[1][0]
       else


### PR DESCRIPTION
This fixes an error from being thrown when a guide section can't be found.
