### PR TITLE
Fixes #1081, event propagation

### DIFF
--- a/source/guides/cookbook/user_interface_and_interaction/using_modal_dialogs.md
+++ b/source/guides/cookbook/user_interface_and_interaction/using_modal_dialogs.md
@@ -64,5 +64,5 @@ This example shows:
   1. Wrapping the common modal markup and actions in a component.
   1. Handling events to close the modal when the overlay is clicked.
 
-<a class="jsbin-embed" href="http://emberjs.jsbin.com/iluLOto/1/embed?output">JS Bin</a>
+<a class="jsbin-embed" href="http://emberjs.jsbin.com/lokozegi/4/edit?output">JS Bin</a>
 


### PR DESCRIPTION
Must use preventDefault=false on action handler so events can properly propagate from inputs.

https://github.com/emberjs/ember.js/issues/3737
