### PR TITLE
Fixed grammatical issue on DS.PromiseObject page

### DIFF
--- a/data/data_api.yml
+++ b/data/data_api.yml
@@ -1388,7 +1388,7 @@ classes:
     line: 1638
     description: |-
       A `PromiseObject` is an object that acts like both an `Ember.Object`
-      and a promise. When the promise is resolved the the resulting value
+      and a promise. When the promise is resolved, then the resulting value
       will be set to the `PromiseObject`'s `content` property. This makes
       it easy to create data bindings with the `PromiseObject` that will
       be updated when the promise resolves.


### PR DESCRIPTION
There is a typo that I corrected on the DS.PromiseObject page.
