### PR TITLE
Add some cookbook links that were missing on the bottom nav links.

### DIFF
--- a/data/guides.yml
+++ b/data/guides.yml
@@ -334,6 +334,12 @@ Cookbook:
   - title: "Creating Reusable Social Share Buttons"
     url: "cookbook/helpers_and_components/creating_reusable_social_share_buttons"
     skip_sidebar_item: true
+  - title: "A Spinning Button for Asynchronous Actions"
+    url: "cookbook/helpers_and_components/spin_button_for_asynchronous_actions"
+    skip_sidebar_item: true
+  - title: "Adding Google Analytics Tracking"
+    url: "cookbook/helpers_and_components/adding_google_analytics_tracking"
+    skip_sidebar_item: true
   # objects
   - title: "Working with Objects"
     url: "cookbook/working_with_objects"


### PR DESCRIPTION
While reading through the cookbook entries at http://emberjs.com/guides/cookbook/helpers_and_components/ , I noticed that using the bottom nav links caused me to skip over the 2nd and 3rd recipe listed. This fix adds those two recipes back into the nav links at the bottom.
