### PR TITLE
Added clarification for getting correct ember-data version via bower

### DIFF
--- a/source/guides/getting-started/obtaining-emberjs-and-dependencies.md
+++ b/source/guides/getting-started/obtaining-emberjs-and-dependencies.md
@@ -19,7 +19,7 @@ For this example, all of these resources should be stored in the folder `js/libs
 
 Reload your web browser to ensure that all files have been referenced correctly and no errors occur.
 
-If you are using a package manager, such as [bower](http://bower.io), make sure to checkout the [Getting Ember](/guides/getting-ember) guide for info on other ways to get Ember.js (this guide is dependant on Ember v1.0 or greater so please be sure to use the latest beta).
+If you are using a package manager, such as [bower](http://bower.io), make sure to checkout the [Getting Ember](/guides/getting-ember) guide for info on other ways to get Ember.js (this guide is dependant on ember-data v1.0 or greater so please be sure to use the latest beta).
 
 ### Live Preview
 <a class="jsbin-embed" href="http://jsbin.com/ijefig/2/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>


### PR DESCRIPTION
Added clarification for getting correct ember-data version via bower on line 22 in website/source/guides/getting-started/obtaining-emberjs-and-dependencies.md
