### PR TITLE
added download attr to download links on homepage

### DIFF
--- a/source/about.html.erb
+++ b/source/about.html.erb
@@ -28,15 +28,15 @@ title: "A framework for creating ambitious web applications"
 
 <div id="download">
   <div id="download-ember">
-    <a class="orange button" href="https://github.com/emberjs/starter-kit/archive/v1.5.1.zip">
+    <a class="orange button" href="https://github.com/emberjs/starter-kit/archive/v1.5.1.zip" download>
       Download the Starter Kit
     </a>
     <div class="info">
       1.5.1:
-      <a class="debug" href="http://builds.emberjs.com/tags/v1.5.1/ember.prod.js">production</a>
-      <a class="debug" href="http://builds.emberjs.com/tags/v1.5.1/ember.min.js">(min + gzip  71kb)</a> |
-      <a class="debug" href="http://builds.emberjs.com/tags/v1.5.1/ember.js">debug</a> |
-      <a href="http://builds.handlebarsjs.com.s3.amazonaws.com/handlebars-v1.3.0.js">Handlebars</a> |
+      <a class="debug" href="http://builds.emberjs.com/tags/v1.5.1/ember.prod.js" download>production</a>
+      <a class="debug" href="http://builds.emberjs.com/tags/v1.5.1/ember.min.js" download>(min + gzip  71kb)</a> |
+      <a class="debug" href="http://builds.emberjs.com/tags/v1.5.1/ember.js" download>debug</a> |
+      <a href="http://builds.handlebarsjs.com.s3.amazonaws.com/handlebars-v1.3.0.js" download>Handlebars</a> |
       <a class="debug" href="/guides/getting-ember">packages</a>
     </div>
   </div>


### PR DESCRIPTION
same as https://github.com/emberjs/website/pull/1490
according to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download the download attribute tells your browser to download the file, rather than opening in a separate tab/window, which then requires you to save.
