### PR TITLE
Pin jsbin version number so that it shows the correct thing

### DIFF
--- a/source/guides/testing/test-helpers.md
+++ b/source/guides/testing/test-helpers.md
@@ -161,6 +161,7 @@ Ember.Test.registerAsyncHelper('addContact',
 
 #### Example
 
-Here is an example of using both `registerHelper` and `registerAsyncHelper`.
+Here is an example using both `registerHelper` and
+`registerAsyncHelper`.
 
-<a class="jsbin-embed" href="http://jsbin.com/jesuyeri/embed?output">Custom Test Helpers</a>
+<a class="jsbin-embed" href="http://jsbin.com/jesuyeri/20/embed?output">Custom Test Helpers</a>


### PR DESCRIPTION
The embedded jsbin was not pinned to a version, so it wasn't actually pointing at a jsbin that used both `registerHelper` and `registerAsyncHelper`.

This changes it to point at a pinned version of the jsbin (and I edited the jsbin to use both helpers, as the guide's text states).

Also, fwiw, I am able to edit the jsbin in question there. Perhaps it was mine originally, but again, since it is not pinned, that means I can edit it and make the embedded version on the ember guides say anything I want, which seems bad.
