### PR TITLE
Moved forward slash deprecation description to the bottom

### DIFF
--- a/source/guides/deprecations/index.md
+++ b/source/guides/deprecations/index.md
@@ -84,14 +84,6 @@ See the updated [Ember.Select](/api/classes/Ember.Select.html) documentation
 and the [built-in views guide](/guides/views/built-in-views) for more details
 and examples.
 
-#### location: 'hash' paths must now include a forward slash. e.g. #/foo NOT #foo
-
-Prior to this release, if you were using `location: 'hash'` (which is the default), you were able able to link to a route with a `location.hash` that didn't contain the expected leading forward slash. e.g. `#foo` instead of the correct `#/foo`. Very few, if any, should be impacted by this since the router always produces the correct form.
-
-Doing so is ambiguous because you may also be trying to link to an element on the page who's id matches `<div id="foo">` and it also erroneously will create an extra history state if a user clicks on something that transitions to that route again, since it will change `location.hash === '#/foo'`.
-
-This ability will be removed quickly to allow us to mimick the browser's behavior of scrolling the page to an element who's id matches, but in our case doing so after the transition ends and everything is rendered. Once this feature is added, you'll be able to link to id's even with doubled up hashes: `#/foo#some-id` as well as the expected `#some-id`.
-
 ##### Ember.js libraries and plugins
 
 If the code triggering this deprecation is being fired from a library, that
@@ -121,3 +113,10 @@ More details on how to register an Ember.js framework component are available
 in the [initializer API documentation](/api/classes/Ember.Application.html#toc_initializers)
 and the [dependency injection guide](/guides/understanding-ember/dependency-injection-and-service-lookup).
 
+#### Deprecate location: 'hash' paths that don't include a forward slash. e.g. #/foo NOT #foo
+
+Prior to this release, if you were using `location: 'hash'` (which is the default), you were able able to link to a route with a `location.hash` that didn't contain the expected leading forward slash. e.g. `#foo` instead of the correct `#/foo`. Very few, if any, should be impacted by this since the router always produces the correct form.
+
+Doing so is ambiguous because you may also be trying to link to an element on the page who's id matches `<div id="foo">` and it also erroneously will create an extra history state if a user clicks on something that transitions to that route again, since it will change `location.hash === '#/foo'`.
+
+This ability will be removed quickly to allow us to mimick the browser's behavior of scrolling the page to an element who's id matches, but in our case doing so after the transition ends and everything is rendered. Once this feature is added, you'll be able to link to id's even with doubled up hashes: `#/foo#some-id` as well as the expected `#some-id`.


### PR DESCRIPTION
@mixonic pointed out that I mistakenly put the deprecation in the middle of the "Global lookup of views" section. This moves it to the bottom.

He suggested using `###` but I believe four `####` is still correct since it is a 1.8.0 sub section. Please correct me if I'm wrong.

Cc/ @rwjblue 
