### PR TITLE
fix javascript syntax for action bubbling example

### DIFF
--- a/source/guides/templates/actions.md
+++ b/source/guides/templates/actions.md
@@ -88,6 +88,7 @@ App.PostRoute = Ember.Route.extend({
       // ...
       if (actionShouldAlsoBeTriggeredOnParentRoute) {
         return true;
+      }
     }
   }
 });


### PR DESCRIPTION
There is a missing closing bracket `}` in the javascript example for action bubbling.
