### PR TITLE
Remove context switching {{each}} references.

### DIFF
--- a/source/about.html.erb
+++ b/source/about.html.erb
@@ -78,8 +78,8 @@ title: "A framework for creating ambitious web applications."
 <div class="getting-started section">
   <script type="text/x-handlebars" id="application">
       <div class="example-tabs">
-        {{#each itemController="tabItem"}}
-          <a {{action "selectTab" this}} {{bind-attr class="isSelected:active"}} href="#">{{unbound name}}</a>
+        {{#each item in model itemController="tabItem"}}
+          <a {{action "selectTab" item}} {{bind-attr class="item.isSelected:active"}} href="#">{{unbound item.name}}</a>
         {{/each}}
         <span class="tabs-footer"></span>
       </div>

--- a/source/guides/components/defining-a-component.md
+++ b/source/guides/components/defining-a-component.md
@@ -27,7 +27,7 @@ component of the same name. Given the above template, you can now use the
 
 ```handlebars
 <h1>My Blog</h1>
-{{#each}}
+{{#each post in model}}
   {{blog-post}}
 {{/each}}
 ```

--- a/source/guides/components/passing-properties-to-a-component.md
+++ b/source/guides/components/passing-properties-to-a-component.md
@@ -79,8 +79,8 @@ You can also bind properties from inside an `{{#each}}` loop. This will
 create a component for each item and bind it to each model in the loop.
 
 ```handlebars
-{{#each}}
-  {{blog-post title=title}}
+{{#each post in model}}
+  {{blog-post title=post.title}}
 {{/each}}
 ```
 <a class="jsbin-embed" href="http://jsbin.com/yexeyi/embed?live">JS Bin</a>

--- a/source/guides/concepts/naming-conventions.md
+++ b/source/guides/concepts/naming-conventions.md
@@ -128,8 +128,8 @@ The template can iterate over the elements of the controller:
 
 ```handlebars
 <ul>
-{{#each controller}}
-  <li>{{title}}</li>
+{{#each item in controller}}
+  <li>{{item.title}}</li>
 {{/each}}
 </ul>
 ```

--- a/source/guides/controllers/dependencies-between-controllers.md
+++ b/source/guides/controllers/dependencies-between-controllers.md
@@ -32,8 +32,8 @@ its parent `PostController`, which can be done via `controllers.post`
 <h1>Comments for {{controllers.post.title}}</h1>
 
 <ul>
-  {{#each comments}}
-    <li>{{text}}</li>
+  {{#each comment in comments}}
+    <li>{{comment.text}}</li>
   {{/each}}
 </ul>
 ```

--- a/source/guides/controllers/index.md
+++ b/source/guides/controllers/index.md
@@ -119,7 +119,7 @@ proxies properties from an Array, and an `Ember.ObjectController`
 proxies properties from an object.
 
 If your controller is an `ArrayController`, you can iterate directly
-over the controller using `{{#each controller}}`. This keeps the
+over the controller using `{{#each item in controller}}`. This keeps the
 template from having to know about how the controller is implemented
 and makes isolation testing and refactoring easier.
 

--- a/source/guides/controllers/representing-multiple-models-with-arraycontroller.md
+++ b/source/guides/controllers/representing-multiple-models-with-arraycontroller.md
@@ -21,8 +21,8 @@ each song:
 <h1>Playlist</h1>
 
 <ul>
-  {{#each}}
-    <li>{{name}} by {{artist}}</li>
+  {{#each song in model}}
+    <li>{{song.name}} by {{song.artist}}</li>
   {{/each}}
 </ul>
 ```
@@ -47,8 +47,8 @@ Now we can use this property in our template:
 
 ```handlebars
 <ul>
-  {{#each}}
-    <li>{{name}} by {{artist}}</li>
+  {{#each song in model}}
+    <li>{{song.name}} by {{song.artist}}</li>
   {{/each}}
 </ul>
 
@@ -93,8 +93,8 @@ App.SongsController = Ember.ArrayController.extend({
 ```
  
 ```handlebars
-{{#each controller}}
-  <li>{{fullName}}</li>
+{{#each item in controller}}
+  <li>{{item.fullName}}</li>
 {{/each}}
 ```
  
@@ -106,7 +106,7 @@ App.SongsController = Ember.ArrayController.extend({
 ```
  
 ```handlebars
-{{#each controller itemController="song"}}
-  <li>{{fullName}}</li>
+{{#each item in controller itemController="song"}}
+  <li>{{item.fullName}}</li>
 {{/each}}
 ```

--- a/source/guides/deprecations/index.md
+++ b/source/guides/deprecations/index.md
@@ -38,7 +38,7 @@ scope:
 
 ```handlebars
 {{view App.SomeView}}
-{{each itemViewClass=App.SomeView}}
+{{each item in items itemViewClass=App.SomeView}}
 ```
 
 Since Ember 1.8, views are more appropriately resolved on the application
@@ -46,7 +46,7 @@ via strings:
 
 ```handlebars
 {{view "some"}}
-{{each itemViewClass="some"}}
+{{each item in items itemViewClass="some"}}
 ```
 
 They may also be fetched via a binding:
@@ -121,6 +121,40 @@ Doing so is ambiguous because you may also be trying to link to an element on th
 
 This ability will be removed quickly to allow us to mimick the browser's behavior of scrolling the page to an element who's id matches, but in our case doing so after the transition ends and everything is rendered. Once this feature is added, you'll be able to link to id's even with doubled up hashes: `#/foo#some-id` as well as the expected `#some-id`.
 
+### Deprecations Added in 1.9
+
+#### Deprecate Context Switching form of {{each}}
+
+In preparation for further work on HTMLBars, the context switching form of `{{each}}` is deprecated. This is mostly a "mechanical" refactor and drammatically
+simplifies how to think about the context in your templates.
+
+In prior versions you may have done one of the following:
+
+```handlebars
+<ul>
+  {{#each}}
+    <li>{{name}}</li>
+  {{/each}}
+</ul>
+```
+
+```handlebars
+<ul>
+  {{#each people}}
+    <li>{{name}}</li>
+  {{/each}}
+</ul>
+```
+
+You should now be using:
+
+```handlebars
+<ul>
+  {{#each person in people}}
+    <li>{{person.name}}</li>
+  {{/each}}
+</ul>
+```
 
 ### Deprecations Added in 1.10
 

--- a/source/guides/getting-started/adding-child-routes.md
+++ b/source/guides/getting-started/adding-child-routes.md
@@ -7,13 +7,13 @@ In `index.html` move the entire `<ul>` of todos into a new template named `todos
 <body>
 <script type="text/x-handlebars" data-template-name="todos/index">
   <ul id="todo-list">
-    {{#each itemController="todo"}}
-      <li {{bind-attr class="isCompleted:completed isEditing:editing"}}>
-        {{#if isEditing}}
-          {{edit-todo class="edit" value=title focus-out="acceptChanges" insert-newline="acceptChanges"}}
+    {{#each todo in model itemController="todo"}}
+      <li {{bind-attr class="todo.isCompleted:completed todo.isEditing:editing"}}>
+        {{#if todo.isEditing}}
+          {{edit-todo class="edit" value=todo.title focus-out="acceptChanges" insert-newline="acceptChanges"}}
         {{else}}
-          {{input type="checkbox" checked=isCompleted class="toggle"}}
-          <label {{action "editTodo" on="doubleClick"}}>{{title}}</label><button {{action "removeTodo"}} class="destroy"></button>
+          {{input type="checkbox" checked=todo.isCompleted class="toggle"}}
+          <label {{action "editTodo" on="doubleClick"}}>{{todo.title}}</label><button {{action "removeTodo"}} class="destroy"></button>
         {{/if}}
       </li>
     {{/each}}

--- a/source/guides/getting-started/displaying-model-data.md
+++ b/source/guides/getting-started/displaying-model-data.md
@@ -20,10 +20,10 @@ Update `index.html` to replace the static `<li>` elements with a Handlebars `{{e
 ```handlebars
 {{! ... additional lines truncated for brevity ... }}
 <ul id="todo-list">
-  {{#each}}
+  {{#each todo in model}}
     <li>
       <input type="checkbox" class="toggle">
-      <label>{{title}}</label><button class="destroy"></button>
+      <label>{{todo.title}}</label><button class="destroy"></button>
     </li>
   {{/each}}
 </ul>

--- a/source/guides/getting-started/marking-a-model-as-complete-incomplete.md
+++ b/source/guides/getting-started/marking-a-model-as-complete-incomplete.md
@@ -4,10 +4,10 @@ In `index.html` update your template to wrap each todo in its own controller by 
 
 ```handlebars
 {{! ... additional lines truncated for brevity ... }}
-{{#each itemController="todo"}}
-  <li {{bind-attr class="isCompleted:completed"}}>
-    {{input type="checkbox" checked=isCompleted class="toggle"}}
-    <label>{{title}}</label><button class="destroy"></button>
+{{#each todo in todos itemController="todo"}}
+  <li {{bind-attr class="todo.isCompleted:completed"}}>
+    {{input type="checkbox" checked=todo.isCompleted class="toggle"}}
+    <label>{{todo.title}}</label><button class="destroy"></button>
   </li>
 {{/each}}
 {{! ... additional lines truncated for brevity ... }}

--- a/source/guides/getting-started/toggle-todo-editing-state.md
+++ b/source/guides/getting-started/toggle-todo-editing-state.md
@@ -4,13 +4,13 @@ We'll update the application to allow users to toggle into this editing state fo
 
 ```handlebars
  {{! ... additional lines truncated for brevity ... }}
-{{#each itemController="todo"}}
-  <li {{bind-attr class="isCompleted:completed isEditing:editing"}}>
-    {{#if isEditing}}
+{{#each todo in todos itemController="todo"}}
+  <li {{bind-attr class="todo.isCompleted:completed todo.isEditing:editing"}}>
+    {{#if todo.isEditing}}
       <input class="edit">
     {{else}}
-      {{input type="checkbox" checked=isCompleted class="toggle"}}
-      <label {{action "editTodo" on="doubleClick"}}>{{title}}</label><button class="destroy"></button>
+      {{input type="checkbox" checked=todo.isCompleted class="toggle"}}
+      <label {{action "editTodo" on="doubleClick"}}>{{todo.title}}</label><button class="destroy"></button>
     {{/if}}
   </li>
 {{/each}}

--- a/source/guides/templates/displaying-a-list-of-items.md
+++ b/source/guides/templates/displaying-a-list-of-items.md
@@ -2,15 +2,14 @@ If you need to enumerate over a list of objects, use Handlebars' `{{#each}}` hel
 
 ```handlebars
 <ul>
-  {{#each people}}
-    <li>Hello, {{name}}!</li>
+  {{#each person in people}}
+    <li>Hello, {{person.name}}!</li>
   {{/each}}
 </ul>
 ```
 
 The template inside of the `{{#each}}` block will be repeated once for
-each item in the array, with the context of the template set to the
-current item.
+each item in the array, with the each item set to the `person` keyword.
 
 The above example will print a list like this:
 
@@ -26,38 +25,13 @@ Like everything in Handlebars, the `{{#each}}` helper is bindings-aware.
 If your application adds a new item to the array, or removes an item,
 the DOM will be updated without having to write any code.
 
-There is an alternative form of `{{#each}}` that does not change the
-scope of its inner template. This is useful for cases where you need to
-access a property from the outer scope within the loop.
-
-```handlebars
-{{name}}'s Friends
-
-<ul>
-  {{#each friend in friends}}
-    <li>{{name}}'s friend {{friend.name}}</li>
-  {{/each}}
-</ul>
-```
-
-This would print a list like this:
-
-```html
-Trek's Friends
-
-<ul>
-  <li>Trek's friend Yehuda</li>
-  <li>Trek's friend Tom!</li>
-</ul>
-```
-
 The `{{#each}}` helper can have a matching `{{else}}`.
 The contents of this block will render if the collection is empty:
 
 ```handlebars
-{{#each people}}
-  Hello, {{name}}!
+{{#each person in people}}
+  Hello, {{person.name}}!
 {{else}}
   Sorry, nobody is here.
-{{/each}}  
+{{/each}}
 ```

--- a/source/javascripts/app/examples/loading/templates/application.hbs
+++ b/source/javascripts/app/examples/loading/templates/application.hbs
@@ -1,13 +1,13 @@
 <h3>Last 3 Pull Requests to Ember.js</h3>
 <ul>
-{{#each}}
+{{#each pr in model}}
   <li>
-    <div class="issue-number">#{{number}}</div>
+    <div class="issue-number">#{{pr.number}}</div>
     <div class="issue-title">
-      <a {{bind-attr href=html_url}}>{{title}}</a>
+      <a {{bind-attr href=html_url}}>{{pr.title}}</a>
     </div>
     <div class="author-name">
-      Opened by <a {{bind-attr href=head.user.html_url}}><strong>@{{head.user.login}}</strong></a>
+      Opened by <a {{bind-attr href=pr.head.user.html_url}}><strong>@{{pr.head.user.login}}</strong></a>
     </div>
   </li>
 {{/each}}

--- a/source/javascripts/app/examples/routing/templates/application.hbs
+++ b/source/javascripts/app/examples/routing/templates/application.hbs
@@ -2,13 +2,13 @@
 <aside>
     <ul>
         <li><h2>Mailboxes</h2></li>
-        {{#each}}
+        {{#each mailbox in model}}
             <li>
-                {{#link-to "mailbox" this current-when="mailbox"}}
+                {{#link-to "mailbox" mailbox current-when="mailbox"}}
                     <span class="count">
-                        {{messages.length}}
+                        {{mailbox.messages.length}}
                     </span>
-                    {{name}}
+                    {{mailbox.name}}
                 {{/link-to}}
             </li>
         {{/each}}

--- a/source/javascripts/app/examples/routing/templates/mailbox.hbs
+++ b/source/javascripts/app/examples/routing/templates/mailbox.hbs
@@ -6,12 +6,12 @@
         <th>To</th>
     </tr>
 
-    {{#each messages}}
-        {{#link-to "mail" this tagName="tr"}}
-            <td>{{date date}}</td>
-            <td>{{view.isActive}}{{subject}}</td>
-            <td>{{from}}</td>
-            <td>{{to}}</td>
+    {{#each message in messages}}
+        {{#link-to "mail" message tagName="tr"}}
+            <td>{{date message.date}}</td>
+            <td>{{view.isActive}}{{message.subject}}</td>
+            <td>{{message.from}}</td>
+            <td>{{message.to}}</td>
         {{/link-to}}
     {{/each}}
 </table>


### PR DESCRIPTION
Also add to 1.9 section of deprecation guide.

RE: https://github.com/emberjs/ember.js/pull/9523.
