### PR TITLE
Use this.controller instead of this.controllerFor

### DIFF
--- a/source/guides/routing/preventing-and-retrying-transitions.md
+++ b/source/guides/routing/preventing-and-retrying-transitions.md
@@ -23,7 +23,7 @@ Here's one way this situation could be handled:
 App.FormRoute = Ember.Route.extend({
   actions: {
     willTransition: function(transition) {
-      if (this.controllerFor('form').get('userHasEnteredData') &&
+      if (this.controller.get('userHasEnteredData') &&
           !confirm("Are you sure you want to abandon progress?")) {
         transition.abort();
       } else {


### PR DESCRIPTION
I greped the website repo for "controllerFor("  and this was the only case where I could find a controllerFor that was used to reference a controller with the same name as the Route.  This is a fix for emberjs/website#1509.
