### PR TITLE
Bindings no longer needed 

### DIFF
--- a/source/guides/views/built-in-views.md
+++ b/source/guides/views/built-in-views.md
@@ -6,7 +6,7 @@ They are:
 
 ```handlebars
 <label>
-  {{view Ember.Checkbox checkedBinding="model.isDone"}}
+  {{view Ember.Checkbox checked=model.isDone}}
   {{model.title}}
 </label>
 ```
@@ -26,11 +26,11 @@ App.MyText = Ember.TextField.extend({
 
 ```handlebars
 {{view Ember.Select viewName="select"
-                    contentBinding="people"
+                    content=people
                     optionLabelPath="model.fullName"
                     optionValuePath="model.id"
                     prompt="Pick a person:"
-                    selectionBinding="selectedPerson"}}
+                    selection=selectedPerson}}
 ```
 
 #### Ember.TextArea


### PR DESCRIPTION
In the document, we have not used the built in helpers for input, checkbox field. Is it intentional? This PR is just a beginning for changing most of the examples to reflect the latest code. Otherwise, a ember beginner will only use the built in ember views such as "Em.TextField" instead of "{{input}}" in their hbs
