### PR TITLE
Update adding-child-routes.md

### DIFF
--- a/source/guides/getting-started/adding-child-routes.md
+++ b/source/guides/getting-started/adding-child-routes.md
@@ -36,12 +36,12 @@ Still within `index.html` place a Handlebars `{{outlet}}` helper where the `<ul>
 
 The `{{outlet}}` Handlebars helper designates an area of a template that will dynamically update as we transition between routes. Our first new child route will fill this area with the list of all todos in the application.
 
-In `js/router.js` update the router to change the `todos` mapping so it can accept child routes and add this first `index` route:
+In `js/router.js` update the router to change the `todos` mapping, with an additional empty function parameter so it can accept child routes, and add this first `index` route:
 
 ```javascript
 Todos.Router.map(function () {
   this.resource('todos', { path: '/' }, function () {
-    // additional child routes
+    // additional child routes will go here later
   });
 });
 


### PR DESCRIPTION
It wasn't clear that a new empty function() needs to be added to resource() in order for child routes to work at all. This commit briefly explains that this empty function is necessary.
