### PR TITLE
[DOC] Teardown test callback should reset application

### DIFF
--- a/source/guides/testing/integration.md
+++ b/source/guides/testing/integration.md
@@ -22,11 +22,11 @@ App.injectTestHelpers();
 
 With QUnit, `setup` and `teardown` functions can be defined in each test module's configuration. These functions are called for each test in the module. If you are using a framework other than QUnit, use the hook that is called before each individual test.
 
-Before each test, reset the application: `App.reset()` completely resets the state of the application.
+After each test, reset the application: `App.reset()` completely resets the state of the application.
 
 ```javascript
 module("Integration Tests", {
-  setup: function() {
+  teardown: function() {
     App.reset();
   }
 });

--- a/source/guides/testing/testing-user-interaction.md
+++ b/source/guides/testing/testing-user-interaction.md
@@ -18,7 +18,7 @@ without worrying about async behaviour your helper might trigger.
 
 ```javascript
 module('Integration: Transitions', {
-  setup: function() {
+  teardown: function() {
     App.reset();
   }
 });
@@ -61,7 +61,7 @@ when the restricted URL is visited.
 
 ```javascript
 module('Integration: Transitions', {
-  setup: function() {
+  teardown: function() {
     App.reset();
   }
 });


### PR DESCRIPTION
Relates to rpflorence/ember-qunit#29

The testing guide recommend to reset the application at the setup module callback, however ember-qunit `moduleFor` method does some job before the `setup` is executed which could originate exceptions if the application has not yet reseted.

If the application is reseted at `teardown`, it will be in a clean state when the test routine is initiated.
