### PR TITLE
Fix reference so required modules are properly linked

### DIFF
--- a/source/api/module.html.erb
+++ b/source/api/module.html.erb
@@ -7,7 +7,7 @@
 <% end %>
 
 <% if @module['requires'] %>
-  <p>Requires: <%= @module['requires'].map{|r| link_to(r['name'], "#{r['name']}.html") }.join(", ") %></p>
+  <p>Requires: <%= @module['requires'].map{|r| link_to(r, "#{r}.html") }.join(", ") %></p>
 <% end %>
 
 <p><%= api_markdown @module['description'] %></p>


### PR DESCRIPTION
reference to 'requires' on the website aren't working because of changes in the API specification format.

http://emberjs.com/api/modules/ember-application.html (note the random comma)
https://github.com/emberjs/website/blob/master/data/api.yml#L1163
