### PR TITLE
Put linear-gradient in line with w3c spec

### DIFF
--- a/source/stylesheets/examples.css.scss
+++ b/source/stylesheets/examples.css.scss
@@ -407,7 +407,7 @@
   }
 
   tr.active {
-    @include background(linear-gradient(top, #7db9e8, #267dc9));
+    @include background(linear-gradient(to bottom, #7db9e8, #267dc9));
     color: white;
     text-shadow: 1px 1px 0px #666;
   }

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -447,7 +447,7 @@ p {
 
       background-color: #ff6e56;
       @include filter-gradient(#ff6e56, #ed4f35, vertical);
-      @include background-image(linear-gradient(top, #ff6e56 0%, #ed4f35 100%));
+      @include background-image(linear-gradient(to bottom, #ff6e56 0%, #ed4f35 100%));
 
       border: 1px solid #a93926;
       @include border-radius(4px);
@@ -1422,7 +1422,7 @@ body.security #content {
     border-bottom-color: #a04332;
 
     @include filter-gradient(#fe845a, #d14e37, vertical);
-    @include background-image( linear-gradient(top, #fe845a, #d14e37) );
+    @include background-image( linear-gradient(to bottom, #fe845a, #d14e37) );
     @include border-radius(5px);
     @include box-shadow(inset 0 1px 0 rgba(255, 255, 255, 0.35));
 
@@ -1431,7 +1431,7 @@ body.security #content {
       border-top-color: #ea7a68;
       border-bottom-color: #c1513d;
       @include filter-gradient(#fc906b, #e2654e, vertical);
-      @include background-image( linear-gradient(top, #fc906b, #e2654e) );
+      @include background-image( linear-gradient(to bottom, #fc906b, #e2654e) );
     }
 
     &:active {
@@ -1439,7 +1439,7 @@ body.security #content {
       border-top-color: #92473a;
       border-bottom-color: #e1583f;
       @include filter-gradient(#b2412e, #ed7249, vertical);
-      @include background-image( linear-gradient(top, #b2412e, #ed7249) );
+      @include background-image( linear-gradient(to bottom, #b2412e, #ed7249) );
       @include box-shadow(none);
       @include text-shadow(rgba(0, 0, 0, 0.2) 0 -1px 0);
     }


### PR DESCRIPTION
Just thought it'd be a good idea that the linear-gradients were in line with the [w3c spec](http://www.w3.org/TR/css3-images/#linear-gradients). There are some ramifications, namely, browsers that only supported one of the initial spec grammars that did not include the `to <side-or-corner>` syntax.
According to [Mozilla's MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient), Firefox 3.6 -> 10 and Chrome 10 -> 26 would be affected.
IE 9 supports neither, 10 supports both, and 11 only supports the formal spec.
**Firefox:**
[Firefox 3.6 was automatically updated](https://groups.google.com/forum/#!topic/mozilla.dev.planning/H7jdpvT3Nbc) to version 12 on May 9th, 2012.
**Chrome:**
Chrome has had automatic upgrades enabled for as long as I can remember.
**IE:**
Since only v10 is affected only windows 7 and server 2008 are affected. If the user has been getting their Windows Updates, they should be on IE 11 now (which supports the formal spec) unless they [specifically installed something to disable the update](http://www.microsoft.com/en-us/download/details.aspx?id=40722).
**Safari:**
I have limited data on Safari due to being at the office right now. I can say that Safari 7 seems to support the formal spec though I haven't found any good docs with a version/support table that is up to date (the MDN table seems to indicate a nightly circa Safari 6, June 2013).
