### PR TITLE
[Search] Improved Search Titles

### DIFF
--- a/source/layout.erb
+++ b/source/layout.erb
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Ember.js - <%= current_page.data.title || @title %></title>
+    <meta property="st:title" content="<%= current_page.data.title || @title %>" />
     <link rel="shortcut icon" href="/images/favicon.png" />
     <!--[if lte IE 7 ]><%= stylesheet_link_tag "fonts/fontello-ie7" %><![endif]-->
     <%= stylesheet_link_tag "site" %>


### PR DESCRIPTION
Added Swiftype meta tag to be used for search titles instead of page titles.

Currently, both search results and search autocomplete display options are like this (searching for "Data"):

"Ember.js - Ember Data"
"Ember.js - Stabilizing Ember Data"
…

Adding Swiftype meta tag to be used instead of page title will essentially remove "Ember.js - " from each matching search title and change the results to this:

"Ember Data"
"Stabilizing Ember Data"
…

**The "st:title" meta tag takes precedence over "title" tag**. More about Swiftype meta tags [here](https://swiftype.com/documentation/meta_tags).
