### PR TITLE
Fix typo

### DIFF
--- a/source/guides/testing/testing-components.md
+++ b/source/guides/testing/testing-components.md
@@ -159,7 +159,7 @@ App.MyFooComponent = Ember.Component.extend({
   // layout supercedes template when rendered
   layout: Ember.Handlebars.compile(
     "<h2>I'm a little {{noun}}</h2><br/>" +
-    "<button {{action 'clickFoo'}}>Click Me</button>"
+    "<button {{action 'changeName'}}>Click Me</button>"
   ),
 
   noun: 'teapot',


### PR DESCRIPTION
called a non existent action in `Components with built in layout` example code
