### PR TITLE
Add missing title attribute in rendered HTML

### DIFF
--- a/source/guides/templates/binding-element-attributes.md
+++ b/source/guides/templates/binding-element-attributes.md
@@ -53,7 +53,7 @@ renders the following HTML:
 ```html
 <a id="ember239" class="ember-view" href="#/photos">Photos</a>
 
-<input id="ember257" class="ember-view ember-text-field" type="text">
+<input id="ember257" class="ember-view ember-text-field" type="text" title="Name">
 ```
 
 There are two ways to enable support for data attributes. One way would be to add an 
@@ -75,7 +75,7 @@ Now the same handlebars code above renders the following HTML:
 <a id="ember240" class="ember-view" href="#/photos" data-toggle="dropdown">Photos</a>
 
 <input id="ember259" class="ember-view ember-text-field" 
-       type="text" data-toggle="tooltip" data-placement="bottom">
+       type="text" data-toggle="tooltip" data-placement="bottom" title="Name">
 ```
 
 You can also automatically bind data attributes on the base view with the


### PR DESCRIPTION
The `data` attributes need special handling. The `title` attribute will get rendered automatically, right? Please correct me if I am wrong. Thanks!
