### PR TITLE
Fixed syntax error in testem.json example

### DIFF
--- a/source/guides/testing/test-runners.md
+++ b/source/guides/testing/test-runners.md
@@ -57,7 +57,7 @@ npm install -g --save-dev testem
       "your_test_code_here.js"
     ],
     "launch_in_dev": ["PhantomJS"],
-    "launch_in_ci": ["PhantomJS"],
+    "launch_in_ci": ["PhantomJS"]
 }
 ```
 


### PR DESCRIPTION
Removed a unneeded comma that would cause a syntax error in the example testem.json file. 
