### PR TITLE
Update Getting Started guide page "Adding a Route and Template"

### DIFF
--- a/source/guides/getting-started/adding-a-route-and-template.md
+++ b/source/guides/getting-started/adding-a-route-and-template.md
@@ -37,11 +37,6 @@ Next, update your `index.html` to wrap the inner contents of `<body>` in a Handl
   
   </script>
 
-  <script src="js/libs/jquery.min.js"></script>
-  <script src="js/libs/handlebars.js"></script>
-  <script src="js/libs/ember.js"></script>
-  <script src="js/libs/ember-data.js"></script>
-  
   <script src="js/application.js"></script>
   <script src="js/router.js"></script>
 <!-- ... additional lines truncated for brevity ... -->


### PR DESCRIPTION
Update Getting Started guide page _"Adding a Route and Template"_ to remove outdated references to JS libs.

As the libraries are added in the previous page ("Obtaining Ember.js and Dependencies)[1](http://emberjs.com/guides/getting-started/obtaining-emberjs-and-dependencies), the references here are unnecessary and also out-of-date (the files downloaded have specific version numbers, i.e. `jquery-1.10.2.min.js`).
