### PR TITLE
Removed incorrect statement

### DIFF
--- a/source/guides/cookbook/helpers_and_components/creating_reusable_social_share_buttons.md
+++ b/source/guides/cookbook/helpers_and_components/creating_reusable_social_share_buttons.md
@@ -40,12 +40,7 @@ The component defines certain attributes of its HTML representation as bound to 
 its `attributeBindings` property. When the values of these properties change, the component's HTML element's
 attributes will be updated to match the new values.
 
-
 An appropriate tag and css class are applied through the `tagName` and `classNames` properties.
-
-
-Note: Your component must have a matching template named `share-twitter`. Because there is no HTML inside our
-`<a>` tag, this template will be empty.
 
 #### Example
 


### PR DESCRIPTION
If I understand [this page](http://emberjs.com/guides/routing/generated-objects/#toc_generated-views-and-templates) correctly, you definitely don't have to manually create a template if it is all-empty; it is done automatically by the framework.

Please proof-read me to verify that I'm not mistaken in this, but I feel that the text I removed here just makes people confused (since its incorrect, AFAICT).
