### PR TITLE
Remove references to {{view SomeGlobal in favor of new syntax

### DIFF
--- a/source/guides/templates/writing-helpers.md
+++ b/source/guides/templates/writing-helpers.md
@@ -76,5 +76,5 @@ Which is functionally equivalent to, and accepts all the same
 arguments as:
 
 ```handlebars
-{{view App.CalendarView}}
+{{view "calendar"}}
 ```

--- a/source/guides/understanding-ember/the-view-layer.md
+++ b/source/guides/understanding-ember/the-view-layer.md
@@ -140,15 +140,16 @@ The process looks something like:
 As Ember renders a templated view, it will generate a view hierarchy. Let's assume we have a template `form`.
 
 ```handlebars
-{{view App.Search placeholder="Search"}}
-{{#view Ember.Button}}Go!{{/view}}
+{{view "search" placeholder="Search"}}
+{{#view view.buttonView}}Go!{{/view}}
 ```
 
 And we insert it into the DOM like this:
 
 ```javascript
 var view = Ember.View.create({
-  templateName: 'form'
+  templateName: 'form',
+  buttonView: Ember.Button
 }).append();
 ```
 
@@ -210,15 +211,15 @@ For example, consider the following Handlebars template:
 
 ```handlebars
 <h1>Joe's Lamprey Shack</h1>
-{{controller.restaurantHours}}
+{{restaurantHours}}
 
-{{#view App.FDAContactForm}}
+{{#view "fdaContactForm"}}
   If you are experiencing discomfort from eating at Joe's Lamprey Shack,
 please use the form below to submit a complaint to the FDA.
 
-  {{#if controller.allowComplaints}}
-    {{view Ember.TextArea valueBinding="controller.complaint"}}
-    <button {{action 'submitComplaint'}}>Submit</button>
+  {{#if allowComplaints}}
+    {{input value="complaint"}}
+    <button {{action "submitComplaint"}}>Submit</button>
   {{/if}}
 {{/view}}
 ```
@@ -237,7 +238,7 @@ Handlebars expressions:
 </figure>
 
 From inside of the `TextArea`, the `parentView` would point to the
-`FDAContactForm` and the `FDAContactForm`'s `childViews` would be an
+`FdaContactForm` and the `FdaContactForm`'s `childViews` would be an
 array of the single `TextArea` view.
 
 You can see the internal view hierarchy by asking for the `_parentView`
@@ -252,7 +253,7 @@ console.log(_childViews.objectAt(0).toString());
 **Warning!** You may not rely on these internal APIs in application code.
 They may change at any time and have no public contract. The return
 value may not be observable or bindable. It may not be an Ember object.
-If you feel the need to use them, please contact us so we can expose a better 
+If you feel the need to use them, please contact us so we can expose a better
 public API for your use-case.
 
 Bottom line: This API is like XML. If you think you have a use for it,
@@ -323,9 +324,9 @@ App.ChildView = Ember.View.extend({
 And here's the Handlebars template that uses them:
 
 ```handlebars
-{{#view App.GrandparentView}}
-  {{#view App.ParentView}}
-    {{#view App.ChildView}}
+{{#view "grandparent"}}
+  {{#view "parent"}}
+    {{#view "child"}}
       <h1>Click me!</h1>
     {{/view}}
   {{/view}}
@@ -363,9 +364,9 @@ App.FormView = Ember.View.extend({
 ```
 
 ```handlebars
-{{#view App.FormView}}
-  {{view Ember.TextField valueBinding="controller.firstName"}}
-  {{view Ember.TextField valueBinding="controller.lastName"}}
+{{#view "form"}}
+  {{input value=firstName}}
+  {{input value=lastName}}
   <button type="submit">Done</button>
 {{/view}}
 ```

--- a/source/guides/views/adding-layouts-to-views.md
+++ b/source/guides/views/adding-layouts-to-views.md
@@ -72,14 +72,14 @@ App.PopupView = Ember.View.extend({
 Now you can re-use your popup with different templates:
 
 ```html
-{{#view App.PopupView}}
+{{#view "popup"}}
   <form>
     <label for="name">Name:</label>
     <input id="name" type="text" />
   </form>
 {{/view}}
 
-{{#view App.PopupView}}
+{{#view "popup"}}
   <p> Thank you for signing up! </p>
 {{/view}}
 ```

--- a/source/guides/views/built-in-views.md
+++ b/source/guides/views/built-in-views.md
@@ -1,43 +1,33 @@
-Ember comes pre-packaged with a set of views for building a few basic controls like text inputs, check boxes, and select lists.
+Ember comes pre-packaged with a set of views for building a basic controls like text inputs, check boxes, and select lists. Usually, these views will be used via the [input helpers](/guides/templates/input-helpers/). However, the base views may be helpful in creating custom form behaviors.
 
-They are:
+* [Ember.Checkbox](/api/classes/Ember.Checkbox.html)
+* [Ember.TextField](/api/classes/Ember.TextField.html)
+* [Ember.TextArea](/api/classes/Ember.TextArea.html)
 
-#### Ember.Checkbox
-
-```handlebars
-<label>
-  {{view Ember.Checkbox checked=model.isDone}}
-  {{model.title}}
-</label>
-```
-
-#### Ember.TextField
+For example, here we have created a custom text field that toggles a dirty property:
 
 ```javascript
+// {{view "myText" value=name inputDidChange=nameDidChange}}
 App.MyText = Ember.TextField.extend({
-  formBlurred: null, // passed to the view helper as formBlurred=controllerPropertyName
-  change: function(evt) {
-    this.set('formBlurred', true);
+  inputDidChange: false,
+  change: function() {
+    this.set('inputDidChange', true);
   }
 });
 ```
 
-#### Ember.Select
+Ember itself provides one additional view not covered by the input helpers, and this is the select box view.
+
+* [Ember.Select](/api/classes/Ember.Select.html)
+
+This class can also be customized by extending it. To use the select view bundled with Ember, call it via the view helper:
 
 ```handlebars
-{{view Ember.Select viewName="select"
-                    content=people
+{{view Ember.Select content=people
                     optionLabelPath="content.fullName"
                     optionValuePath="content.id"
                     prompt="Pick a person:"
                     selection=selectedPerson}}
 ```
 
-#### Ember.TextArea
-
-```javascript
-var textArea = Ember.TextArea.create({
-  valueBinding: 'TestObject.value'
-});
-```
-
+The select view is extremely feature-rich, and may perform badly when rendering many items. Due to this, it has not yet been converted into an component or helper like other inputs.

--- a/source/guides/views/customizing-a-views-element.md
+++ b/source/guides/views/customizing-a-views-element.md
@@ -134,13 +134,13 @@ By default, new instances of `Ember.View` create a `<div>` element. You can
 override this by passing a `tagName` parameter:
 
 ```handlebars
-{{view App.InfoView tagName="span"}}
+{{view "info" tagName="span"}}
 ```
 
 You can also assign an ID attribute to the view's HTML element by passing an `id` parameter:
 
 ```handlebars
-{{view App.InfoView id="info-view"}}
+{{view "info" id="info-view"}}
 ```
 
 This makes it easy to style using CSS ID selectors:
@@ -155,7 +155,7 @@ This makes it easy to style using CSS ID selectors:
 You can assign class names similarly:
 
 ```handlebars
-{{view App.InfoView class="info urgent"}}
+{{view "info" class="info urgent"}}
 ```
 
 You can bind class names to a property of the view by using `classBinding` instead of `class`. The same behavior as described in `bind-attr` applies:
@@ -168,7 +168,7 @@ App.AlertView = Ember.View.extend({
 ```
 
 ```handlebars
-{{view App.AlertView classBinding="isUrgent priority"}}
+{{view "alert" classBinding="isUrgent priority"}}
 ```
 
 This yields a view wrapper that will look something like this:

--- a/source/guides/views/handling-events.md
+++ b/source/guides/views/handling-events.md
@@ -5,7 +5,7 @@ as a method on your view.
 For example, imagine we have a template like this:
 
 ```handlebars
-{{#view App.ClickableView}}
+{{#view "clickable"}}
 This is a clickable area!
 {{/view}}
 ```

--- a/source/guides/views/inserting-views-in-templates.md
+++ b/source/guides/views/inserting-views-in-templates.md
@@ -2,7 +2,7 @@ So far, we've discussed writing templates for a single view. However, as your ap
 
 ### {{view}}
 
-To add a child view to a parent, use the `{{view}}` helper, which takes a path to a view class.
+To add a child view to a parent, use the `{{view}}` helper. The `{{view}}` helper takes a string used to look up the view class.
 
 ```javascript
 // Define parent view
@@ -25,7 +25,7 @@ App.InfoView = Ember.View.extend({
 ```html
 <script type="text/x-handlebars" data-template-name="user">
   User: {{view.firstName}} {{view.lastName}}
-  {{view App.InfoView}}
+  {{view "info"}}
 </script>
 ```
 
@@ -76,9 +76,7 @@ User: {{view.firstName}} {{view.lastName}}
 {{view view.infoView}}
 ```
 
-When nesting a view class like this, make sure to use a lowercase
-letter, as Ember will interpret a property with a capital letter as a
-global property.
+When using the view helper with a property, prefer starting the property name with a lowercase letter. Using an uppercase letter, such as in `{{view MyClass}}` may trigger a deprecated use-case.
 
 ### Setting Child View Templates
 
@@ -102,7 +100,7 @@ App.InfoView = Ember.View.extend({
 
 ```handlebars
 User: {{view.firstName}} {{view.lastName}}
-{{#view App.InfoView}}
+{{#view "info"}}
   <b>Posts:</b> {{view.posts}}
   <br>
   <b>Hobbies:</b> {{view.hobbies}}

--- a/source/guides/wip/rails.md
+++ b/source/guides/wip/rails.md
@@ -352,8 +352,8 @@ We use the handlebars expression `template` to refer to another template we'd li
 Let's create the `_form` template in `app/assets/javascripts/templates/photos/_form.handlebars`. It will include only the form elements for our photo, like so:
 
 ```handlebars
-<label for="title-field">Title:</label>{{view Ember.TextField id="title-field" valueBinding="controller.model.title"}}
-<label for="url-field">URL:</label>{{view Ember.TextField id="url-field" valueBinding="controller.model.url"}}
+<label for="title-field">Title:</label>{{input id="title-field" value=model.title}}
+<label for="url-field">URL:</label>{{input id="url-field" value=model.url}}
 
 <button {{action 'save' target="Photoblog.stateManager"}}>Save</button>
 <button {{action 'cancel' target="Photoblog.stateManager"}}>Cancel</button>


### PR DESCRIPTION
Refs emberjs/ember.js#5294

This updates the documentation on views to avoid the global syntax.
