### PR TITLE
Update show-when-all-todos-are-complete.md

### DIFF
--- a/source/guides/getting-started/show-when-all-todos-are-complete.md
+++ b/source/guides/getting-started/show-when-all-todos-are-complete.md
@@ -16,8 +16,8 @@ In `js/controllers/todos_controller.js` implement the matching `allAreDone` prop
 ```javascript
 // ... additional lines truncated for brevity ...
 allAreDone: function(key, value) {
-  return !!this.get('length') && this.everyProperty('isCompleted', true);
-}.property('@each.isCompleted')
+  return this.get('length') > 0 && this.get('completed') === this.get('length');
+}.property('completed')
 // ... additional lines truncated for brevity ...
 ```
 

--- a/source/guides/getting-started/toggle-all-todos.md
+++ b/source/guides/getting-started/toggle-all-todos.md
@@ -6,13 +6,13 @@ To implement this behavior update the `allAreDone` property in `js/controllers/t
 // ... additional lines truncated for brevity ...
 allAreDone: function(key, value) {
   if (value === undefined) {
-    return !!this.get('length') && this.everyProperty('isCompleted', true);
+    return this.get('length') > 0 && this.get('completed') === this.get('length');
   } else {
     this.setEach('isCompleted', value);
     this.invoke('save');
     return value;
   }
-}.property('@each.isCompleted')
+}.property('@completed')
 // ... additional lines truncated for brevity ...
 ```
 


### PR DESCRIPTION
Updated to remove deprecated everyProperty method and obscure double not operator. 
Also changed property dependency to depend upon the completed property, which matches what the hasCompleted property looks like from the previous step in the guide.