### PR TITLE
The meaning of `this` changes one promise fulfil

### DIFF
--- a/source/guides/models/persisting-records.md
+++ b/source/guides/models/persisting-records.md
@@ -33,8 +33,10 @@ var post = store.createRecord('post', {
   body: 'Lorem ipsum'
 });
 
+var _self = this; // When the promise returns 'this' may no longer reference the controller, so keep a pointer to the context when invoking the promise.
+
 post.save().then(function(post) {
-  this.transitionToRoute('posts/show', post);
+  _self.transitionToRoute('posts/show', post);
 });
 
 // => POST to '/posts'
@@ -49,8 +51,10 @@ var post = store.createRecord('post', {
   body: 'Lorem ipsum'
 });
 
+var _self = this;
+
 var onSuccess = function(post) {
-  this.transitionToRoute('posts/show', post);
+  _self.transitionToRoute('posts/show', post);
 };
 
 var onFail = function(post) {


### PR DESCRIPTION
Having spent some time trying to figure out why the `transitionToRoute` function was coming back as undefined, it was apparent that `this` no longer referred to the controller when the promise returned, but to the window.  I may be misunderstanding some aspect of promise fulfilment, but this was the only way I could get the example to work.
