### PR TITLE
Stretch background width to fit for wide screens

### DIFF
--- a/source/stylesheets/about.css.scss
+++ b/source/stylesheets/about.css.scss
@@ -17,6 +17,9 @@ body.index, body.about {
   background: no-repeat top center #faf4f1;
   background-image: url('/images/background-shades.png');
   background-image: url('/images/background-shades.svg'), none; // See: http://css-tricks.com/svg-fallbacks/
+  @media screen and (min-width: 2000px) { // Stretch background width when wider than source image
+    background-size: 100% auto;
+  }
 
   .feature p {
     margin-top: 1.5em;


### PR DESCRIPTION
This pull request ensures that the background image found on the Home/About section fills wide screens (those wider than the 2000px source image).

On screens wider than 2000px, the Home/About page currently looks like this (notice the blank areas at the left and right sides of the window):
![screen shot 2014-05-23 at 17 14 34](https://cloud.githubusercontent.com/assets/250934/3071973/b6b970a6-e2bf-11e3-9884-fc9502ba638d.png)

With the added media query and background-size property found in this pull request, the background image stretches horizontally to fill the width of the screen as seen here:
![screen shot 2014-05-23 at 17 14 21](https://cloud.githubusercontent.com/assets/250934/3071999/fb019612-e2bf-11e3-9a87-40c973514d4c.png)

The layout is unaffected for browser windows under 2000px in width.
