### PR TITLE
Remove use of term "theoretically"

### DIFF
--- a/source/guides/concepts/naming-conventions.md
+++ b/source/guides/concepts/naming-conventions.md
@@ -5,9 +5,9 @@ for your routes, controllers and templates.
 You can usually guess the names, but this guide outlines, in one place, 
 all of the naming conventions. In the following examples 'App' is a name 
 that we chose to namespace or represent our Ember application when it was 
-created, but you can theoretically choose any name you want for your 
-application. We will show you later how to create an Ember application, 
-but for now we will focus on conventions.
+created, but you can choose any name you want for your application.
+We will show you later how to create an Ember application, but for now we
+will focus on conventions.
 
 ## The Application
 


### PR DESCRIPTION
Usage of the term _theoretically_ here, prior to this PR, suggests that the behavior resulting from use of a name other than `App` is not confidently known function correctly. If it is not known to work correctly, then this PR should be rejected and the documentation should describe the supported usage.
