### PR TITLE
Use ALL-UPPERCASE for these instead of having escaped stuff in the header

### DIFF
--- a/source/guides/routing/asynchronous-routing.md
+++ b/source/guides/routing/asynchronous-routing.md
@@ -163,7 +163,7 @@ App.FunkyRoute = Ember.Route.extend({
 });
 ```
 
-### `beforeModel` and `afterModel`
+### beforeModel and afterModel
 
 The `model` hook covers many use cases for pause-on-promise transitions,
 but sometimes you'll need the help of the related hooks `beforeModel`


### PR DESCRIPTION
I think it looks saner that way (even though the name of the hooks are actually in lowercase). What do you say?
