### PR TITLE
de-nest modal/overlay elements in modal example

### DIFF
--- a/source/guides/cookbook/user_interface_and_interaction/using_modal_dialogs.md
+++ b/source/guides/cookbook/user_interface_and_interaction/using_modal_dialogs.md
@@ -64,5 +64,5 @@ This example shows:
   1. Wrapping the common modal markup and actions in a component.
   1. Handling events to close the modal when the overlay is clicked.
 
-<a class="jsbin-embed" href="http://emberjs.jsbin.com/lokozegi/4/edit?output">JS Bin</a>
+<a class="jsbin-embed" href="http://emberjs.jsbin.com/lokozegi/110/edit">JS Bin</a>
 


### PR DESCRIPTION
This solves issues with DOM event bubbling prevented by actions. bubbles=false hijacks events, so things like bootstrap widgets, whose events are handled on the document, wouldn't work inside the modal.

https://github.com/emberjs/website/issues/1081
https://github.com/emberjs/website/pull/1383
