### PR TITLE
Improve bindings guide to use relative bindings

### DIFF
--- a/source/guides/object-model/bindings.md
+++ b/source/guides/object-model/bindings.md
@@ -4,23 +4,24 @@ properties on the same object, or across two different objects. Unlike most othe
 frameworks that include some sort of binding implementation, bindings in
 Ember.js can be used with any object, not just between views and models.
 
-The easiest way to create a two-way binding is by creating a new property
-with the string `Binding` at the end, then specifying a path from the global scope:
+The easiest way to create a two-way binding is to use a computed alias, that
+specifies the path to another object.
 
 ```javascript
-App.wife = Ember.Object.create({
+wife = Ember.Object.create({
   householdIncome: 80000
 });
 
-App.husband = Ember.Object.create({
-  householdIncomeBinding: 'App.wife.householdIncome'
+husband = Ember.Object.create({
+  wife: wife,
+  householdIncome: Ember.computed.alias('wife.householdIncome')
 });
 
-App.husband.get('householdIncome'); // 80000
+husband.get('householdIncome'); // 80000
 
 // Someone gets raise.
-App.husband.set('householdIncome', 90000);
-App.wife.get('householdIncome'); // 90000
+husband.set('householdIncome', 90000);
+wife.get('householdIncome'); // 90000
 ```
 
 Note that bindings don't update immediately. Ember waits until all of your
@@ -30,27 +31,30 @@ overhead of syncing bindings when values are transient.
 
 ## One-Way Bindings
 
-A one-way binding only propagates changes in one direction. Usually, one-way
-bindings are just a performance optimization and you can safely use
-the more concise two-way binding syntax (as, of course, two-way bindings are
-de facto one-way bindings if you only ever change one side).
+A one-way binding only propagates changes in one direction. Often, one-way
+bindings are just a performance optimization and you can safely use a two-way binding
+(as, of course, two-way bindings are de facto one-way bindings if you only ever change
+one side). Sometimes one-way bindings are useful to achieve specific behaviour such
+as a default that is the same as another property but can be overriden (e.g. a
+shipping address that starts the same as a billing address but can later be changed)
 
 ```javascript
-App.user = Ember.Object.create({
+user = Ember.Object.create({
   fullName: "Kara Gates"
 });
 
-App.userView = Ember.View.create({
-  userNameBinding: Ember.Binding.oneWay('App.user.fullName')
+userView = Ember.View.create({
+  user: user,
+  userNameBinding: Ember.computed.oneWay('user.fullName')
 });
 
 // Changing the name of the user object changes
 // the value on the view.
-App.user.set('fullName', "Krang Gates");
-// App.userView.userName will become "Krang Gates"
+user.set('fullName', "Krang Gates");
+// userView.userName will become "Krang Gates"
 
 // ...but changes to the view don't make it back to
 // the object.
-App.userView.set('userName', "Truckasaurus Gates");
-App.user.get('fullName'); // "Krang Gates"
+userView.set('userName', "Truckasaurus Gates");
+user.get('fullName'); // "Krang Gates"
 ```


### PR DESCRIPTION
The use of global key paths is much less relevant today than it used to be, and this demonstration is therefore a bit outdated.

I think there may be space to talk about key paths being global when they start with a capital, but IMO this is not the place and just muddies the water.

This was triggered by [this SO question](https://stackoverflow.com/questions/20978904/why-does-a-simple-ember-js-binding-not-work/20978989).
