### PR TITLE
[cookbook] Encourage use of `activate` hook over private hook

### DIFF
--- a/source/guides/cookbook/user_interface_and_interaction/resetting_scroll_on_route_changes.md
+++ b/source/guides/cookbook/user_interface_and_interaction/resetting_scroll_on_route_changes.md
@@ -8,19 +8,19 @@ Add the following mixin to the affected Routes:
 
 ```js
 App.ResetScroll = Ember.Mixin.create({
-  enter: function() {
+  activate: function() {
     this._super();
     window.scrollTo(0,0);
   }
 });
 ```
 
-Only if you need do something on the `enter` method you must call `this._super()` at the beginning:
+Only if you need do something on the `activate` method you must call `this._super()` at the beginning:
 
 ```js
 App.IndexRoute = Ember.Route.extend(App.ResetScroll, {
-  //I need to do other things with enter
-  enter: function() {
+  //I need to do other things with activate
+  activate: function() {
     this._super.apply(this, arguments); // Call super at the beginning
     // Your stuff
   }
@@ -29,4 +29,4 @@ App.IndexRoute = Ember.Route.extend(App.ResetScroll, {
 
 #### Example
 
-<a class="jsbin-embed" href="http://emberjs.jsbin.com/IxERoxoy/4/embed?html,css,js,output">Ember Starter Kit</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://emberjs.jsbin.com/kixowati/1/embed?html,js,output">Ember Starter Kit</a><script src="http://static.jsbin.com/js/embed.js"></script>


### PR DESCRIPTION
`enter` is technically a private method. Update the tutorial and jsbin example to reflect the use of `activate`.
