### PR TITLE
Fix API documentation font-family

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -1582,7 +1582,7 @@ a.edit-page {
 
   .description {
     p {
-      font-family: 'Helvetica Neue';
+      font-family: 'Helvetica Neue', Helvetica, Arial, Sans-Serif;
       font-weight: 200;
       margin: 1.5em 0;
     }


### PR DESCRIPTION
Before:

![screenshot from 2014-01-17 14 42 00](https://f.cloud.github.com/assets/153842/1940679/46143f48-7f7d-11e3-9824-c6596ac64215.png)

After:

![screenshot from 2014-01-17 14 42 22](https://f.cloud.github.com/assets/153842/1940680/49d7fff2-7f7d-11e3-976a-73069d881a39.png)
