### PR TITLE
Give SEO love for `ember tutorials` keyword

### DIFF
--- a/data/guides.yml
+++ b/data/guides.yml
@@ -1,4 +1,4 @@
-"Ember.js Guides":
+"Guides and Tutorials":
   - title: "Ember.js Guides"
     url: "index.html"
     skip_sidebar: true


### PR DESCRIPTION
This changes the `<title>` of the guides index from "Ember.js - Ember.js
Guides: Ember.js Guides" to "Ember.js - Guides and Tutorials: Ember.js
Guides".

I couldn't get it any nicer because of the way the `<title>` is
constructed. This should be good enough to appease Google though.
