### PR TITLE
Removed instructions to add an already added method

### DIFF
--- a/source/guides/getting-started/deleting-todos.md
+++ b/source/guides/getting-started/deleting-todos.md
@@ -8,7 +8,7 @@ In `index.html` update the static `<button>` element to include an `{{action}}` 
 <!--- ... additional lines truncated for brevity ... -->
 ```
 
-This will call the `removeTodo` method that will delete the todo locally and then persist this data change.
+This will call the `removeTodo` action defined in the previous chapter and will delete the todo locally and then persist this data change.
 
 Because the todo is no longer part of the collection of all todos, its `<li>` element in the page will be automatically removed for us. If the deleted todo was incomplete, the count of remaining todos will be decreased by one and the display of this number will be automatically re-rendered. If the new count results in an inflection change between "todo" and "todos" this area of the page will be automatically re-rendered.
 


### PR DESCRIPTION
The removeTodo function was added in the previous page - ["Accepting Edits"](http://emberjs.com/guides/getting-started/accepting-edits/) - so it is not necessary to ask people to add it again.
