### PR TITLE
[website] [master] Resolver logging on debug page

### DIFF
--- a/source/guides/understanding-ember/debugging.md
+++ b/source/guides/understanding-ember/debugging.md
@@ -127,11 +127,11 @@ Ember.LOG_BINDINGS = true
 
 #### Turn on resolver resolution logging
 
-This option logs all the objects that Ember creates to the console. Custom objects
+This option logs all the lookups that are done to the console. Custom objects
 you've created yourself have a tick, and Ember generated ones don't.
 
-It's useful for understanding which objects Ember is generating and finding behind
-the scenes automatically.
+It's useful for understanding which objects Ember is finding when it does a lookup
+and which it is generating automatically for you.
 
 ```javascript
 App = Ember.Application.create({


### PR DESCRIPTION
Fixes that we don't mention the better logging that @rjackson added for default resolver.
Relates to: https://github.com/emberjs/ember.js/pull/4655
and also, was mentioning it in this discussion and realised it wasn't present in the debug section: http://discuss.emberjs.com/t/nested-resources-and-dynamic-segments/5111/4
