### PR TITLE
add link to web components spec

### DIFF
--- a/source/blog/2013-12-17-whats-coming-in-ember-in-2014.md
+++ b/source/blog/2013-12-17-whats-coming-in-ember-in-2014.md
@@ -255,10 +255,10 @@ candidates for slimming action.
 
 There are a number of open issues around distributing reusable,
 third-party components and libraries of components. Typically we defer
-to the Web Components spec, but there are areas where the spec does not
-currently provide any guidance. As we deal with them, we are keen to
-provide feedback to the Web Components spec authors with how we have
-chosen to solve the problems.
+to the [Web Components spec](http://www.w3.org/TR/components-intro/), but
+there are areas where the spec does not currently provide any guidance.
+As we deal with them, we are keen to provide feedback to the Web Components
+spec authors with how we have chosen to solve the problems.
 
 Other limitations are due to certain features not being available in
 older browsers, and we are working on polyfilling and working around

--- a/source/guides/components/index.md
+++ b/source/guides/components/index.md
@@ -14,11 +14,11 @@ idea that the W3C is currently working on the [Custom
 Elements](https://dvcs.w3.org/hg/webcomponents/raw-file/tip/spec/custom/index.html)
 spec.
 
-Ember's implementation of components hews as closely to the Web
-Components specification as possible. Once Custom Elements are widely
-available in browsers, you should be able to easily migrate your Ember
-components to the W3C standard and have them be usable by other
-frameworks.
+Ember's implementation of components hews as closely to the [Web
+Components specification](http://www.w3.org/TR/components-intro/) as possible.
+Once Custom Elements are widely available in browsers, you should be able to
+easily migrate your Ember components to the W3C standard and have them be
+usable by other frameworks.
 
 This is so important to us that we are working closely with the
 standards bodies to ensure our implementation of components matches the


### PR DESCRIPTION
While reading the web component info, I wanted to click through to read the spec, so I added links.

Also, adjusted formatting to keep lines under 80 chars, following the link addition.

![ember_js_-_components__introduction](https://cloud.githubusercontent.com/assets/514063/2843286/15f1e3be-d07d-11e3-9b9e-a9235d89e602.png)
![ember_js_-_what_s_coming_in_ember_in_2014](https://cloud.githubusercontent.com/assets/514063/2843288/1aa182f2-d07d-11e3-94ea-e69c93b780a0.png)
