### PR TITLE
Document usage of link-to helper in inline form

### DIFF
--- a/source/guides/templates/links.md
+++ b/source/guides/templates/links.md
@@ -97,6 +97,24 @@ In the above example, the model hook for `PhotoRoute` will run with `params.phot
 `CommentRoute` _won't_ run since you supplied a model object for the `comment` segment. The comment's id will
 populate the url according to `CommentRoute`'s `serialize` hook.
 
+### Using link-to as an inline helper
+
+In addition to being used as a block expression, the `link-to` helper
+can also be used in inline form by specifying the link text as the first
+argument to the helper:
+
+```handlebars
+A link in {{#link-to 'index'}}Block Expression Form{{/link-to}},
+and a link in {{link-to 'Inline Form' 'index'}}.
+```
+
+The output of the above would be:
+
+```html
+A link in <a href='/'>Block Expression Form</a>,
+and a link in <a href='/'>Inline Form</a>.
+```
+
 ### Adding additional attributes on a link
 
 When generating a link you might want to set additional attributes for it. You can do this with additional


### PR DESCRIPTION
The [Adding Attributes on a Link](http://emberjs.com/guides/templates/links/#toc_adding-additional-attributes-on-a-link) section of the guides uses the `link-to` helper in inline form, but everywhere else in the guide to links, the link-to helper is used in block from (`{{#link-to ...}}  link text {{/link-to}}`).

This documents the use of `link-to` as an inline helper: `{{link-to 'link text' 'routeName'}}`
