### PR TITLE
just missing a close paren on the setResolver setup on the unit test intro guide

### DIFF
--- a/source/guides/testing/unit.md
+++ b/source/guides/testing/unit.md
@@ -106,7 +106,7 @@ the resolver should be set like this:
 ***Make sure to replace "App" with your application's namespace in the following line***
 
 ```javascript
-setResolver(Ember.DefaultResolver.create({ namespace: App })
+setResolver(Ember.DefaultResolver.create({ namespace: App }))
 ```
 
 Otherwise, you would require the custom resolver and pass it to `setResolver`


### PR DESCRIPTION
Just was going through the unit testing setup from the guides and noticed after a copy paste that you were missing a close paren
