### PR TITLE
Move `isLoading` outside of actions in the "spin button" guide

### DIFF
--- a/source/guides/cookbook/helpers_and_components/spin_button_for_asynchronous_actions.md
+++ b/source/guides/cookbook/helpers_and_components/spin_button_for_asynchronous_actions.md
@@ -65,4 +65,4 @@ For safety and sanity of the component, one can add a settimeout of however much
 Also note that the component does not let multiple clicks get in the way of loading status.
 
 #### Example
-<a class="jsbin-embed" href="http://emberjs.jsbin.com/EXaxEfE/8">JS Bin</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://emberjs.jsbin.com/EXaxEfE/14/">JS Bin</a><script src="http://static.jsbin.com/js/embed.js"></script>


### PR DESCRIPTION
Since `isLoading` is just a property, it shouldn't be within `actions` on the `SpinButtonComponent`. I also created a new JS Bin with the change.
