### PR TITLE
replace everyProperty with isEvery

### DIFF
--- a/source/guides/getting-started/toggle-all-todos.md
+++ b/source/guides/getting-started/toggle-all-todos.md
@@ -6,7 +6,7 @@ To implement this behavior update the `allAreDone` property in `js/controllers/t
 // ... additional lines truncated for brevity ...
 allAreDone: function(key, value) {
   if (value === undefined) {
-    return !!this.get('length') && this.everyProperty('isCompleted', true);
+    return !!this.get('length') && this.isEvery('isCompleted', true);
   } else {
     this.setEach('isCompleted', value);
     this.invoke('save');


### PR DESCRIPTION
`everyProperty` is referred on page 'http://emberjs.com/guides/getting-started/toggle-all-todos/'.
However `everyProperty` is already depreciated and should be replaced by `isEvery`.
