### PR TITLE
Fixed incorrect usage of nested resources

### DIFF
--- a/source/guides/routing/loading-and-error-substates.md
+++ b/source/guides/routing/loading-and-error-substates.md
@@ -80,9 +80,9 @@ the following loading substate behavior we've been alluding to.
 
 ```js
 App.Router.map(function() {
-  this.resource('foo', function() {   // -> FooRoute
-    this.resource('bar', function() { // -> BarRoute
-      this.route('baz');              // -> BarBazRoute
+  this.resource('foo', function() {       // -> FooRoute
+    this.resource('foo.bar', function() { // -> FooBarRoute
+      this.route('baz');                  // -> FooBarBazRoute
     });
   });
 });
@@ -100,13 +100,13 @@ above `foo.bar.baz` that it can transition into, starting with
 Ember will find a loading route at the above location if either a) a 
 Route subclass has been defined for such a route, e.g.
 
-1. `App.BarLoadingRoute`
+1. `App.FooBarLoadingRoute`
 2. `App.FooLoadingRoute`
 3. `App.LoadingRoute`
 
 or b) a properly-named loading template has been found, e.g.
 
-1. `bar/loading`
+1. `foo/bar/loading`
 2. `foo/loading`
 3. `loading`
 


### PR DESCRIPTION
I hope I got it right. :smiley: This is the thing with [nested resources](http://emberjs.com/guides/routing/defining-your-routes/) not inheriting the parent name in their route name. I.e. a `bar` resource under a `foo` resource would have its children be bar._, not foo.bar._, according to the referenced page. (in the "Nested resources" section of that page)
