### PR TITLE
Update test-helpers "fillIn" description

### DIFF
--- a/source/guides/testing/test-helpers.md
+++ b/source/guides/testing/test-helpers.md
@@ -29,7 +29,7 @@ your application, making it much easier to write deterministic tests.
 * `visit(url)`
   - Visits the given route and returns a promise that fulfills when all resulting
      async behavior is complete.
-* `fillIn(input_selector, text)`
+* `fillIn(selector, text)`
   - Fills in the selected input with the given text and returns a promise that
      fulfills when all resulting async behavior is complete.
 * `click(selector)`


### PR DESCRIPTION
The fillIn method signature had "input_selector" but this was out of accord with the other helper method signatures. Should just be "selector", or change the other input ones to use input_selector. I chose to unify them all to "selector".
