### PR TITLE
Simplify example making consistent with others

### DIFF
--- a/source/guides/models/connecting-to-an-http-server.md
+++ b/source/guides/models/connecting-to-an-http-server.md
@@ -54,9 +54,9 @@ Given the following models:
 
 ```js
 App.Post = DS.Model.extend({
-  title: DS.attr(),
+  title:    DS.attr(),
   comments: DS.hasMany('comment'),
-  user: DS.belongsTo('user')
+  user:     DS.belongsTo('user')
 });
 
 App.Comment = DS.Model.extend({


### PR DESCRIPTION
Others don't define those vars, and this is just an example so no need to make it
more visually complex.
