### PR TITLE
Fix link to guide index markdown

### DIFF
--- a/lib/toc.rb
+++ b/lib/toc.rb
@@ -106,7 +106,7 @@ module TOC
       if section_slug == guide_slug
         return "#{base_guide_url}/#{current_guide['url']}/index.md"
       else
-        return "#{base_guide_url}/#{current_guide['url']}.md"
+        return "#{base_guide_url}/#{current_guide['url'].gsub(/.html/, '')}.md"
       end
     end
 


### PR DESCRIPTION
The link to the guide markdown was index.html.md, which is incorrect. It should always be index.md.
