### PR TITLE
Run docs task with bundle exec

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -54,7 +54,7 @@ def generate_docs
       sha = describe =~ /-g(.+)/ ? $1 : describe
 
       Bundler.with_clean_env do
-        sh("rake docs")
+        sh("bundle exec rake docs")
       end
     end
 


### PR DESCRIPTION
Getting another issue with bundler, if you have the wrong versions of rake installed then preview will fail:

```
╭─alex@aspeller ~/opensource/ember-website ‹2.0.0-p353› ‹improve-bindings-guide*›
╰─➤  bundle exec rake preview                                                                                                                                                                        1 ↵
Generating Ember.js docs data from /Users/alex/opensource/ember.js... rake docs
Built Ember.js with SHA 4b3a39b
Generating Ember Data docs data from /Users/alex/opensource/ember-data... rake docs
rake aborted!
You have already activated rake 10.1.1, but your Gemfile requires rake 10.1.0. Prepending `bundle exec` to your command may solve this.
/Users/alex/opensource/ember-data/Rakefile:1:in `<top (required)>'
(See full trace by running task with --trace)
rake aborted!
Command failed with status (1): [rake docs...]
/Users/alex/opensource/ember-website/Rakefile:57:in `block (3 levels) in generate_docs'
/Users/alex/opensource/ember-website/Rakefile:56:in `block (2 levels) in generate_docs'
/Users/alex/opensource/ember-website/Rakefile:51:in `chdir'
/Users/alex/opensource/ember-website/Rakefile:51:in `block in generate_docs'
/Users/alex/opensource/ember-website/Rakefile:44:in `each'
/Users/alex/opensource/ember-website/Rakefile:44:in `generate_docs'
/Users/alex/opensource/ember-website/Rakefile:90:in `block in <top (required)>'
Tasks: TOP => preview
(See full trace by running task with --trace)
```
