### PR TITLE
Updated Live Examples test-controller.md

### DIFF
--- a/source/guides/testing/testing-controllers.md
+++ b/source/guides/testing/testing-controllers.md
@@ -65,7 +65,7 @@ test('calling the action setProps updates props A and B', function() {
 
 #### Live Example
 
-<a class="jsbin-embed" href="http://jsbin.com/sanaf/embed?output">Unit Testing 
+<a class="jsbin-embed" href="http://jsbin.com/pokil/embed?output">Unit Testing 
 Controllers "Actions"</a>
 
 ### Testing Controller Needs
@@ -126,7 +126,7 @@ test('modify the post', function() {
 
 #### Live Example
 
-<a class="jsbin-embed" href="http://jsbin.com/busoz/embed?output">Unit Testing Controllers "Needs"</a>
+<a class="jsbin-embed" href="http://jsbin.com/juxima/embed?output">Unit Testing Controllers "Needs"</a>
 
 <script src="http://static.jsbin.com/js/embed.js"></script>
 


### PR DESCRIPTION
Live Examples are failing in JSbin because the ember-qunit file is not loading. It was removed in the master branch. Pointing JSbin to current tag `v0.1.8`solves the problem.
