### PR TITLE
[GUIDE] Add reference to using the ember-data-model-maker

### DIFF
--- a/source/guides/models/connecting-to-an-http-server.md
+++ b/source/guides/models/connecting-to-an-http-server.md
@@ -90,6 +90,8 @@ return the JSON in the following format:
 }
 ```
 
+To quickly prototype a model and see the expected JSON, try using the [Ember Data Model Maker](http://andycrum.github.io/ember-data-model-maker/) by Andy Crum.
+
 ### Customizing the Adapter
 
 To customize the REST adapter, define a subclass of `DS.RESTAdapter` and


### PR DESCRIPTION
Mention http://andycrum.github.io/ember-data-model-maker/ as an option to prototype a model.
