### PR TITLE
Using `resource` instead of `route` for nouns

### DIFF
--- a/source/guides/routing/generated-objects.md
+++ b/source/guides/routing/generated-objects.md
@@ -11,7 +11,7 @@ Given you have the following route:
 
 ```javascript
 App.Router.map(function() {
-  this.route('posts');
+  this.resource('posts');
 });
 ```
 


### PR DESCRIPTION
Fixed conflicting use of `route` for nouns, which was suggested by previous guide. Maybe should also add somewhere explaining why the difference between `route` and `resource`. Are they just alias or they do have different effects.
