### PR TITLE
Second fix for sidebar glitch and page artifact

### DIFF
--- a/source/builds/index.html.erb
+++ b/source/builds/index.html.erb
@@ -24,7 +24,9 @@ title: Builds
     </ol>
   </div>
 
-  {{outlet}}
+  <div id="subcontent" class="has-sidebar">
+     {{outlet}}
+  </div>
 </script>
 
 <script type="text/x-handlebars" data-template-name="index">

--- a/source/stylesheets/builds.css.scss
+++ b/source/stylesheets/builds.css.scss
@@ -1,6 +1,20 @@
 @import "compass";
 @import "mixins/hidpi";
 
+// the builds page is an ember app inserted into the master layout, replicate styling
+// content -> builds page ( sidebar / subcontent ) 
+#subcontent {
+  @extend #content;
+}
+
+// styles applied to ul/ol under #content are not meant for #sidebar styling
+// this needs to be reset on builds page as the sidebar is nested inside the content
+#content #sidebar {
+  ul, ol {
+    margin: 0;
+  }
+}
+
 #builds-application {
   #sidebar {
     $sidebar-width: 140px;


### PR DESCRIPTION
This fix has been tested on `Google Chrome Version 34.0.1847.137` / `Ubuntu 12.04`

**synopsis:** The CSS and page structure were not designed to have a `sidebar` inside a `content`, a `sidebar` should be at the same level as a `content`. In the case of the builds page (which renders an ember app), this caused a situation where the page structure was: 

```
#content
    #sidebar
    #content
```

This commit fixes the duplicate ID usage and the CSS glitch for the sidebar.

**note:** the testing has been done using middleman server
**note:** the `before` pictures represents the state of the page prior to the last glitchy commit which introduced an additional bug, the `after` represents the state after all the new changes

**Before / After**

![1_compare](https://cloud.githubusercontent.com/assets/1452653/3422549/39951da6-ff4c-11e3-8ae2-e0faa9af2902.jpg)
![2_compare](https://cloud.githubusercontent.com/assets/1452653/3422550/3c80d0a0-ff4c-11e3-9cd5-8e540a48754e.jpg)
![3_compare](https://cloud.githubusercontent.com/assets/1452653/3422551/3ef62a42-ff4c-11e3-9892-c8ff166d8ae8.jpg)
![4_compare](https://cloud.githubusercontent.com/assets/1452653/3422552/435cdb80-ff4c-11e3-8556-d3d7314374b6.jpg)
![5_compare](https://cloud.githubusercontent.com/assets/1452653/3422553/46a19d8a-ff4c-11e3-8d00-3d191fe6fd83.jpg)
