### PR TITLE
Replaces `filterProperty` with `filterBy` in query-params.md

### DIFF
--- a/source/guides/routing/query-params.md
+++ b/source/guides/routing/query-params.md
@@ -52,7 +52,7 @@ App.ArticlesController = Ember.ArrayController.extend({
     var articles = this.get('model');
 
     if (category) {
-      return articles.filterProperty('category', category);
+      return articles.filterBy('category', category);
     } else {
       return articles;
     }


### PR DESCRIPTION
Replaces `filterProperty` with `filterBy` in query-params.md as `filterProperty` is deprecated
