### PR TITLE
Add beforeObserver deprecation entry

### DIFF
--- a/source/guides/deprecations/index.md
+++ b/source/guides/deprecations/index.md
@@ -120,3 +120,24 @@ Prior to this release, if you were using `location: 'hash'` (which is the defaul
 Doing so is ambiguous because you may also be trying to link to an element on the page who's id matches `<div id="foo">` and it also erroneously will create an extra history state if a user clicks on something that transitions to that route again, since it will change `location.hash === '#/foo'`.
 
 This ability will be removed quickly to allow us to mimick the browser's behavior of scrolling the page to an element who's id matches, but in our case doing so after the transition ends and everything is rendered. Once this feature is added, you'll be able to link to id's even with doubled up hashes: `#/foo#some-id` as well as the expected `#some-id`.
+
+
+### Deprecations Added in 1.10
+
+#### Deprecate beforeObservers
+
+beforeObservers are deprecated due to the negative performance implications they have for Ember internals and applications.
+
+Typically they were used to have access to the old value of a property when it's about to change, but you can get same functionality in an even more efficient way with just a few lines of code:
+
+```js
+function fooObserver(obj){
+  var newFoo = obj.get('foo');
+  if (obj._oldFoo !== newFoo) {
+    // do your stuff here
+    obj._oldFoo = newFoo;
+  }
+}
+addObserver(obj, 'foo', fooObserver);
+fooObserver(obj); // Optionally call the observer immediately
+```


### PR DESCRIPTION
I am not completely sure if I had a conversation where I heard that they will be removed in ember 2.0 or I just made up that fact.
