### PR TITLE
remove 'removeTodo' from the copy n paste code

### DIFF
--- a/source/guides/getting-started/accepting-edits.md
+++ b/source/guides/getting-started/accepting-edits.md
@@ -59,11 +59,6 @@ actions: {
     } else {
       this.get('model').save();
     }
-  },
-  removeTodo: function () {
-    var todo = this.get('model');
-    todo.deleteRecord();
-    todo.save();
   }
 },
 // ... additional lines truncated for brevity ...


### PR DESCRIPTION
I could be wrong but... I think at this stage in the tutorial we don't yet have a removeTodo function. The next page tells us to add it.
