### PR TITLE
Fixes #1310 - Updates deprecated `filterProperty`

### DIFF
--- a/source/guides/getting-started/displaying-the-number-of-incomplete-todos.md
+++ b/source/guides/getting-started/displaying-the-number-of-incomplete-todos.md
@@ -34,7 +34,7 @@ The `inflection` property will return either a plural or singular version of the
  Reload your web browser to ensure that no errors occur. You should now see an accurate number for remaining todos.
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/onOCIrA/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/onOCIrA/74/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 


### PR DESCRIPTION
`filterProperty` was used within JS Bin. I've updated the example to use `filterBy` method instead.

[Here's the updated JS Bin example](http://jsbin.com/onOCIrA/74/embed?live)
