### PR TITLE
Make TodosIndexRoute modelFor use singular todo

### DIFF
--- a/source/guides/getting-started/adding-child-routes.md
+++ b/source/guides/getting-started/adding-child-routes.md
@@ -50,7 +50,7 @@ Todos.Router.map(function () {
 
 Todos.TodosIndexRoute = Ember.Route.extend({
   model: function() {
-    return this.modelFor('todos');
+    return this.modelFor('todo');
   }
 });
 ```


### PR DESCRIPTION
Plural `todos` was breaking the example, and is not what was shown in the JSFiddle.
