### PR TITLE
[Guides] #1180 - Add Getting Ember Section

### DIFF
--- a/data/guides.yml
+++ b/data/guides.yml
@@ -51,6 +51,10 @@
   - title: "Replacing the Fixture Adapter with Another Adapter"
     url: "getting-started/using-other-adapters"
 
+"Getting Ember":
+  - title: "Getting Ember"
+    url: "getting-ember"
+
 Concepts:
   - title: "Core Concepts"
     url: "concepts/core-concepts"

--- a/source/about.html.erb
+++ b/source/about.html.erb
@@ -20,7 +20,8 @@ title: "About"
       <a class="debug" href="http://builds.emberjs.com/tags/v1.2.0/ember.prod.js">production</a>
       <a class="debug" href="http://builds.emberjs.com/tags/v1.2.0/ember.min.js">(min + gzip  67kb)</a> |
       <a class="debug" href="http://builds.emberjs.com/tags/v1.2.0/ember.js">debug</a> |
-      <a href="http://builds.handlebarsjs.com.s3.amazonaws.com/handlebars-v1.1.2.js">Handlebars</a>
+      <a href="http://builds.handlebarsjs.com.s3.amazonaws.com/handlebars-v1.1.2.js">Handlebars</a> |
+      <a class="debug" href="/guides/getting-ember">packages</a>
     </div>
   </div>
 

--- a/source/guides/getting-ember/index.md
+++ b/source/guides/getting-ember/index.md
@@ -1,0 +1,34 @@
+##Ember Builds
+
+The Ember Release Management Team maintains a variety of ways to get  Ember and Ember Data builds.
+
+###Channels
+The latest [Release](/builds#/release), [Beta](/builds#/beta), and [Canary](/builds#/canary) builds of Ember and Ember data can be found [here](/builds). For each channel a development, minified, and production version is available. For more on the differnt channels read the [Post 1.0 Release Cycle](http://emberjs.com/blog/2013/09/06/new-ember-release-process.html) blog post.
+
+###Tagged Releases
+Past release and beta builds  of Ember and Ember Data are availabe at [Tagged Releases](/builds#/tagged). These builds can be useful to track down regressions in your application, but it is recomended to use the latest stable relesae in production.
+
+
+
+##Bower
+
+Bower is a package manager for the web. Bower makes it easy to manage dependencies in your application including Ember and Ember Data. To learn more about Bower vist [http://bower.io/](http://bower.io/).
+
+Adding Ember to your application with Bower is easy simply run `bower install ember --save`. For Ember Data run `bower install ember-data --save`. You can also add `ember` or `ember-data` to your `bower.json` file as follows.
+
+```json
+{
+	"dependencies": {
+		"ember": "~1.2",
+		"ember-data" "~1.0.0-beta.4"
+	}
+}
+
+```
+
+##RubyGems
+
+If you application uses a Ruby based build system you can use the [ember-source](http://rubygems.org/gems/ember-source) and [ember-data-source](http://rubygems.org/gems/ember-data-source) RubyGems to access ember and ember data sources from Ruby.
+
+If your application is built in rails the [ember-rails](http://rubygems.org/gems/ember-rails) RubyGem makes it easy to integrate Ember into your Ruby on Rails application.
+

--- a/source/guides/getting-started/obtaining-emberjs-and-dependencies.md
+++ b/source/guides/getting-started/obtaining-emberjs-and-dependencies.md
@@ -19,6 +19,8 @@ For this example, all of these resources should be stored in the folder `js/libs
 
 Reload your web browser to ensure that all files have been referenced correctly and no errors occur.
 
+If you are using a package manager, such as [bower](http://bower.io), make sure to checkout the [Getting Ember](/guides/getting-ember) guide for info on other ways to get Ember.js.
+
 ### Live Preview
 <a class="jsbin-embed" href="http://jsbin.com/ijefig/2/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
  


### PR DESCRIPTION
This adds a section to the guides about getting Ember and Ember data. It mentions the builds section of the site as well as the bower and rubygem packages.

Links to the guide page are also in the Getting Started Guide as well as on the landing page.

I'm sure lots of additions / corrections are needed.
