### PR TITLE
Put builds app after common js, fix builds page

### DIFF
--- a/source/builds/index.html.erb
+++ b/source/builds/index.html.erb
@@ -2,7 +2,7 @@
 title: Builds
 ---
 
-<% content_for :head do %>
+<% content_for :foot do %>
   <script type="text/javascript" src="/javascripts/builds.js"></script>
 <% end %>
 


### PR DESCRIPTION
Fix for the builds page. Did some grepping to be fairly sure this is happening nowhere else.
