### PR TITLE
Absolute URLs without the emberjs domain

### DIFF
--- a/source/blog/2013-03-22-stabilizing-ember-data.md
+++ b/source/blog/2013-03-22-stabilizing-ember-data.md
@@ -211,7 +211,7 @@ You can see our progress on Ember Data's master branch, by looking at
 [2]: https://github.com/emberjs/data/blob/master/packages/ember-data/lib/adapters/basic_adapter.js
 
 Over the next few weeks, we will be writing documentation that will be
-available in the [Ember.js Guides](http://emberjs.com/guides/). Once a
+available in the [Ember.js Guides](/guides/). Once a
 few people have had the opportunity to use the Basic Adapter and
 sanity-check our work, we will start cutting beta releases of Ember
 Data. We think that this will be a lot easier for new developers than "make

--- a/source/blog/2013-04-21-ember-1-0-rc3.markdown
+++ b/source/blog/2013-04-21-ember-1-0-rc3.markdown
@@ -51,7 +51,7 @@ will be our official library.
 ### Ember Builds
 
 Each successful [CI](https://travis-ci.org/emberjs/ember.js) run now publishes its build results to
-[http://emberjs.com/builds](http://emberjs.com/builds). This should make
+[http://emberjs.com/builds](/builds). This should make
 it much simpler to reference and use the [the latest ember build](http://builds.emberjs.com/canary/ember.js).
 
 Thanks to Stanley Stuart, Luke Melia, Erik Bryn and others for getting this set up.

--- a/source/blog/2013-05-03-ember-data-progress-update.md
+++ b/source/blog/2013-05-03-ember-data-progress-update.md
@@ -5,7 +5,7 @@ tags: Ember Data
 ---
 
 Just over a month ago, we told you about our [plans for stabilizing Ember
-Data](http://emberjs.com/blog/2013/03/22/stabilizing-ember-data.html). I'd like
+Data](/blog/2013/03/22/stabilizing-ember-data.html). I'd like
 to give you an update on the status of those efforts.
 
 First, though, I'd like to thank everyone who has been contributing to Ember

--- a/source/blog/2013-07-25-ember-1-0-rc6-1-rc5-1-rc4-1-rc3-1-rc2-1-and-rc1-1-released.md
+++ b/source/blog/2013-07-25-ember-1-0-rc6-1-rc5-1-rc4-1-rc3-1-rc2-1-and-rc1-1-released.md
@@ -8,7 +8,7 @@ Because many Ember.js apps allow users to interact with private data, we
 take security issues very seriously.
 
 In fact, we're one of the few JavaScript projects that has a
-[clearly outlined security policy](http://emberjs.com/security/) and a
+[clearly outlined security policy](/security/) and a
 [low-traffic mailing list exclusively for security
 announcements](https://groups.google.com/forum/#!forum/ember-security).
 
@@ -47,7 +47,7 @@ traditional server-side framework.
 That being said, we will remain vigilant in ensuring that even small
 security issues are taken care of properly. If you discover what you
 believe may be a security issue in Ember.js, we ask that you follow
-our [responsible disclosure policy](http://emberjs.com/security/).
+our [responsible disclosure policy](/security/).
 
 Lastly, thanks to Yehuda Katz, Stefan Penner and Kris Selden, who
 donated their valuable time to reviewing the patch, auditing other code

--- a/source/blog/2013-08-31-ember-1-0-released.md
+++ b/source/blog/2013-08-31-ember-1-0-released.md
@@ -67,8 +67,8 @@ in his recently completed guides:
 * [Asynchronous Routing][1]
 * [Preventing and Retrying Transitions][2]
 
-[1]: http://emberjs.com/guides/routing/asynchronous-routing/
-[2]: http://emberjs.com/guides/routing/preventing-and-retrying-transitions/
+[1]: /guides/routing/asynchronous-routing/
+[2]: /guides/routing/preventing-and-retrying-transitions/
 
 ### Preparation for Modules
 
@@ -152,8 +152,8 @@ For Ember 1.0, Trek led a documentation audit of all of the API documentation in
 the entire codebase, which led to 1,700 new lines of documentation, and an
 across-the-board freshening for new idioms and best practices.
 
-[9]: http://emberjs.com/api
-[10]: http://emberjs.com/guides
+[9]: /api
+[10]: /guides
 
 ### Ember Data 1.0 Beta 1
 

--- a/source/blog/2013-09-04-ember-data-1-0-beta-2-released.md
+++ b/source/blog/2013-09-04-ember-data-1-0-beta-2-released.md
@@ -23,4 +23,4 @@ Nick Ragaz, Ricardo Mendes, Ryunosuke SATO, Sylvain Mina, and ssured
 
 Thanks to everyone who has been porting adapters to Ember Data 1.0!
 
-[1]: http://emberjs.com/builds/#/beta/latest
+[1]: /builds/#/beta/latest

--- a/source/blog/2013-09-06-new-ember-release-process.markdown
+++ b/source/blog/2013-09-06-new-ember-release-process.markdown
@@ -26,7 +26,7 @@ The Ember.js 1.x Schedule:
 All builds will be available on the new [Ember.js Builds][1] section of the
 Ember website.
 
-[1]: http://emberjs.com/builds/
+[1]: /builds/
 
 All new features will start out on master, behind a feature flag. Canary
 and `latest` builds will ship with all experimental features, enable-able
@@ -65,7 +65,7 @@ the build on any browser we support.
 Every time the build passes across all browsers, the `ember-latest` build
 will be updated. This is the most bleeding of bleeding-edge builds.
 
-You can get all of the latest builds at http://emberjs.com/builds/#/canary/latest.
+You can get all of the latest builds at [http://emberjs.com/builds/#/canary/latest](/builds/#/canary/latest).
 
 ### Canary Builds
 
@@ -115,7 +115,7 @@ features that looked ready originally but which aren't going to make the
 cut for the next stable build.
 
 You can get the latest successful build off of the beta branch at
-http://emberjs.com/builds/#/beta/latest.
+[http://emberjs.com/builds/#/beta/latest](/builds/#/beta/latest).
 
 ### Release Build
 

--- a/source/blog/2013-12-04-ember-1-2-0-and-ember-1-3-0-beta-released.md
+++ b/source/blog/2013-12-04-ember-1-2-0-and-ember-1-3-0-beta-released.md
@@ -72,7 +72,7 @@ hours of their free time into automating the infrastructure around the
 release process.
 
 As usual, you can always find the latest stable, beta, and canary
-releases at [emberjs.com/builds](http://emberjs.com/builds).
+releases at [emberjs.com/builds](/builds).
 
 While you're there, check out the new illustrations, courtesy of [Leah
 Silber](https://twitter.com/wifelette) and [Design

--- a/source/blog/2014-01-14-ember-security-releases.md
+++ b/source/blog/2014-01-14-ember-security-releases.md
@@ -7,7 +7,7 @@ tags: Releases, Security
 Because developers trust Ember.js to handle sensitive customer data in
 production, we take the security of the project extremely seriously.  In
 fact, we're one of the few JavaScript projects that has a [clearly
-outlined security policy](http://emberjs.com/security/) and a
+outlined security policy](/security/) and a
 [low-traffic mailing list exclusively for security
 announcements](https://groups.google.com/forum/#!forum/ember-security).
 
@@ -49,7 +49,7 @@ thank you.
 
 If you discover what you believe may be a security issue in Ember.js, we
 ask that you follow our [responsible disclosure
-policy](http://emberjs.com/security/).
+policy](/security/).
 
 If you are using Ember.js in production, please consider subscribing to
 our [security announcements mailing
@@ -58,6 +58,6 @@ extremely low-traffic and only contains announcements such as these.
 
 ## Additional Reading
 
-* [Ember.js Security Policy Announcement](http://emberjs.com/blog/2013/04/05/announcing-the-ember-security-policy.html)
-* [Ember.js Security Policy](http://emberjs.com/security/)
+* [Ember.js Security Policy Announcement](/blog/2013/04/05/announcing-the-ember-security-policy.html)
+* [Ember.js Security Policy](/security/)
 * [Ember.js Security Group](https://groups.google.com/forum/#!forum/ember-security)

--- a/source/blog/2014-02-07-ember-security-releases.md
+++ b/source/blog/2014-02-07-ember-security-releases.md
@@ -7,7 +7,7 @@ tags: Releases, Security
 Because developers trust Ember.js to handle sensitive customer data in
 production, we take the security of the project extremely seriously.  In
 fact, we're one of the few JavaScript projects that has a [clearly
-outlined security policy](http://emberjs.com/security/) and a
+outlined security policy](/security/) and a
 [low-traffic mailing list exclusively for security
 announcements](https://groups.google.com/forum/#!forum/ember-security).
 
@@ -34,7 +34,7 @@ and the advisory.
 
 If you discover what you believe may be a security issue in Ember.js, we
 ask that you follow our [responsible disclosure
-policy](http://emberjs.com/security/).
+policy](/security/).
 
 If you are using Ember.js in production, please consider subscribing to
 our [security announcements mailing
@@ -43,6 +43,6 @@ extremely low-traffic and only contains announcements such as these.
 
 ## Additional Reading
 
-* [Ember.js Security Policy Announcement](http://emberjs.com/blog/2013/04/05/announcing-the-ember-security-policy.html)
-* [Ember.js Security Policy](http://emberjs.com/security/)
+* [Ember.js Security Policy Announcement](/blog/2013/04/05/announcing-the-ember-security-policy.html)
+* [Ember.js Security Policy](/security/)
 * [Ember.js Security Group](https://groups.google.com/forum/#!forum/ember-security)

--- a/source/blog/2014-03-18-the-road-to-ember-data-1-0.md
+++ b/source/blog/2014-03-18-the-road-to-ember-data-1-0.md
@@ -207,7 +207,7 @@ Once the issues we've outlined above are complete, we'll be releasing a 1.0 of E
 
 For example, if Ember.js 1.7 is the current stable version at the time of Ember Data's first stable release, it will be Ember Data 1.7.
 
-As with Ember.js, we intend Ember Data to follow the same [Chrome-inspired six-week release process](http://emberjs.com/blog/2013/09/06/new-ember-release-process.html). That release process has paid dividends in terms of predictability and momentum, and the feedback has been overwhelmingly positive. Importantly, having separate stable, beta and canary releases also allows us to clearly [communicate which features are stable](http://emberjs.com/builds/#/beta) and ready for production, and which are still being worked on.
+As with Ember.js, we intend Ember Data to follow the same [Chrome-inspired six-week release process](/blog/2013/09/06/new-ember-release-process.html). That release process has paid dividends in terms of predictability and momentum, and the feedback has been overwhelmingly positive. Importantly, having separate stable, beta and canary releases also allows us to clearly [communicate which features are stable](http://emberjs.com/builds/#/beta) and ready for production, and which are still being worked on.
 
 ## A Framework for Data
 

--- a/source/blog/2014-06-07-core-team-meeting-minutes-2014-06-06.md
+++ b/source/blog/2014-06-07-core-team-meeting-minutes-2014-06-06.md
@@ -77,7 +77,7 @@ should be sure to thank [Brian Donovan](https://twitter.com/eventualbuddha) and 
 #### Query Parameters
 When we released 1.0 we pledged to follow [Semantic Versioning](http://semver.org/) and not break public-facing API until 2.0. Because of this, we're hesitant to release extensions to Ember.js's
 public API until we feel confident supporting it for the foreseeable future. We've taken several stabs
-at adding query parameters to our router. People have been very happy with the [latest incarnation](http://emberjs.com/guides/routing/query-params/) available on canary builds, but there have been a few
+at adding query parameters to our router. People have been very happy with the [latest incarnation](/guides/routing/query-params/) available on canary builds, but there have been a few
 edge cases we wanted to address. The last of these (providing a hook for overriding parameter resets
 on route exit) is about to land and we should hopefully include query parameters in the first 1.7.beta release.
 

--- a/source/blog/2014-06-28-core-team-meeting-minutes-2014-06-13.md
+++ b/source/blog/2014-06-28-core-team-meeting-minutes-2014-06-13.md
@@ -34,7 +34,7 @@ core team member and let them know!
 
 ### Query parameters
 This has been [enabled by default](https://github.com/emberjs/ember.js/commit/4130e556132eabad11aa619092c8ea840ba4957b)
-in beta and nightly builds. Check out [Query Parameters Guide](http://emberjs.com/guides/routing/query-params/)
+in beta and nightly builds. Check out [Query Parameters Guide](/guides/routing/query-params/)
 for usage details.
 
 ### Keeping the train moving

--- a/source/guides/controllers/dependencies-between-controllers.md
+++ b/source/guides/controllers/dependencies-between-controllers.md
@@ -62,4 +62,4 @@ App.AnotherController = Ember.Controller.extend({
 For more information about dependecy injection and `needs` in Ember.js,
 see the [dependency injection guide](/guides/understanding-ember/dependency-injection-and-service-lookup).
 For more information about aliases, see the API docs for
-[aliased properties](http://emberjs.com/api/#method_computed_alias).
+[aliased properties](/api/#method_computed_alias).

--- a/source/guides/cookbook/contributing/understanding_the_cookbook_format.md
+++ b/source/guides/cookbook/contributing/understanding_the_cookbook_format.md
@@ -6,7 +6,7 @@ how your contribution should be formatted.
 Cookbook-style guides contain recipes that guide a beginning programmer to a deeper knowledge of the subject
 by answering specific, "how-to" style questions. Cookbook recipes address more topics than
 [API documentation for a class](http://docs.emberjs.com/#doc=Ember.StateManager&src=fal), but are smaller in
-scope than [a topic-based guide](http://emberjs.com/guides/view_layer/).
+scope than [a topic-based guide](/guides/view_layer/).
 
 All recipes follow the same format:
 
@@ -31,6 +31,6 @@ Take a look at an [O'Reilly Cookbook](http://shop.oreilly.com/category/series/co
 format.
 
 [api_docs_for_class]: http://docs.emberjs.com/#doc=Ember.StateManager&src=fal
-[topic_based_guide]: http://emberjs.com/guides/view_layer/
+[topic_based_guide]: /guides/view_layer/
 [oreilly_cookbooks]: http://shop.oreilly.com/category/series/cookbooks.do
 [coffeescript_cookbook]: http://coffeescriptcookbook.com/

--- a/source/guides/cookbook/ember_data/linking_to_slugs.md
+++ b/source/guides/cookbook/ember_data/linking_to_slugs.md
@@ -8,13 +8,13 @@ a record in a url in place of an id.
 ## Solution
 
 Ember makes it easy to override the Route's default
-[model](http://emberjs.com/api/classes/Ember.Route.html#method_model)
+[model](/api/classes/Ember.Route.html#method_model)
 hook. You can define a custom model function to look up records by a
 `slug` property instead of by the `id`.
 
 Changing the `link-to` to use a slug instead of an `id` is easy and
 only requires creating a custom
-[serialize](http://emberjs.com/api/classes/Ember.Route.html#method_serialize)
+[serialize](/api/classes/Ember.Route.html#method_serialize)
 function on the route.
 
 ## Discussion

--- a/source/guides/cookbook/event_handling_and_data_binding/binding_properties_of_an_object_to_its_own_properties.md
+++ b/source/guides/cookbook/event_handling_and_data_binding/binding_properties_of_an_object_to_its_own_properties.md
@@ -17,7 +17,7 @@ App.Person = Ember.Object.extend({
 Ember.js includes a number of macros that will help create properties whose values are based
 on the values of other properties, correctly connecting them with bindings so they remain
 updated when values change. These all are stored on the `Ember.computed` object
-and [documented in the API documentation](http://emberjs.com/api/#method_computed)
+and [documented in the API documentation](/api/#method_computed)
 
 #### Example
 <a class="jsbin-embed" href="http://emberjs.jsbin.com/AfufoSO/3/edit?output">JS Bin</a>

--- a/source/guides/cookbook/user_interface_and_interaction/converting_strings_to_currency_with_accounting_js.md
+++ b/source/guides/cookbook/user_interface_and_interaction/converting_strings_to_currency_with_accounting_js.md
@@ -25,6 +25,6 @@ formattedAmount: function(key, value) {
 
 <a class="jsbin-embed" href="http://emberjs.jsbin.com/AqeVuZI/2/embed?live,js,output">JS Bin</a>
 
-[setters]: http://emberjs.com/guides/object-model/computed-properties/
+[setters]: /guides/object-model/computed-properties/
 [accounting]: http://josscrowcroft.github.io/accounting.js/
 

--- a/source/guides/cookbook/working_with_objects/continuous_redrawing_of_views.md
+++ b/source/guides/cookbook/working_with_objects/continuous_redrawing_of_views.md
@@ -182,10 +182,10 @@ The source code:
 
 Further reading:
 
-* [Ember Object](http://emberjs.com/api/classes/Ember.Object.html)
-* [Ember Application Initializers](http://emberjs.com/api/classes/Ember.Application.html#toc_initializers)
-* [Method Inject](http://emberjs.com/api/classes/Ember.Application.html#method_inject)
-* [Conditionals](http://emberjs.com/guides/templates/conditionals/)
-* [Writing Helpers](http://emberjs.com/guides/templates/writing-helpers/)
-* [Defining a Component](http://emberjs.com/guides/components/defining-a-component/)
-* [Ember Array Controller](http://emberjs.com/api/classes/Ember.ArrayController.html)
+* [Ember Object](/api/classes/Ember.Object.html)
+* [Ember Application Initializers](/api/classes/Ember.Application.html#toc_initializers)
+* [Method Inject](/api/classes/Ember.Application.html#method_inject)
+* [Conditionals](/guides/templates/conditionals/)
+* [Writing Helpers](/guides/templates/writing-helpers/)
+* [Defining a Component](/guides/components/defining-a-component/)
+* [Ember Array Controller](/api/classes/Ember.ArrayController.html)

--- a/source/guides/getting-ember/index.md
+++ b/source/guides/getting-ember/index.md
@@ -3,7 +3,7 @@
 The Ember Release Management Team maintains a variety of ways to get  Ember and Ember Data builds.
 
 ###Channels
-The latest [Release](/builds#/release), [Beta](/builds#/beta), and [Canary](/builds#/canary) builds of Ember and Ember data can be found [here](/builds). For each channel a development, minified, and production version is available. For more on the different channels read the [Post 1.0 Release Cycle](http://emberjs.com/blog/2013/09/06/new-ember-release-process.html) blog post.
+The latest [Release](/builds#/release), [Beta](/builds#/beta), and [Canary](/builds#/canary) builds of Ember and Ember data can be found [here](/builds). For each channel a development, minified, and production version is available. For more on the different channels read the [Post 1.0 Release Cycle](/blog/2013/09/06/new-ember-release-process.html) blog post.
 
 ###Tagged Releases
 Past release and beta builds  of Ember and Ember Data are available at [Tagged Releases](/builds#/tagged). These builds can be useful to track down regressions in your application, but it is recommended to use the latest stable release in production.

--- a/source/guides/getting-started/accepting-edits.md
+++ b/source/guides/getting-started/accepting-edits.md
@@ -5,7 +5,7 @@ To accomplish this, we'll create a new custom component and register it with Han
 Create a new file `js/views/edit_todo_view.js`. You may place this file anywhere you like (even just putting all code into the same file), but this guide will assume you have created the file and named it as indicated.
 
 In `js/views/edit_todo_view.js` create an extension of `Ember.TextField` and register it as
-a [helper](http://emberjs.com/api/classes/Ember.Handlebars.html#method_helper):
+a [helper](/api/classes/Ember.Handlebars.html#method_helper):
 
 ```javascript
 Todos.EditTodoView = Ember.TextField.extend({

--- a/source/guides/getting-started/display-a-button-to-remove-completed-todos.md
+++ b/source/guides/getting-started/display-a-button-to-remove-completed-todos.md
@@ -34,7 +34,7 @@ completed: function() {
 // ... additional lines truncated for brevity ...
 ```
 
-The `completed` and `clearCompleted` methods both invoke the `filterBy` method, which is part of the [ArrayController](http://emberjs.com/api/classes/Ember.ArrayController.html#method_filterProperty) API and returns an instance of [EmberArray](http://emberjs.com/api/classes/Ember.Array.html) which contains only the items for which the callback returns true.  The `clearCompleted` method also invokes the `invoke` method which is part of the [EmberArray](http://emberjs.com/api/classes/Ember.Array.html#method_invoke) API.  `invoke` will execute a method on each object in the Array if the method exists on that object.
+The `completed` and `clearCompleted` methods both invoke the `filterBy` method, which is part of the [ArrayController](/api/classes/Ember.ArrayController.html#method_filterProperty) API and returns an instance of [EmberArray](http://emberjs.com/api/classes/Ember.Array.html) which contains only the items for which the callback returns true.  The `clearCompleted` method also invokes the `invoke` method which is part of the [EmberArray](http://emberjs.com/api/classes/Ember.Array.html#method_invoke) API.  `invoke` will execute a method on each object in the Array if the method exists on that object.
 
 Reload your web browser to ensure that there are no errors and the behavior described above occurs.
 

--- a/source/guides/models/finding-records.md
+++ b/source/guides/models/finding-records.md
@@ -26,7 +26,7 @@ It is an object that implements [`Ember.Enumerable`][1]. This is important
 because, for example, if you want to retrieve records by index, the `[]` notation
 will not work--you'll have to use `objectAt(index)` instead.
 
-[1]: http://emberjs.com/api/classes/Ember.Enumerable.html
+[1]: /api/classes/Ember.Enumerable.html
 
 ### Finding a Single Record
 

--- a/source/guides/models/frequently-asked-questions.md
+++ b/source/guides/models/frequently-asked-questions.md
@@ -102,13 +102,13 @@ methods. This is useful for web applications that have a channel
 [Web Sockets](http://www.w3.org/TR/2009/WD-websockets-20091222/)) to
 notify it of new or updated records on the backend.
 
-[push](http://emberjs.com/api/data/classes/DS.Store.html#method_push)
+[push](/api/data/classes/DS.Store.html#method_push)
 is the simplest way to load records to Ember Data's store. When using
 `push` it is important to remember to deserialize the JSON object
 before pushing it into the store. `push` only accepts one record at a
 time. If you would like to load an array of records to the store you
 can call
-[pushMany](http://emberjs.com/api/data/classes/DS.Store.html#method_pushMany).
+[pushMany](/api/data/classes/DS.Store.html#method_pushMany).
 
 ```js
 socket.on('message', function (message) {
@@ -119,7 +119,7 @@ socket.on('message', function (message) {
 });
 ```
 
-[pushPayload](http://emberjs.com/api/data/classes/DS.Store.html#method_pushPayload)
+[pushPayload](/api/data/classes/DS.Store.html#method_pushPayload)
 is a convenience wrapper for `store#push` that will deserialize
 payloads if the model's Serializer implements a `pushPayload`
 method. It is important to note this method will not work with the
@@ -132,7 +132,7 @@ socket.on('message', function (message) {
 });
 ```
 
-[update](http://emberjs.com/api/data/classes/DS.Store.html#method_update)
+[update](/api/data/classes/DS.Store.html#method_update)
 works like a `push` except it can handle partial attributes without
 overwriting the existing record properties. This method is useful if
 your web application only receives notifications of the changed

--- a/source/guides/models/index.md
+++ b/source/guides/models/index.md
@@ -42,7 +42,7 @@ a copy of the latest passing build from
 * [Minified][minified-build]
 
 [emberdata]: https://github.com/emberjs/data
-[builds]: http://emberjs.com/builds
+[builds]: /builds
 [development-build]: http://builds.emberjs.com/canary/ember-data.js
 [minified-build]: http://builds.emberjs.com/canary/ember-data.min.js
 

--- a/source/guides/object-model/computed-properties.md
+++ b/source/guides/object-model/computed-properties.md
@@ -32,7 +32,7 @@ Whenever you access the `fullName` property, this function gets called, and it r
 
 #### Alternate invocation
 
-At this point, you might be wondering how you are able to call the `.property` function on a function.  This is possible because Ember extends the `function` prototype.  Read more on that [here](http://emberjs.com/guides/configuring-ember/disabling-prototype-extensions/). If you'd like to replicate the declaration from above without using these extensions you could do so with the following:
+At this point, you might be wondering how you are able to call the `.property` function on a function.  This is possible because Ember extends the `function` prototype.  More information about extending native prototypes is available in the [disabling prototype extensions guide](/guides/configuring-ember/disabling-prototype-extensions/). If you'd like to replicate the declaration from above without using these extensions you could do so with the following:
 
 ```javascript
   fullName: Ember.computed('firstName', 'lastName', function() {

--- a/source/guides/routing/link-to-router-flow.md
+++ b/source/guides/routing/link-to-router-flow.md
@@ -81,11 +81,11 @@ the model.
 The purpose of this phase is both to collect and resolve all model
 promises for newly entered routes (or routes with updated contexts),
 as well as allow for any of the
-[beforeModel](http://emberjs.com/api/classes/Ember.Route.html#method_beforeModel)
+[beforeModel](/api/classes/Ember.Route.html#method_beforeModel)
 /
-[model](http://emberjs.com/api/classes/Ember.Route.html#method_model)
+[model](/api/classes/Ember.Route.html#method_model)
 /
-[afterModel](http://emberjs.com/api/classes/Ember.Route.html#method_afterModel)
+[afterModel](/api/classes/Ember.Route.html#method_afterModel)
 hooks to reject elsewhere. If any of these hooks return a promise, the
 transition will pause until the promise resolves/rejects.
 
@@ -102,9 +102,9 @@ After the transition has been validated and any models are resolved
 ember enters the Sync exit/enter/setup Phase. Here Ember calls
 [exit](/api/classes/Ember.Route.html#method_exit) on the existing
 routes and
-[enter](http://emberjs.com/api/classes/Ember.Route.html#method_enter)
+[enter](/api/classes/Ember.Route.html#method_enter)
 /
-[setup](http://emberjs.com/api/classes/Ember.Route.html#method_setup)
+[setup](/api/classes/Ember.Route.html#method_setup)
 on the newly entered routes.
 
 <img src="/images/guides/routing/sync-phase.png" alt="Active route" class="highlight">

--- a/source/guides/routing/loading-and-error-substates.md
+++ b/source/guides/routing/loading-and-error-substates.md
@@ -1,5 +1,5 @@
 In addition to the techniques described in the
-[Asynchronous Routing Guide](http://emberjs.com/guides/routing/asynchronous-routing/),
+[Asynchronous Routing Guide](/guides/routing/asynchronous-routing/),
 the Ember Router provides powerful yet overridable
 conventions for customizing asynchronous transitions
 between routes by making use of `error` and `loading`
@@ -9,7 +9,7 @@ substates.
 
 The Ember Router allows you to return promises from the various
 `beforeModel`/`model`/`afterModel` hooks in the course of a transition
-(described [here](http://emberjs.com/guides/routing/asynchronous-routing/)).
+(described [here](/guides/routing/asynchronous-routing/)).
 These promises pause the transition until they fulfill, at which point
 the transition will resume.
 

--- a/source/guides/testing/testing-components.md
+++ b/source/guides/testing/testing-components.md
@@ -368,4 +368,4 @@ with Embedded Components</a>
 
 [Unit Testing Basics]: /guides/testing/unit-testing-basics
 [Integration Test Helpers]: /guides/testing/test-helpers
-[layout]: http://emberjs.com/api/classes/Ember.Component.html#property_layout
+[layout]: /api/classes/Ember.Component.html#property_layout

--- a/source/guides/wip/rails.md
+++ b/source/guides/wip/rails.md
@@ -11,7 +11,7 @@ In this guide, we'll show you how to build a simple, personal photoblog applicat
 
 Ember.js is a front-end javascript model-view-controller framework. It is designed to help you create ambitious web applications which run inside the browser. These applications can use AJAX as their primary mechanism for communicating with an API, much like a desktop or mobile application.
 
-Ruby on Rails is a Ruby-based full stack web framework. It also uses a model-view-controller paradigm to architect applications built on top of it, but in a much different way than Ember.js. The differences are beyond the scope of this guide, but you can read about them in our [Ember MVC guide](http://emberjs.com/guides/ember_mvc/). What is critical to understand is that Ruby on Rails runs on the server, not the client. It is an excellent platform to build websites and APIs.
+Ruby on Rails is a Ruby-based full stack web framework. It also uses a model-view-controller paradigm to architect applications built on top of it, but in a much different way than Ember.js. The differences are beyond the scope of this guide, but you can read about them in our [Ember MVC guide](/guides/ember_mvc/). What is critical to understand is that Ruby on Rails runs on the server, not the client. It is an excellent platform to build websites and APIs.
 
 In the next few steps, we'll create a Ruby on Rails application which does two distinct but equally important things: It acts as a host for the Ember.js application we will write, and it acts as an API with which the application will communicate. 
 

--- a/source/layout.erb
+++ b/source/layout.erb
@@ -7,7 +7,7 @@
     <link rel="shortcut icon" href="/images/favicon.png" />
     <!--[if lte IE 7 ]><%= stylesheet_link_tag "fonts/fontello-ie7" %><![endif]-->
     <%= stylesheet_link_tag "site" %>
-    <link href="http://emberjs.com/blog/feed.xml" rel="alternate" type="application/atom+xml" title="Ember.js - Blog" />
+    <link href="/blog/feed.xml" rel="alternate" type="application/atom+xml" title="Ember.js - Blog" />
     <%= yield_content :head %>
   </head>
 


### PR DESCRIPTION
Many URLs reference the emberjs domain- this can be mis-leading when working with the website to preview changes.
