### PR TITLE
Fix markup to apply syntax highlight

### DIFF
--- a/source/guides/cookbook/helpers_and_components/writing_a_custom_handlebars_helper.md
+++ b/source/guides/cookbook/helpers_and_components/writing_a_custom_handlebars_helper.md
@@ -6,7 +6,7 @@ Write a custom Handlebars helper that can be called from any template and gets u
 
 ### Discussion
 
-```hbs
+```html
 <script type="text/x-handlebars">
    $ {{dollar model}}
 </script>

--- a/source/guides/deprecations/index.md
+++ b/source/guides/deprecations/index.md
@@ -36,7 +36,7 @@ instead.
 Previous to Ember 1.8, views would commonly be fetched from the global
 scope:
 
-```hbs
+```handlebars
 {{view App.SomeView}}
 {{each itemViewClass=App.SomeView}}
 ```
@@ -44,14 +44,14 @@ scope:
 Since Ember 1.8, views are more appropriately resolved on the application
 via strings:
 
-```hbs
+```handlebars
 {{view "some"}}
 {{each itemViewClass="some"}}
 ```
 
 They may also be fetched via a binding:
 
-```hbs
+```handlebars
 {{view view.someViewViaTheCurrentView}}
 {{each itemViewClass=someViewViaAControllerProperty}}
 ```
@@ -69,14 +69,14 @@ The [Ember.Select](/api/classes/Ember.Select.html) view has not been upgraded to
 have a helper. Instead, it was suggested that you call it via the global
 class name:
 
-```hbs
+```handlebars
 {{view Ember.Select content=manyItems}}
 ```
 
 Since this lookup is now deprecated, the select view has been registered
 on an application as `select`. The new usage is:
 
-```hbs
+```handlebars
 {{view "select" content=manyItems}}
 ```
 

--- a/source/guides/routing/query-params.md
+++ b/source/guides/routing/query-params.md
@@ -257,7 +257,7 @@ if you navigate to `/badgers` and filter by `"rookies"`, then navigate
 to `/bears` and filter by `"best"`, and then navigate to `/potatoes` and
 filter by `"lamest"`, then given the following nav bar links,
 
-```hbs
+```handlebars
 {{#link-to 'team' 'badgers '}}Badgers{{/link-to}}
 {{#link-to 'team' 'bears'   }}Bears{{/link-to}}
 {{#link-to 'team' 'potatoes'}}Potatoes{{/link-to}}
@@ -265,7 +265,7 @@ filter by `"lamest"`, then given the following nav bar links,
 
 the generated links would be
 
-```hbs
+```html
 <a href="/badgers?filter=rookies">Badgers</a>
 <a href="/bears?filter=best">Bears</a>
 <a href="/potatoes?filter=lamest">Potatoes</a>

--- a/source/guides/understanding-ember/dependency-injection-and-service-lookup.md
+++ b/source/guides/understanding-ember/dependency-injection-and-service-lookup.md
@@ -82,7 +82,7 @@ Let's build a controller that manages audio playback and makes it available to o
 
 First, we create `AudioController` and attach it to the DOM by using the `render` helper. This helper renders a template, and backs that template with a controller of the same name.
 
-```hbs
+```handlebars
 {{! application.hbs }}
 {{render "audio"}}
 {{outlet}}
@@ -90,7 +90,7 @@ First, we create `AudioController` and attach it to the DOM by using the `render
 
 And we must create an `audio.hbs` template to render:
 
-```hbs
+```handlebars
 {{! audio.hbs }}
 <audio id="audio" controls loop>
   <source {{bind-attr src=currentSrc}} type="audio/mpeg"></source>


### PR DESCRIPTION
`hbs` is not valid language name.

Before:
![2014-10-15 21 42 20](https://cloud.githubusercontent.com/assets/290782/4645472/569b851c-5469-11e4-83c3-63f8c905639e.png)

After:
![2014-10-15 21 42 29](https://cloud.githubusercontent.com/assets/290782/4645473/59d6174c-5469-11e4-8eef-4f0dd53c24d3.png)
