### PR TITLE
Update cookbook modal dialog JSBin

### DIFF
--- a/source/guides/cookbook/user_interface_and_interaction/using_modal_dialogs.md
+++ b/source/guides/cookbook/user_interface_and_interaction/using_modal_dialogs.md
@@ -64,5 +64,6 @@ This example shows:
   1. Wrapping the common modal markup and actions in a component.
   1. Handling events to close the modal when the overlay is clicked.
 
-<a class="jsbin-embed" href="http://emberjs.jsbin.com/lokozegi/110/edit">JS Bin</a>
-
+<a class="jsbin-embed" href="http://emberjs.jsbin.com/peyogo/2/embed?html,js,output">
+  Recipe: Using a Modal Dialog
+</a>


### PR DESCRIPTION
Someone pointed out that there were some mis-matched HTML tags in the JSBin. Also this embed link hides the CSS output, which looks more reasonable on the page than having 4 columns showing in the JSBin. 
