### PR TITLE
API Sidebar Links Are Too Bold

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -244,7 +244,6 @@ p {
           display: block;
           text-transform: none;
           color: #d84a32;
-          font-weight: normal;
           font-size: 13px;
           &:hover {
             background-color: #f2d1cb;


### PR DESCRIPTION
After the last push the API links got super bold. This appears to fix that.

**Before:**
![screen shot 2014-05-21 at 10 29 12 am](https://cloud.githubusercontent.com/assets/183799/3044231/d37c1984-e10f-11e3-8a26-ab50f18641f4.png)

**After:**
![screen shot 2014-05-21 at 10 28 57 am](https://cloud.githubusercontent.com/assets/183799/3044240/e38d8038-e10f-11e3-9c92-183444ce3c07.png)
