### PR TITLE
Put handlebars `input` attrs on their own lines

### DIFF
--- a/source/guides/getting-started/creating-a-new-model.md
+++ b/source/guides/getting-started/creating-a-new-model.md
@@ -3,8 +3,12 @@ Next we'll update our static HTML `<input>` to an Ember view that can expose mor
 ```handlebars
 {{! ... additional lines truncated for brevity ... }}
 <h1>todos</h1>
-{{input type="text" id="new-todo" placeholder="What needs to be done?" 
-              value=newTitle action="createTodo"}}
+{{input
+  type="text"
+  id="new-todo"
+  placeholder="What needs to be done?"
+  value=newTitle
+  action="createTodo"}}
 {{! ... additional lines truncated for brevity ... }}
 ```
 


### PR DESCRIPTION
- Previously, put args after 80 chars on a second line
- Spacing was confusing when reading through guide

Before:

![screen shot 2014-11-15 at 12 18 19 pm](https://cloud.githubusercontent.com/assets/601515/5059049/859d0208-6cc1-11e4-8512-4d84bc4cd1f8.png)

After:

![screen shot 2014-11-15 at 12 17 46 pm](https://cloud.githubusercontent.com/assets/601515/5059050/8bff94ee-6cc1-11e4-8c8d-f5474037ad78.png)
