### PR TITLE
Fix example: use extend not create

### DIFF
--- a/source/guides/views/defining-a-view.md
+++ b/source/guides/views/defining-a-view.md
@@ -15,7 +15,7 @@ To tell the view which template to use, set its `templateName` property. For exa
 I would set the `templateName` property to `"say-hello"`.
 
 ```javascript
-var view = Ember.View.create({
+var view = Ember.View.extend({
   templateName: 'say-hello',
   name: "Bob"
 });


### PR DESCRIPTION
I ran into an issue using the provided example. The other pages use Ember.View.extend(...) which worked for me. So unless there's more to Ember.View.create(...) that I missed and is missing from the example, I assume this was a typo.
