### PR TITLE
Update disabling-prototype-extensions.md

### DIFF
--- a/source/guides/configuring-ember/disabling-prototype-extensions.md
+++ b/source/guides/configuring-ember/disabling-prototype-extensions.md
@@ -100,9 +100,9 @@ fullName: function() {
 
 
 // Instead, do this:
-fullName: Ember.computed(function() {
+fullName: Ember.computed('firstName', 'lastName', function() {
   return this.get('firstName') + ' ' + this.get('lastName');
-}).property('firstName', 'lastName')
+})
 ```
 
 Observers are annotated using `Ember.observer()`:


### PR DESCRIPTION
Updated Ember.computed description to include property name parameters before the actual function implementation, since we are no longer chaining .property() on the end.
