### PR TITLE
Use Ember.Handlebars in helpers guide

### DIFF
--- a/source/guides/templates/writing-helpers.md
+++ b/source/guides/templates/writing-helpers.md
@@ -5,7 +5,7 @@ For example, imagine you are frequently wrapping certain values in a `<span>` ta
 ```javascript
 Ember.Handlebars.helper('highlight', function(value, options) {
   var escaped = Handlebars.Utils.escapeExpression(value);
-  return new Handlebars.SafeString('<span class="highlight">' + escaped + '</span>');
+  return new Ember.Handlebars.SafeString('<span class="highlight">' + escaped + '</span>');
 });
 ```
 


### PR DESCRIPTION
This is pretty nit picky, but if JSHint is configured out of the box with your build tools to accept Ember as a global, this save you from having JShint throw "Handlebars in undefined" errors if you copy the example directly from the guide.
