### PR TITLE
Documentation fix, (find returns promises)

### DIFF
--- a/data/data_api.yml
+++ b/data/data_api.yml
@@ -1280,14 +1280,16 @@ classes:
       for a specific id, use `DS.Store`'s `find()` method:
 
       ```javascript
-      var person = store.find('person', 123);
+      store.find('person', 123).then(function (person) {
+      });
       ```
 
       If your application has multiple `DS.Store` instances (an unusual case), you can
       specify which store should be used:
 
       ```javascript
-      var person = store.find('person', 123);
+      store.find('person', 123).then(function (person) {
+      });
       ```
 
       By default, the store will talk to your backend using a standard

--- a/source/guides/models/creating-and-deleting-records.md
+++ b/source/guides/models/creating-and-deleting-records.md
@@ -48,12 +48,14 @@ it from `all()` queries on the `store`. The deletion can then be persisted using
 Alternatively, you can use the `destroyRecord` method to delete and persist at the same time.
 
 ```js
-var post = store.find('post', 1);
-post.deleteRecord();
-post.get('isDeleted'); // => true
-post.save(); // => DELETE to /posts/1
+store.find('post', 1).then(function (post) {
+  post.deleteRecord();
+  post.get('isDeleted'); // => true
+  post.save(); // => DELETE to /posts/1
+});
 
 // OR
-var post = store.find('post', 2);
-post.destroyRecord(); // => DELETE to /posts/2
+store.find('post', 2).then(function (post) {
+  post.destroyRecord(); // => DELETE to /posts/2
+});
 ```

--- a/source/guides/models/persisting-records.md
+++ b/source/guides/models/persisting-records.md
@@ -13,13 +13,13 @@ post.save(); // => POST to '/posts'
 ```
 
 ```javascript
-var post = store.find('post', 1);
+store.find('post', 1).then(function (post) {
+  post.get('title') // => "Rails is Omakase"
 
-post.get('title') // => "Rails is Omakase"
+  post.set('title', 'A new post');
 
-post.set('title', 'A new post');
-
-post.save(); // => PUT to '/posts/1'
+  post.save(); // => PUT to '/posts/1'
+});
 ```
 
 ### Promises

--- a/source/guides/models/the-rest-adapter.md
+++ b/source/guides/models/the-rest-adapter.md
@@ -12,7 +12,8 @@ with based on the name of the model. For example, if you ask for a
 `Post` by ID:
 
 ```js
-var post = store.find('post', 1);
+store.find('post', 1).then(function (post) {
+});
 ```
 
 The REST adapter will automatically send a `GET` request to `/posts/1`.


### PR DESCRIPTION
I tried to find all occurences when find was used as if it returned a post object and not a promise, but there might be some ones left.

Maybe the lines that look like this: 

``` js
store.find('post', 1).then(function (post) {
});
```

Would benefit from some more explanation of the fact that it returns a promise object, but I'm not sure how one would do that.
