### PR TITLE
change to standard jquery ajax call

### DIFF
--- a/source/guides/understanding-ember/debugging.md
+++ b/source/guides/understanding-ember/debugging.md
@@ -144,10 +144,12 @@ Ember.LOG_STACKTRACE_ON_DEPRECATION = true
 
 ```javascript
 Ember.onerror = function(error) {
-  Em.$.ajax('/error-notification', 'POST', {
-    stack: error.stack,
-    otherInformation: 'exception message'
-  });
+    Em.$.ajax('/error-notification',
+              {type: 'POST', 
+               data: {
+                   stack: error.stack,
+                   otherInformation: 'exception message'
+               }});
 }
 ```
 


### PR DESCRIPTION
jQuery.ajax expects (url, settings) as parameters.  The ajax call to /error-notification used (url, type, settings), which generates a 'GET' in latest version of Chrome, even if 'PUT' is given as the second parameter.
