### PR TITLE
fix typo in actions section of templates guide

### DIFF
--- a/source/guides/templates/actions.md
+++ b/source/guides/templates/actions.md
@@ -122,7 +122,7 @@ For example, if the `post` argument was passed:
 <p><button {{action "select" post}}>✓</button> {{post.title}}</p>
 ```
 
-The route's `select` action handler would be called with a single argument
+The controller's `select` action handler would be called with a single argument
 containing the post model:
 
 ```js


### PR DESCRIPTION
The sample code following the text is a controller, not a route.
