### PR TITLE
[Test Helpers] find's context defaults to root element

### DIFF
--- a/source/guides/testing/test-helpers.md
+++ b/source/guides/testing/test-helpers.md
@@ -50,7 +50,8 @@ Synchronous helpers are performed immediately when triggered.
 * `find(selector, context)`
   - Finds an element within the app's root element and within the context 
     (optional). Scoping to the root element is especially useful to avoid 
-    conflicts with the test framework's reporter.
+    conflicts with the test framework's reporter, and this is done by default
+    if the context is not specified.
 * `currentPath()`
   - Returns the current path.
 * `currentRouteName()`


### PR DESCRIPTION
The find method's context argument defaults to the application's
root element if it isn't specified.  This updates the language
to reflect that behavior.
