### PR TITLE
Update focusing_a_textfield_after_its_been_inserted.md

### DIFF
--- a/source/guides/cookbook/user_interface_and_interaction/focusing_a_textfield_after_its_been_inserted.md
+++ b/source/guides/cookbook/user_interface_and_interaction/focusing_a_textfield_after_its_been_inserted.md
@@ -24,6 +24,20 @@ Focus Input component!
 {{focus-input}}
 ```
 
+### Cleaner solution
+Extend the textfield to allow HTML Autofocus
+```javascript
+Ember.TextField.reopen({
+  attributeBindings: ['autofocus']
+});
+```
+This will allow you to add the autofocus attribute to the regular input
+```handlebars
+{{input value=someField type="text" placeholder="Your Name here" autofocus="autofocus"}}
+```
+** Please note that autofocus is not supported in Internet Explorer 9 and lower. **
+
+
 ### Discussion
 Custom components provide a way to extend native HTML elements with new behavior
 like autofocusing.


### PR DESCRIPTION
Added a cleaner approach to handling autofocus which should be used as a property of the text field. 
Defining a component for autofocus is an overkill.
