### PR TITLE
Replace raw http links in 'Further reading:' section

### DIFF
--- a/source/guides/cookbook/working_with_objects/continuous_redrawing_of_views.md
+++ b/source/guides/cookbook/working_with_objects/continuous_redrawing_of_views.md
@@ -182,11 +182,10 @@ The source code:
 
 Further reading:
 
-* <http://emberjs.com/api/classes/Ember.Object.html>
-* <http://emberjs.com/api/classes/Ember.Application.html>, See section on
-  "Initializers"
-* <http://emberjs.com/api/classes/Ember.Application.html#method_inject>
-* <http://emberjs.com/guides/templates/conditionals/>
-* <http://emberjs.com/guides/templates/writing-helpers/>
-* <http://emberjs.com/guides/components/defining-a-component/>
-* <http://emberjs.com/api/classes/Ember.ArrayController.html>
+* [Ember Object](http://emberjs.com/api/classes/Ember.Object.html)
+* [Ember Application Initializers](http://emberjs.com/api/classes/Ember.Application.html#toc_initializers)
+* [Method Inject](http://emberjs.com/api/classes/Ember.Application.html#method_inject)
+* [Conditionals](http://emberjs.com/guides/templates/conditionals/)
+* [Writing Helpers](http://emberjs.com/guides/templates/writing-helpers/)
+* [Defining a Component](http://emberjs.com/guides/components/defining-a-component/)
+* [Ember Array Controller](http://emberjs.com/api/classes/Ember.ArrayController.html)


### PR DESCRIPTION
Links are shown as title for content rather than raw http URLs in 'Further reading:' section

Before change:
![ember_js_-_cookbook__continuous_redrawing_of_views](https://cloud.githubusercontent.com/assets/514063/2560122/e8d94f66-b7a9-11e3-8552-060a37b2dfd7.png)
