### PR TITLE
update Kris Selden Github link

### DIFF
--- a/data/team.yml
+++ b/data/team.yml
@@ -14,7 +14,7 @@
   github: https://github.com/ebryn
   image: ebryn.jpg
 - name: Kris Selden
-  github: https://github.com/kselden
+  github: https://github.com/krisselden
   image: kselden.jpg
 - name: Stefan Penner
   github: https://github.com/stefanpenner


### PR DESCRIPTION
Clicked Kris Selden's Github link from team page tonight and noticed it went to an old Github account that is not up to date for Kris.

The original link, https://github.com/kselden, has a link and a text file pointing users to https://github.com/krisselden
