### PR TITLE
Update Syntax in regards to accessing the store

### DIFF
--- a/source/guides/concepts/naming-conventions.md
+++ b/source/guides/concepts/naming-conventions.md
@@ -117,7 +117,7 @@ Here's an example:
 App.FavoritesRoute = Ember.Route.extend({
   model: function() {
     // the model is an Array of all of the posts
-    return this.store.find('post');
+    return store.find('post');
   }
 });
 ```
@@ -175,7 +175,7 @@ generating a link for a model object).
 ```javascript
 App.PostRoute = Ember.Route.extend({
   model: function(params) {
-    return this.store.find('post', params.post_id);
+    return store.find('post', params.post_id);
   },
 
   serialize: function(post) {

--- a/source/guides/getting-started/creating-a-new-model.md
+++ b/source/guides/getting-started/creating-a-new-model.md
@@ -27,7 +27,7 @@ Todos.TodosController = Ember.ArrayController.extend({
       if (!title.trim()) { return; }
 
       // Create the new Todo model
-      var todo = this.store.createRecord('todo', {
+      var todo = store.createRecord('todo', {
         title: title,
         isCompleted: false
       });

--- a/source/guides/getting-started/displaying-model-data.md
+++ b/source/guides/getting-started/displaying-model-data.md
@@ -6,7 +6,7 @@ Inside the file `js/router.js` implement a `TodosRoute` class with a `model` fun
 // ... additional lines truncated for brevity ...
 Todos.TodosRoute = Ember.Route.extend({
   model: function() {
-    return this.store.find('todo');
+    return store.find('todo');
   }
 });
 ```

--- a/source/guides/getting-started/show-only-complete-todos.md
+++ b/source/guides/getting-started/show-only-complete-todos.md
@@ -31,7 +31,7 @@ Todos.Router.map(function() {
 
 Todos.TodosCompletedRoute = Ember.Route.extend({
   model: function() {
-    return this.store.filter('todo', function(todo) {
+    return store.filter('todo', function(todo) {
       return todo.get('isCompleted');
     });
   },

--- a/source/guides/getting-started/show-only-incomplete-todos.md
+++ b/source/guides/getting-started/show-only-incomplete-todos.md
@@ -29,7 +29,7 @@ Todos.Router.map(function() {
 // ... additional lines truncated for brevity ...
 Todos.TodosActiveRoute = Ember.Route.extend({
   model: function(){
-    return this.store.filter('todo', function(todo) {
+    return store.filter('todo', function(todo) {
       return !todo.get('isCompleted');
     });
   },

--- a/source/guides/models/connecting-to-an-http-server.md
+++ b/source/guides/models/connecting-to-an-http-server.md
@@ -25,7 +25,7 @@ For example, if you ask for an `App.Photo` record by ID:
 ```js
 App.PhotoRoute = Ember.Route.extend({
   model: function(params) {
-    return this.store.find('photo', params.photo_id);
+    return store.find('photo', params.photo_id);
   }
 });
 ```

--- a/source/guides/models/creating-and-deleting-records.md
+++ b/source/guides/models/creating-and-deleting-records.md
@@ -7,7 +7,7 @@ store.createRecord('post', {
 });
 ```
 
-The store object is available in controllers and routes using `this.store`.
+The store object is available in controllers and routes using `store..
 
 Although `createRecord` is fairly straightforward, the only thing to watch out for
 is that you cannot assign a promise as a relationship, currently.
@@ -16,7 +16,7 @@ For example, if you want to set the `author` property of a post, this would **no
 if the `user` with id isn't already loaded into the store:
 
 ```js
-var store = this.store;
+var store = store.
 
 store.createRecord('post', {
   title: 'Rails is Omakase',
@@ -28,7 +28,7 @@ store.createRecord('post', {
 However, you can easily set the relationship after the promise has fulfilled:
 
 ```js
-var store = this.store;
+var store = store.
 
 var post = store.createRecord('post', {
   title: 'Rails is Omakase',

--- a/source/guides/models/finding-records.md
+++ b/source/guides/models/finding-records.md
@@ -8,14 +8,14 @@ argument determines if a request is made for all records, a single record, or a 
 ### Finding All Records of a Type
 
 ```javascript
-var posts = this.store.find('post'); // => GET /posts
+var posts = store.find('post'); // => GET /posts
 ```
 
 To get a list of records already loaded into the store, without making
 another network request, use `all` instead.
 
 ```javascript
-var posts = this.store.all('post'); // => no network request
+var posts = store.all('post'); // => no network request
 ```
 
 `find` returns a `DS.PromiseArray` that fulfills to a `DS.RecordArray` and `all`
@@ -35,7 +35,7 @@ Ember Data will attempt to retrieve a record of that with that ID. This will
 return a promise that fulfills with the requested record:
 
 ```javascript
-var aSinglePost = this.store.find('post', 1); // => GET /posts/1
+var aSinglePost = store.find('post', 1); // => GET /posts/1
 ```
 
 ### Querying For Records
@@ -48,7 +48,7 @@ For example, we could search for all `person` models who have the name of
 `Peter`:
 
 ```javascript
-var peters = this.store.find('person', { name: "Peter" }); // => GET to /persons?name='Peter'
+var peters = store.find('person', { name: "Peter" }); // => GET to /persons?name='Peter'
 ```
 
 ### Integrating with the Route's Model Hook
@@ -75,13 +75,13 @@ App.Router.map(function() {
 
 App.PostsRoute = Ember.Route.extend({
   model: function() {
-    return this.store.find('post');
+    return store.find('post');
   }
 });
 
 App.PostRoute = Ember.Route.extend({
   model: function(params) {
-    return this.store.find('post', params.post_id);
+    return store.find('post', params.post_id);
   }
 })
 ```

--- a/source/guides/models/frequently-asked-questions.md
+++ b/source/guides/models/frequently-asked-questions.md
@@ -67,7 +67,7 @@ and modified on the client.
 ```js
 App.PostsFavoritedRoute = Ember.Route.extend({
   model: function() {
-    var store = this.store;
+    var store = store.
 
     // Create a filter for all favorited posts that will be displayed in
     // the template. Any favorited posts that are already in the store

--- a/source/guides/models/handling-metadata.md
+++ b/source/guides/models/handling-metadata.md
@@ -3,7 +3,7 @@ Along with the records returned from your store, you'll likely need to handle so
 Pagination is a common example of using metadata. Imagine a blog with far more posts than you can display at once. You might query it like so:
 
 ```js
-this.store.findQuery("post", {
+store.findQuery("post", {
   limit: 10,
   offset: 0
 });
@@ -34,7 +34,7 @@ By default, Ember Data's JSON deserializer looks for a `meta` key:
 The metadata for a specific type is then set to the contents of `meta`. You can access it with `store.metadataFor`:
 
 ```js
-var meta = this.store.metadataFor("post");
+var meta = store.metadataFor("post");
 ```
 
 Now, `meta.total` can be used to calculate how many pages of posts you'll have.

--- a/source/guides/models/index.md
+++ b/source/guides/models/index.md
@@ -69,7 +69,7 @@ For example, we might want to find an `App.Person` model with the ID of
 ```js
 App.IndexRoute = Ember.Route.extend({
   model: function() {
-    return this.store.find('person', 1);
+    return store.find('person', 1);
   }
 });
 ```
@@ -88,7 +88,7 @@ a restaurant, you might have models like `Order`, `LineItem`, and
 Fetching orders becomes very easy:
 
 ```js
-this.store.find('order');
+store.find('order');
 ```
 
 Models define the type of data that will be provided by your server. For
@@ -135,7 +135,7 @@ have a model called `Person`. An individual record in your app might
 have a type of `Person` and an ID of `1` or `steve-buscemi`.
 
 ```js
-this.store.find('person', 1); // => { id: 1, name: 'steve-buscemi' }
+store.find('person', 1); // => { id: 1, name: 'steve-buscemi' }
 ```
 
 IDs are usually assigned by the server when you save them for the first

--- a/source/guides/models/pushing-records-into-the-store.md
+++ b/source/guides/models/pushing-records-into-the-store.md
@@ -39,14 +39,14 @@ App.Album = DS.Model.extend({
 
 App.ApplicationRoute = Ember.Route.extend({
   model: function() {
-    this.store.push('album', {
+    store.push('album', {
       id: 1,
       title: "Fewer Moving Parts",
       artist: "David Bazan",
       songCount: 10
     });
 
-    this.store.push('album', {
+    store.push('album', {
       id: 2,
       title: "Calgary b/w I Can't Make You Love Me/Nick Of Time",
       artist: "Bon Iver",

--- a/source/guides/models/the-fixture-adapter.md
+++ b/source/guides/models/the-fixture-adapter.md
@@ -54,7 +54,7 @@ application. For example:
 ```JavaScript
 App.DocumenterRoute = Ember.Route.extend({
   model: function() {
-    return this.store.find('documenter', 1); // returns a promise that will resolve
+    return store.find('documenter', 1); // returns a promise that will resolve
                                              // with the record representing Trek Glowacki
   }
 });

--- a/source/guides/models/working-with-records.md
+++ b/source/guides/models/working-with-records.md
@@ -6,7 +6,7 @@ objects. Making changes is as simple as setting the attribute you
 want to change:
 
 ```js
-var tyrion = this.store.find('person', 1);
+var tyrion = store.find('person', 1);
 // ...after the record has loaded
 tyrion.set('firstName', "Yollo");
 ```

--- a/source/guides/routing/defining-your-routes.md
+++ b/source/guides/routing/defining-your-routes.md
@@ -211,7 +211,7 @@ route handler might look like this:
 ```js
 App.PostsRoute = Ember.Route.extend({
   model: function() {
-    return this.store.find('posts');
+    return store.find('posts');
   }
 });
 ```
@@ -237,7 +237,7 @@ App.Router.map(function() {
 
 App.PostRoute = Ember.Route.extend({
   model: function(params) {
-    return this.store.find('post', params.post_id);
+    return store.find('post', params.post_id);
   }
 });
 ```
@@ -248,7 +248,7 @@ default behavior.
 For example, if the dynamic segment is `:post_id`, Ember.js is smart
 enough to know that it should use the model `App.Post` (with the ID
 provided in the URL). Specifically, unless you override `model`, the route will
-return `this.store.find('post', params.post_id)` automatically.
+return `store.find('post', params.post_id)` automatically.
 
 Not coincidentally, this is exactly what Ember Data expects. So if you
 use the Ember router with Ember Data, your dynamic segments will work

--- a/source/guides/routing/query-params.md
+++ b/source/guides/routing/query-params.md
@@ -174,7 +174,7 @@ App.ArticlesRoute = Ember.Route.extend({
 
     // params has format of { category: "someValueOrJustNull" },
     // which we can just forward to the server.
-    return this.store.findQuery('articles', params);
+    return store.findQuery('articles', params);
   }
 });
 


### PR DESCRIPTION
I believe that as of Ember > 1.3 that writing 'this.store' to access the store was update to just need to write 'store.'. I attempted to update the docs to reflect that change.
