### PR TITLE
Fix for visual sidebar glitch on builds page

### DIFF
--- a/source/builds/index.html.erb
+++ b/source/builds/index.html.erb
@@ -24,9 +24,7 @@ title: Builds
     </ol>
   </div>
 
-  <div id="content" class="has-sidebar">
-    {{outlet}}
-  </div>
+  {{outlet}}
 </script>
 
 <script type="text/x-handlebars" data-template-name="index">


### PR DESCRIPTION
There are two divs on this page using the same id of "content"

<div id="content-wrapper">
    <div id="content">
        <!--outlet-->
        <div id="sidebar"></div>
        <div id="content"></div>
        <!--/outlet-->
    </div>
</div>


This causes a CSS glitch on the sidebar menu. Referencing the other pages it seems this external "content" div is not needed and removing fixes the CSS glitch.

![builds_glitch](https://cloud.githubusercontent.com/assets/1452653/3350211/33591b78-f997-11e3-8f0a-10f1cf81c976.png)
