### PR TITLE
.fail() -> .catch() because fail is deprecated

### DIFF
--- a/source/guides/models/persisting-records.md
+++ b/source/guides/models/persisting-records.md
@@ -79,7 +79,7 @@ example showing how to retry persisting:
 ```javascript
 function retry(callback, nTimes) {
   // if the promise fails
-  return callback().fail(function(reason) {
+  return callback().catch(function(reason) {
     // if we haven't hit the retry limit
     if (nTimes-- > 0) {
       // retry again with the result of calling the retry callback


### PR DESCRIPTION
See https://github.com/emberjs/ember.js/blob/master/packages/ember-runtime/lib/mixins/deferred.js#L40-L43

Thx to locks from IRC.
