### PR TITLE
Typo in toc_spec.rb :selemium -> :selenium

### DIFF
--- a/spec/toc_spec.rb
+++ b/spec/toc_spec.rb
@@ -19,7 +19,7 @@ describe "TOC", :type => :feature do
     unless `which phantomjs`.empty?
       Capybara.current_driver = :poltergeist
     else
-      Capybara.current_driver = :selemium
+      Capybara.current_driver = :selenium
     end
     Capybara.run_server = false
   end


### PR DESCRIPTION
There was a typo in spec file in terms of selenium driver.
