### PR TITLE
Update toggle-todo-editing-state.md

### DIFF
--- a/source/guides/getting-started/toggle-todo-editing-state.md
+++ b/source/guides/getting-started/toggle-todo-editing-state.md
@@ -23,14 +23,14 @@ this todo's controller. Finally, we wrap our todo in a Handlebars `{{if}}` helpe
 Inside `js/controllers/todo_controller.js` we'll implement the matching logic for this template behavior:
 
 ```javascript
-// ... additional lines truncated for brevity ...
-actions: {
-   editTodo: function() {
-     this.set('isEditing', true);
-   }
- },
+Todos.TodoController = Ember.ObjectController.extend({
+  actions: {
+    editTodo: function() {
+      this.set('isEditing', true);
+    }
+  },
  
-isEditing: false,
+  isEditing: false,
 
 // ... additional lines truncated for brevity ...
 ```


### PR DESCRIPTION
Adding more details to prevent misplacing the new code. Since "isEditing: false" is followed by a comma, this piece of code must be added before "isCompleted:...".
- corrected indentation for the code to be added (was odd number of whitespaces).
  Best. Paul
