### PR TITLE
Update rendering-a-template.md

### DIFF
--- a/source/guides/routing/rendering-a-template.md
+++ b/source/guides/routing/rendering-a-template.md
@@ -78,8 +78,8 @@ If you want to render two different templates into outlets of two different rend
 App.PostRoute = App.Route.extend({
   renderTemplate: function() {
     this.render('favoritePost', {   // the template to render
-      into: 'posts',                // the route to render into
-      outlet: 'posts',              // the name of the outlet in the route's template
+      into: 'posts',                // the template to render into
+      outlet: 'posts',              // the name of the outlet in that template
       controller: 'blogPost'        // the controller to use for the template
     });
     this.render('comments', {


### PR DESCRIPTION
There is some divergences in the render option `into`, compared to the [api docs](http://emberjs.com/api/classes/Ember.Route.html#method_render).

I believe that the correct is "the template to render into", because `options.into` is passed to `_lookupActiveView` [here](https://github.com/emberjs/ember.js/blob/c0ce02cc66f2716b1f00d2306eccb695b1c62b16/packages/ember-routing/lib/system/route.js#L1517), and [it](https://github.com/emberjs/ember.js/blob/c470b4ded06f1fef6db9c2ca2d9d1f17203b93be/packages/ember-routing/lib/system/router.js#L198) accepts a `templateName` argument.

Close emberjs/ember.js#4367
