### PR TITLE
Fixed callout image surfacing on search

### DIFF
--- a/source/stylesheets/about.css.scss
+++ b/source/stylesheets/about.css.scss
@@ -3,7 +3,7 @@
 $hidpi-min-pixel-ratio: 1.3 !default;
 
 .callout-image {
-  z-index: 99999;
+  z-index: 99998;
   position: absolute;
   left: 20px;
   text-decoration: none !important;


### PR DESCRIPTION
The callout image for the new jobs board was z-indexed above the
search modal background. I sent it down a notch.

![:'(](https://photos-3.dropbox.com/t/0/AABTHSM8TQqEdArEvvJ6T3VLBNwDtHr30ipFNU0GxvVCfw/12/20720/png/1024x768/3/1400295600/0/2/Screenshot%202014-05-16%2021.40.43.png/e7Ysdc51eohUj6Pc-f9y_8hNeURpsxsZhoKIptaDkuw)
