### PR TITLE
Fix height of edit icon

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -1485,7 +1485,7 @@ a.edit-page {
   color: #444;
   margin: 0;
   width: 24px;
-  height: 16px;
+  height: 18px;
   display: inline-block;
   float: right;
   overflow: hidden;


### PR DESCRIPTION
Should at least match the `font-size`.
