### PR TITLE
Update displaying-a-models-completeness.md

### DIFF
--- a/source/guides/getting-started/displaying-a-models-completeness.md
+++ b/source/guides/getting-started/displaying-a-models-completeness.md
@@ -2,9 +2,9 @@ TodoMVC strikes through completed todos by applying a CSS class `completed` to t
 
 ```handlebars
 {{! ... additional lines truncated for brevity ... }}
-<li {{bind-attr class="isCompleted:completed"}}>
+<li {{bind-attr class="todo.isCompleted:completed"}}>
   <input type="checkbox" class="toggle">
-  <label>{{title}}</label><button class="destroy"></button>
+  <label>{{todo.title}}</label><button class="destroy"></button>
 </li>
 {{! ... additional lines truncated for brevity ... }}
 ```


### PR DESCRIPTION
{{#each todo in model}} , {{#each}} or {{#each todo in todos }} are used interchangeably without notifying the user. I propose to use a consistent approach (whichever is preferred), which is more suitable for step-by-step guide or notifying user about changes if the goal is to get user familiar with different approaches. 
