### PR TITLE
doc: updating fixture adapter guide page copy and link

### DIFF
--- a/source/guides/models/the-fixture-adapter.md
+++ b/source/guides/models/the-fixture-adapter.md
@@ -48,7 +48,7 @@ App.Documenter.FIXTURES = [
 ];
 ```
 
-That's it! You can now use all of methods for [Finding Models][2] in your
+That's it! You can now use all of methods for [Finding Records][2] in your
 application. For example:
 
 ```JavaScript
@@ -73,5 +73,5 @@ is called `id`. Should you not provide an `id` field in your fixtures, or
 not override the primary key, the Fixture Adapter will throw an error.
 
 [1]: /guides/models/defining-models
-[2]: /guides/models/finding-models
+[2]: /guides/models/finding-records
 [3]: /guides/models/the-rest-adapter


### PR DESCRIPTION
Currently the 'Finding Models' link is pointed to a deprecated page and returning a 404.

Updated the guide for fixture adapter to reflect and navigate to the 'Finding Records' page. 
