### PR TITLE
Update specifying-the-location-api.md

### DIFF
--- a/source/guides/routing/specifying-the-location-api.md
+++ b/source/guides/routing/specifying-the-location-api.md
@@ -16,7 +16,7 @@ App.Router.map(function() {
 If you want `/posts/new` to work instead, you can tell the Router to use the browser's
 [history](http://caniuse.com/history) API. 
 
-Keep in mind that your server must serve the Ember app at all the routes defined here.
+Keep in mind that your server must serve the Ember app all the routes defined here.
 
 ```js
 App.Router.reopen({


### PR DESCRIPTION
Grammar error. Removing an extra `at`
