### PR TITLE
fix url links for todomvc examples and code

### DIFF
--- a/source/blog/2013-03-21-making-ember-easier.md
+++ b/source/blog/2013-03-21-making-ember-easier.md
@@ -36,7 +36,7 @@ To call out a few of the big ones:
 * [NetTuts' Getting into Ember.js series](http://net.tutsplus.com/tutorials/javascript-ajax/getting-into-ember-js/) by Rey Bango
 * The guides on the Ember.js website have been dramatically expanded
 
-Additionally, great open source examples built on top of RC1 are out in the wild, like [TodoMVC](https://github.com/addyosmani/todomvc/tree/gh-pages/architecture-examples/emberjs) and the "Big Kahuna," [Discourse](https://github.com/discourse/discourse).
+Additionally, great open source examples built on top of RC1 are out in the wild, like [TodoMVC](https://github.com/addyosmani/todomvc/tree/gh-pages/examples/emberjs) and the "Big Kahuna," [Discourse](https://github.com/discourse/discourse).
 
 We've also been working on tooling to make the process of developing Ember.js apps easier. For example, [Ryan Florence's ember-tools](https://github.com/rpflorence/ember-tools) significantly improves bootstrapping a new project, and the [Ember Inspector plugin for Chrome](https://github.com/tildeio/ember-extension) (which we [demoed at EmberCamp](https://www.youtube.com/watch?feature=player_detailpage&v=RYAD2arvysU#t=1924s)) should make debugging and understanding apps much easier.
 

--- a/source/guides/getting-started/deleting-todos.md
+++ b/source/guides/getting-started/deleting-todos.md
@@ -16,7 +16,7 @@ Reload your web browser to ensure that there are no errors and the behaviors des
 
 
 <aside>
-Note: The current action may be invoked twice (via `acceptChanges`) leading to an exception. For details on how to handle this situation, please see [the latest version of the TodoMVC source](https://github.com/tastejs/todomvc/blob/gh-pages/architecture-examples/emberjs/js/controllers/todo_controller.js).
+Note: The current action may be invoked twice (via `acceptChanges`) leading to an exception. For details on how to handle this situation, please see [the latest version of the TodoMVC source](https://github.com/tastejs/todomvc/blob/gh-pages/examples/emberjs/js/controllers/todo_controller.js).
 </aside>
 
 ### Live Preview

--- a/source/guides/getting-started/planning-the-application.md
+++ b/source/guides/getting-started/planning-the-application.md
@@ -23,4 +23,4 @@ TodoMVC has the following main features:
 
   1. It retains a user's todos between application loads by using the browser's `localstorage` mechanism.
 
-You can interact with a completed version of the application by visiting the [TodoMVC site](http://todomvc.com/architecture-examples/emberjs/).
+You can interact with a completed version of the application by visiting the [TodoMVC site](http://todomvc.com/examples/emberjs/).


### PR DESCRIPTION
Fix broken links to todomvc examples.

Pointed out by @mcwumbly in the forums: http://discuss.emberjs.com/t/broken-link-to-live-todomvc-example-on-getting-started/6519.
