### PR TITLE
Expose running current tests on /builds site.

### DIFF
--- a/source/javascripts/app/builds/app.js
+++ b/source/javascripts/app/builds/app.js
@@ -219,6 +219,7 @@ App.Project.reopenClass({
       projectFilter: "ember",
       projectRepo: 'emberjs/ember.js',
       channel: "canary",
+      enableTestURL: true
     }, {
       projectName: "Ember Data",
       projectFilter: "ember-data",
@@ -317,6 +318,10 @@ App.ProjectsMixin = Ember.Mixin.create({
       project.lastReleaseDebugUrl = self.lastReleaseUrl(project.projectFilter, project.channel, project.lastRelease, '.js');
       project.lastReleaseProdUrl  = self.lastReleaseUrl(project.projectFilter, project.channel, project.lastRelease, '.prod.js');
       project.lastReleaseMinUrl   = self.lastReleaseUrl(project.projectFilter, project.channel, project.lastRelease, '.min.js');
+
+      if (project.enableTestURL) {
+        project.lastReleaseTestUrl  = self.lastReleaseUrl(project.projectFilter, project.channel, project.lastRelease, '-tests-index.html');
+      }
 
       if (project.channel === 'canary')
         project.lastRelease = 'latest';

--- a/source/javascripts/app/builds/templates/_files_table.js.hbs
+++ b/source/javascripts/app/builds/templates/_files_table.js.hbs
@@ -73,6 +73,9 @@
       <a class="debug" {{bind-attr href=lastReleaseProdUrl}} download>production</a>
       <a class="debug" {{bind-attr href=lastReleaseMinUrl}} download>(min)</a> |
       <a class="debug" {{bind-attr href=lastReleaseDebugUrl}} download>debug</a>
+      {{#if lastReleaseTestUrl}} |
+        <a class="debug" {{bind-attr href=lastReleaseTestUrl}} target="_blank" >live tests</a>
+      {{/if}}
       {{#if lastReleaseChangelogUrl }} |
         <a class="debug" {{bind-attr href=lastReleaseChangelogUrl}}>changelog</a>
       {{/if}}


### PR DESCRIPTION
Currently, only enabled for canary but can be enabled for beta once
1.9.0-beta.2 is released.

![screenshot](http://monosnap.com/image/YWX2rk5Zg8357KKnJaUJo1A5moBIrd.png)

Links to http://builds.emberjs.com/canary/ember-tests-index.html which allows running Ember's full test suite.
