### PR TITLE
Clarify URL update behaviour when using `transition.abort()`

### DIFF
--- a/source/guides/routing/preventing-and-retrying-transitions.md
+++ b/source/guides/routing/preventing-and-retrying-transitions.md
@@ -36,6 +36,14 @@ App.FormRoute = Ember.Route.extend({
 });
 ```
 
+When the user clicks on a `{{link-to}}` helper, or when the app initiates a 
+transition by using `transitionTo`, the transition will be aborted and the URL
+will remain unchanged. However, if the browser back button is used to 
+navigate away from `FormRoute`, or if the user manually changes the URL, the 
+new URL will be navigated to before the `willTransition` action is 
+called. This will result in the browser displaying the new URL, even if 
+`willTransition` calls `transition.abort()`.
+
 ### Aborting Transitions Within `model`, `beforeModel`, `afterModel`
 
 The `model`, `beforeModel`, and `afterModel` hooks described in


### PR DESCRIPTION
Using the browser back button in conjunction with `transition.abort()` can lead to the browser URL being out of sync with what's displayed in the app. This commit adds a note explaining that `abort()` can occur after the URL is changed.
