### PR TITLE
Fixed small typo

### DIFF
--- a/source/guides/testing/testing-components.md
+++ b/source/guides/testing/testing-components.md
@@ -219,7 +219,7 @@ test('clicking link updates the title', function() {
   equal($component.find('h2').text(), "I'm a little teapot");
   
   // send action programmatically
-  Em.run(function(){
+  Ember.run(function(){
     component.send('changeName');
   });
   


### PR DESCRIPTION
Ember.run was listed as Em.run, which I assume is not some sort of short-hand for 'Ember.run'.
