### PR TITLE
Change comma position for `action removeTodo` in `todo_controller.js`

### DIFF
--- a/source/guides/getting-started/deleting-todos.md
+++ b/source/guides/getting-started/deleting-todos.md
@@ -18,8 +18,8 @@ actions: {
     var todo = this.get('model');
     todo.deleteRecord();
     todo.save();
-  },
-}
+  }
+},
 // ... additional lines truncated for brevity ...
 ```
 


### PR DESCRIPTION
The current code

``` javascript
Todos.TodoController = Ember.ObjectController.extend({
actions: {
  // ... additional lines truncated for brevity ...
  removeTodo: function() {
    var todo = this.get('model');
    todo.deleteRecord();
    todo.save();
  },
}
// ... additional lines truncated for brevity ...
```

gives an `Uncaught Error: Could not resolve itemController: "todo"` and is unnecessarily confusing for beginners like myself. There is no other `action` at this stage so there is no need for a comma.

Whereas

``` javascript
Todos.TodoController = Ember.ObjectController.extend({
actions: {
  // ... additional lines truncated for brevity ...
  removeTodo: function() {
    var todo = this.get('model');
    todo.deleteRecord();
    todo.save();
  }
},
// ... additional lines truncated for brevity ...
```

works.

The full (working) `todo_controller.js` file looks like this:

``` javascript
Todos.TodoController = Ember.ObjectController.extend({
  actions: {
    editTodo: function() {
      this.set('isEditing', true);
    },
    acceptChanges: function() {
      this.set('isEditing', false);

      if (Ember.isEmpty(this.get('model.title'))) {
        this.send('removeTodo');
      } else {
        this.get('model').save();
      }
    },
    removeTodo: function() {
      var todo = this.get('model');
      todo.deleteRecord();
      todo.save();
    }
  },

  isEditing: false,

  isCompleted: function(key, value){
    var model = this.get('model');

    if (value === undefined) {
      // property being used as a getter
      return model.get('isCompleted');
    } else {
      // property being used as a setter
      model.set('isCompleted', value);
      model.save();
      return value;
    }
  }.property('model.isCompleted')
});
```
