### PR TITLE
fixing getting-started bug when editing todo

### DIFF
--- a/source/guides/getting-ember/index.md
+++ b/source/guides/getting-ember/index.md
@@ -24,7 +24,6 @@ Adding Ember to your application with Bower is easy simply run `bower install em
 		"ember-data": "~1.0.0-beta.4"
 	}
 }
-
 ```
 
 ##RubyGems

--- a/source/guides/getting-started/accepting-edits.md
+++ b/source/guides/getting-started/accepting-edits.md
@@ -52,25 +52,27 @@ actions: {
     this.set('isEditing', true);
   },
   acceptChanges: function() {
-    this.set('isEditing', false);
+    if (this.get('isEditing')) {
+      this.set('isEditing', false);
 
-    if (Ember.isEmpty(this.get('model.title'))) {
-      this.send('removeTodo');
-    } else {
-      this.get('model').save();
+      if (Ember.isEmpty(this.get('model.title'))) {
+        this.send('removeTodo');
+      } else {
+        this.get('model').save();
+      }
     }
   }
 },
 // ... additional lines truncated for brevity ...
 ```
 
-This method will set the controller's `isEditing` property to false and commit all changes made to the todo.
+This method will set the controller's `isEditing` property to false and commit all changes made to the todo if the controller is in the edit mode.
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/USOlAna/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/jorav/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 
-  * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/a7e2f40da4d75342358acdfcbda7a05ccc90f348)
+  * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/662cd9671a9119dec7274631783d4a78e073e9cc)
   * [Controller Guide](/guides/controllers)
   * [Ember.TextField API documentation](/api/classes/Ember.TextField.html)

--- a/source/guides/getting-started/adding-child-routes.md
+++ b/source/guides/getting-started/adding-child-routes.md
@@ -60,11 +60,11 @@ model for this route is the same model as for the `TodosRoute`.
 This mapping is described in more detail in the [Naming Conventions Guide](/guides/concepts/naming-conventions).
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/oweNovo/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/homug/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 
-  * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/3bab8f1519ffc1ca2d5a12d1de35e4c764c91f05)
+  * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/72f19ea2a8661572e41166bcc04ecdb8529caf9a)
   * [Ember Router Guide](/guides/routing)
   * [Ember Controller Guide](/guides/controllers)
   * [outlet API documentation](/api/classes/Ember.Handlebars.helpers.html#method_outlet)

--- a/source/guides/getting-started/deleting-todos.md
+++ b/source/guides/getting-started/deleting-todos.md
@@ -30,9 +30,9 @@ Because the todo is no longer part of the collection of all todos, its `<li>` el
 Reload your web browser to ensure that there are no errors and the behaviors described above occurs.
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/eREkanA/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/gatul/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 
-  * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/14e1f129f76bae8f8ea6a73de1e24d810678a8fe)
+  * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/6d987a7601d2f7466d48674f20c0b73f88b7d25b)
   * [action API documention](/api/classes/Ember.Handlebars.helpers.html#method_action)

--- a/source/guides/getting-started/display-a-button-to-remove-completed-todos.md
+++ b/source/guides/getting-started/display-a-button-to-remove-completed-todos.md
@@ -39,10 +39,10 @@ The `completed` and `clearCompleted` methods both invoke the `filterBy` method, 
 Reload your web browser to ensure that there are no errors and the behavior described above occurs.
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/ULovoJI/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/xamet/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 
-  * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/1da450a8d693f083873a086d0d21e031ee3c129e)
+  * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/91e1aea23cffc78c5fba361a3e8baa1285985101)
   * [Handlebars Conditionals Guide](/guides/templates/conditionals)
   * [Enumerables Guide](/guides/enumerables)

--- a/source/guides/getting-started/display-a-button-to-remove-completed-todos.md
+++ b/source/guides/getting-started/display-a-button-to-remove-completed-todos.md
@@ -34,7 +34,7 @@ completed: function() {
 // ... additional lines truncated for brevity ...
 ```
 
-The `completed` and `clearCompleted` methods both invoke the `filterBy` method, which is part of the [ArrayController](http://emberjs.com/api/classes/Ember.ArrayController.html#method_filterProperty) API and returns an instance of [EmberArray](http://emberjs.com/api/classes/Ember.Array.html) which contains only the items for which the callback returns true.  The `clearCompleted` method also invokes the `invoke` method which is part of the [EmberArray](http://emberjs.com/api/classes/Ember.Array.html#method_invoke) API.  `invoke` will execute a method on each object in the Array if the method exists on that object.
+The `completed` and `clearCompleted` methods both invoke the `filterBy` method, which is part of the [ArrayController](http://emberjs.com/api/classes/Ember.ArrayController.html#method_filterBy) API and returns an instance of [EmberArray](http://emberjs.com/api/classes/Ember.Array.html) which contains only the items for which the callback returns true.  The `clearCompleted` method also invokes the `invoke` method which is part of the [EmberArray](http://emberjs.com/api/classes/Ember.Array.html#method_invoke) API.  `invoke` will execute a method on each object in the Array if the method exists on that object.
 
 Reload your web browser to ensure that there are no errors and the behavior described above occurs.
 

--- a/source/guides/getting-started/show-all-todos-again.md
+++ b/source/guides/getting-started/show-all-todos-again.md
@@ -19,9 +19,9 @@ In `index.html` convert the `<a>` tag for 'All' todos into a Handlebars `{{link-
 Reload your web browser to ensure that there are no errors. You should be able to navigate between urls for all, active, and completed todos.
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/uYuGA/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/quriv/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 
-  * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/843ff914873081560e4ba97df0237b8595b6ae51)
+  * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/2f468676975c8f00057ce79fe3cb179655e5bbaf)
   * [link-to API documentation](/api/classes/Ember.Handlebars.helpers.html#method_link-to)

--- a/source/guides/getting-started/show-only-complete-todos.md
+++ b/source/guides/getting-started/show-only-complete-todos.md
@@ -48,11 +48,11 @@ Normally transitioning into a new route changes the template rendered into the p
 Reload your web browser to ensure that there are no errors and the behavior described above occurs.
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/OzUvuPu/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/lucej/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 
-  * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/bba939a11197552e3a927bcb3a3adb9430e4f331)
+  * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/ae35d359b9f356acb7e2d2cbeacfb4465de24a18)
   * [link-to API documentation](/api/classes/Ember.Handlebars.helpers.html#method_link-to)
   * [Route#renderTemplate API documentation](/api/classes/Ember.Route.html#method_renderTemplate)
   * [Route#render API documentation](/api/classes/Ember.Route.html#method_render)

--- a/source/guides/getting-started/show-only-incomplete-todos.md
+++ b/source/guides/getting-started/show-only-incomplete-todos.md
@@ -46,11 +46,11 @@ Normally transitioning into a new route changes the template rendered into the p
 Reload your web browser to ensure that there are no errors and the behavior described above occurs.
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/arITiZu/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/xukut/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 
-  * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/2a1d35293a52e40d0125f552a1a8b2c01f759313)
+  * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/b9faa7bd35cc116862c8682f6aed8630905fba93)
   * [link-to API documentation](/api/classes/Ember.Handlebars.helpers.html#method_link-to)
   * [Route#renderTemplate API documentation](/api/classes/Ember.Route.html#method_renderTemplate)
   * [Route#render API documentation](/api/classes/Ember.Route.html#method_render)

--- a/source/guides/getting-started/show-when-all-todos-are-complete.md
+++ b/source/guides/getting-started/show-when-all-todos-are-complete.md
@@ -26,9 +26,9 @@ This property will be `true` if the controller has any todos and every todo's `i
 Reload your web browser to ensure that there are no errors and the behavior described above occurs. 
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/IcItARE/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/pigav/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 
-  * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/9bf8a430bc4afb06f31be55f63f1d9806e6ab01c)
+  * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/cacedb959ee963cc89adbe49b61442894733edd7)
   * [Ember.Checkbox API documentation](/api/classes/Ember.Checkbox.html)

--- a/source/guides/getting-started/toggle-all-todos.md
+++ b/source/guides/getting-started/toggle-all-todos.md
@@ -23,10 +23,10 @@ The count of remaining todos and completed todos used elsewhere in the template 
 Reload your web browser to ensure that there are no errors and the behavior described above occurs.
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/AViZATE/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/rabor/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 
-  * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/47b289bb9f669edaa39abd971f5e884142988663)
+  * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/aad688dd7cf7dc592ee54b2584cef9bf349f91cd)
   * [Ember.Checkbox API documentation](/api/classes/Ember.Checkbox.html)
   * [Computed Properties Guide](/guides/object-model/computed-properties/)

--- a/source/guides/getting-started/using-other-adapters.md
+++ b/source/guides/getting-started/using-other-adapters.md
@@ -25,9 +25,9 @@ In `index.html` include `js/libs/localstorage_adapter.js` as a dependency:
 Reload your application. Todos you manage will now persist after the application has been closed.
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/aZIXaYo/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/rotey/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 
-  * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/81801d87da42d0c83685ff946c46de68589ce38f)
+  * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/19d38fb43dc9bdb41501ad0f0b0b6834a1fa6ffc)
   * [LocalStorage Adapter on GitHub](https://github.com/rpflorence/ember-localstorage-adapter)

--- a/source/guides/routing/query-params.md
+++ b/source/guides/routing/query-params.md
@@ -73,7 +73,7 @@ App.ArticlesController = Ember.ArrayController.extend({
     var articles = this.get('model');
 
     if (category) {
-      return articles.filterProperty('category', category);
+      return articles.filterBy('category', category);
     } else {
       return articles;
     }
@@ -99,7 +99,7 @@ The `link-to` helper supports specifying query params by way of the
 `query-params` subexpression helper.
 
 ```handlebars
-// Explicitly set target query para
+// Explicitly set target query parameter
 {{#link-to 'posts' (query-params direction="asc")}}Sort{{/link-to}}
 
 // Binding is also supported


### PR DESCRIPTION
Editing todos throws an error whenever the change is confirmed by using a newline (Enter).  In particular, it throws the error

`Uncaught Error: Attempted to handle event 'willCommit' on <Todos.Todo:ember270:2> while in state root.loaded.updated.inFlight. `

For the final Todo (Replacing the Fixture Adapter with Another Adapter), it throws the error

`Uncaught Error: Attempted to handle event 'willCommit' on <Todos.Todo:ember272:oumdk> while in state root.deleted.saved. `

when you attempt to delete a todo by editing the item to be blank.  This error throws future errors in some cases such as `Assertion failed: calling set on destroyed object `, making the todo list unable to function.  Note that this bug does not occur when one confirms an edit by clicking somewhere out of the textfield.

This bug occurs because when newline triggers an edit or removal of a todo, `acceptChanges` is called a second time due to the textfield being focused out.  This may or may not be intended behavior -- PR fixes this and all JSBins by checking whether it is still in edit mode.