### PR TITLE
Fix typo in documentation for yield helper

### DIFF
--- a/data/api.yml
+++ b/data/api.yml
@@ -9423,7 +9423,7 @@ classitems:
     ```html
     <label>
       First name: <input type="text" />
-    <label>
+    </label>
     ```
   itemtype: method
   name: yield


### PR DESCRIPTION
Added a closing tag for the label
