### PR TITLE
Correct an improper use of apostrophe.

### DIFF
--- a/source/guides/deprecations/index.md
+++ b/source/guides/deprecations/index.md
@@ -19,7 +19,7 @@ views despite the feature being a rarely used one.
 #### Deprecate Ember.DeferredMixin and Ember.Deferred.
 
 `Ember.DeferredMixin` and `Ember.Deferred` have been deprecated in favor
-of using `RSVP.Promise`'s.
+of using `RSVP.Promise`s.
 
 #### Deprecate `.then` on Ember.Application.
 


### PR DESCRIPTION
Remove apostrophe; there is nothing that an RVSP promise possesses in this context.
The apostrophe would be correct if we were discussing an RSVP promise's life-cycle, it's ID property, or it's horoscope.
