### PR TITLE
Fix sidebar for "Understanding Ember.js"

### DIFF
--- a/data/guides.yml
+++ b/data/guides.yml
@@ -395,9 +395,11 @@ Cookbook:
   #   url: "cookbook/debugging_and_configuration/setting_ember_global_flags"
   #   skip_sidebar_item: true
 
-Understanding Ember.js:
+Deprecations:
   - title: "Deprecations"
     url: "deprecations"
+
+Understanding Ember.js:
   - title: "The View Layer"
     url: "understanding-ember/the-view-layer"
   - title: "Managing Asynchrony"


### PR DESCRIPTION
Since `lib/toc.rb` checks whether the first element of a chapter matches the current URL, having `deprecations` as the first item in the `understanding-ember` chapter caused problems with the sidebar. Namely, when accessing e.g. http://emberjs.com/guides/understanding-ember/the-view-layer/ nothing in the sidebar is selected.

![image](https://cloud.githubusercontent.com/assets/2664611/4607906/ddd83c1a-5265-11e4-994c-4f335c58acb4.png)

Fixed by moving Deprecations to it's own chapter. This causes the least friction (as opposed to promoting Deprecations to "Understanding Ember.js"), since a lot of places link directly to http://emberjs.com/guides/deprecations
