### PR TITLE
Adding a comma for clarity

### DIFF
--- a/source/guides/concepts/naming-conventions.md
+++ b/source/guides/concepts/naming-conventions.md
@@ -68,7 +68,7 @@ your entire application shares a single instance of each controller.
 
 ## Simple Routes
 
-Each of your routes will have a controller and a template with the 
+Each of your routes will have a controller, and a template with the 
 same name as the route.
 
 Let's start with a simple router:


### PR DESCRIPTION
I think adding a comma here makes it clearer that it is just the template which has the same name as the route, not both the controller and the template.
