### PR TITLE
Fix minor bug in the "Loading data from a server" example

### DIFF
--- a/source/javascripts/app/examples/loading/templates/application.hbs
+++ b/source/javascripts/app/examples/loading/templates/application.hbs
@@ -4,7 +4,7 @@
   <li>
     <div class="issue-number">#{{pr.number}}</div>
     <div class="issue-title">
-      <a {{bind-attr href=html_url}}>{{pr.title}}</a>
+      <a {{bind-attr href=pr.html_url}}>{{pr.title}}</a>
     </div>
     <div class="author-name">
       Opened by <a {{bind-attr href=pr.head.user.html_url}}><strong>@{{pr.head.user.login}}</strong></a>


### PR DESCRIPTION
This minor bug in one of the examples on the homepage of emberjs.com causes the link to not show up at all.
