### PR TITLE
Cleans up links in Cookbook Intro

### DIFF
--- a/source/guides/cookbook/contributing/understanding_the_cookbook_format.md
+++ b/source/guides/cookbook/contributing/understanding_the_cookbook_format.md
@@ -5,8 +5,8 @@ how your contribution should be formatted.
 ### Solution
 Cookbook-style guides contain recipes that guide a beginning programmer to a deeper knowledge of the subject
 by answering specific, "how-to" style questions. Cookbook recipes address more topics than
-[API documentation for a class](http://docs.emberjs.com/#doc=Ember.StateManager&src=fal), but are smaller in
-scope than [a topic-based guide](/guides/view_layer/).
+[API documentation for a class](http://emberjs.com/api/classes/Ember.Application.html), but are smaller in
+scope than [a topic-based guide](http://emberjs.com/guides/).
 
 All recipes follow the same format:
 
@@ -29,8 +29,3 @@ prerequisite knowledge is encouraged.
 Take a look at an [O'Reilly Cookbook](http://shop.oreilly.com/category/series/cookbooks.do) or the
 [Coffeescript Cookbook](http://coffeescriptcookbook.com/). Both of these are great examples of the Cookbook
 format.
-
-[api_docs_for_class]: http://docs.emberjs.com/#doc=Ember.StateManager&src=fal
-[topic_based_guide]: /guides/view_layer/
-[oreilly_cookbooks]: http://shop.oreilly.com/category/series/cookbooks.do
-[coffeescript_cookbook]: http://coffeescriptcookbook.com/


### PR DESCRIPTION
- Fixes link for "topic based guide" to point to the Ember.js Guides instead of a 404 Error page
- Fixes link for "API documentation for a class" to point to an actual class (`Ember.Application`) instead of the top-level API page
- Removes unused reference/footnote links.
