### PR TITLE
Remove extraneous line from 'creating a new model' code snippet

### DIFF
--- a/source/guides/getting-started/creating-a-new-model.md
+++ b/source/guides/getting-started/creating-a-new-model.md
@@ -24,7 +24,6 @@ Todos.TodosController = Ember.ArrayController.extend({
     createTodo: function() {
       // Get the todo title set by the "New Todo" text field
       var title = this.get('newTitle');
-      if (!title) { return false; }
       if (!title.trim()) { return; }
 
       // Create the new Todo model


### PR DESCRIPTION
The line being removed was confusing, because it wasn't clear why the first one returns false and the second returns without a value.  On looking at the JSBin and the code diffs, I saw that the first line wasn't there, it must have been left over from an older version of the code.  So I removed the extraneous line to bring the code snippet more in line with the actual code.
