### PR TITLE
Update Jsbins to remove context switching

### DIFF
--- a/source/guides/getting-started/accepting-edits.md
+++ b/source/guides/getting-started/accepting-edits.md
@@ -73,7 +73,7 @@ actions: {
 This method will set the controller's `isEditing` property to false and commit all changes made to the todo.
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/USOlAna/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/gureki/1/embed?output">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 

--- a/source/guides/getting-started/adding-child-routes.md
+++ b/source/guides/getting-started/adding-child-routes.md
@@ -61,7 +61,7 @@ model for this route is the same model as for the `TodosRoute`.
 This mapping is described in more detail in the [Naming Conventions Guide](/guides/concepts/naming-conventions).
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/oweNovo/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/teheni/1/embed?output">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 

--- a/source/guides/getting-started/creating-a-new-model.md
+++ b/source/guides/getting-started/creating-a-new-model.md
@@ -62,7 +62,7 @@ In `index.html` include `js/controllers/todos_controller.js` as a dependency:
 Reload your web browser to ensure that all files have been referenced correctly and no errors occur. You should now be able to add additional todos by entering a title in the `<input>` and hitting the `<enter>` key.
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/ImukUZO/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/cobuzo/1/embed?output">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 

--- a/source/guides/getting-started/deleting-todos.md
+++ b/source/guides/getting-started/deleting-todos.md
@@ -20,7 +20,7 @@ Note: The current action may be invoked twice (via `acceptChanges`) leading to a
 </aside>
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/eREkanA/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/kebigu/1/embed?output">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 

--- a/source/guides/getting-started/display-a-button-to-remove-completed-todos.md
+++ b/source/guides/getting-started/display-a-button-to-remove-completed-todos.md
@@ -39,7 +39,7 @@ The `completed` and `clearCompleted` methods both invoke the `filterBy` method, 
 Reload your web browser to ensure that there are no errors and the behavior described above occurs.
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/ULovoJI/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/yoxije/1/embed?output">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 

--- a/source/guides/getting-started/displaying-a-models-completeness.md
+++ b/source/guides/getting-started/displaying-a-models-completeness.md
@@ -14,8 +14,8 @@ This code will apply the CSS class `completed` when the todo's `isCompleted` pro
 The first fixture todo in our application has an `isCompleted` property of `true`. Reload the application to see the first todo is now decorated with a strike-through to visually indicate it has been completed.
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/qevuqedita/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
-  
+<a class="jsbin-embed" href="http://jsbin.com/sejelu/1/embed?output">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+
 ### Additional Resources
 
   * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/b15e5deffc41cf5ba4161808c7f46a283dc2277f)

--- a/source/guides/getting-started/displaying-model-data.md
+++ b/source/guides/getting-started/displaying-model-data.md
@@ -35,8 +35,8 @@ The template loops over the content of its controller. This controller is an ins
 Reload your web browser to ensure that all files have been referenced correctly and no errors occur.
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/EJISAne/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
-  
+<a class="jsbin-embed" href="http://jsbin.com/simixi/1/embed?output">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+
 ### Additional Resources
 
   * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/87bd57700110d9dd0b351c4d4855edf90baac3a8)

--- a/source/guides/getting-started/displaying-the-number-of-incomplete-todos.md
+++ b/source/guides/getting-started/displaying-the-number-of-incomplete-todos.md
@@ -34,7 +34,7 @@ The `inflection` property will return either a plural or singular version of the
  Reload your web browser to ensure that no errors occur. You should now see an accurate number for remaining todos.
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/onOCIrA/74/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/cotoyu/1/embed?output">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 

--- a/source/guides/getting-started/marking-a-model-as-complete-incomplete.md
+++ b/source/guides/getting-started/marking-a-model-as-complete-incomplete.md
@@ -37,7 +37,7 @@ Todos.TodoController = Ember.ObjectController.extend({
 });
 ```
 
-When called from the template to display the current `isCompleted` state of the todo, this property will [proxy that question](http://emberjs.com/api/classes/Ember.ObjectController.html) to its underlying `model`. When called with a value because a user has toggled the checkbox in the template, this property will set the `isCompleted` property of its `model` to the passed value (`true` or `false`), persist the model update, and return the passed value so the checkbox will display correctly. 
+When called from the template to display the current `isCompleted` state of the todo, this property will [proxy that question](http://emberjs.com/api/classes/Ember.ObjectController.html) to its underlying `model`. When called with a value because a user has toggled the checkbox in the template, this property will set the `isCompleted` property of its `model` to the passed value (`true` or `false`), persist the model update, and return the passed value so the checkbox will display correctly.
 
 The `isCompleted` function is marked a [computed property](/guides/object-model/computed-properties/) whose value is dependent on the value of `model.isCompleted`.
 
@@ -55,7 +55,7 @@ In `index.html` include `js/controllers/todo_controller.js` as a dependency:
  Reload your web browser to ensure that all files have been referenced correctly and no errors occur. You should now be able to change the `isCompleted` property of a todo.
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/UDoPajA/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/gizopu/1/embed?output">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 

--- a/source/guides/getting-started/show-all-todos-again.md
+++ b/source/guides/getting-started/show-all-todos-again.md
@@ -1,4 +1,4 @@
-Next we can update the application to allow navigating back to the list of all todos. 
+Next we can update the application to allow navigating back to the list of all todos.
 
 In `index.html` convert the `<a>` tag for 'All' todos into a Handlebars `{{link-to}}` helper:
 
@@ -19,7 +19,7 @@ In `index.html` convert the `<a>` tag for 'All' todos into a Handlebars `{{link-
 Reload your web browser to ensure that there are no errors. You should be able to navigate between urls for all, active, and completed todos.
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/uYuGA/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/jowipi/1/embed?output">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 

--- a/source/guides/getting-started/show-only-complete-todos.md
+++ b/source/guides/getting-started/show-only-complete-todos.md
@@ -48,7 +48,7 @@ The model data for this route is the collection of todos whose `isCompleted` pro
 Reload your web browser to ensure that there are no errors and the behavior described above occurs.
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/OzUvuPu/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/heviqo/1/embed?output">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 

--- a/source/guides/getting-started/show-only-incomplete-todos.md
+++ b/source/guides/getting-started/show-only-incomplete-todos.md
@@ -21,7 +21,7 @@ In `js/router.js` update the router to recognize this new path and implement a m
 ```javascript
 Todos.Router.map(function() {
   this.resource('todos', { path: '/' }, function() {
-    // additional child routes    
+    // additional child routes
     this.route('active');
   });
 });
@@ -46,7 +46,7 @@ Normally transitioning into a new route changes the template rendered into the p
 Reload your web browser to ensure that there are no errors and the behavior described above occurs.
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/arITiZu/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/gaqey/1/embed?output">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 

--- a/source/guides/getting-started/toggle-all-todos.md
+++ b/source/guides/getting-started/toggle-all-todos.md
@@ -23,7 +23,7 @@ The count of remaining todos and completed todos used elsewhere in the template 
 Reload your web browser to ensure that there are no errors and the behavior described above occurs.
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/AViZATE/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/jipil/1/embed?output">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 

--- a/source/guides/getting-started/toggle-todo-editing-state.md
+++ b/source/guides/getting-started/toggle-todo-editing-state.md
@@ -17,7 +17,7 @@ We'll update the application to allow users to toggle into this editing state fo
  {{! ... additional lines truncated for brevity ... }}
 ```
 
-The above code applies three new behaviors to our application: it applies the CSS class `editing` when the controller's `isEditing` property is true and removes it when the `isEditing` property is false. We add a new `{{action}}` helper to the `<label>` so double-clicks will call `editTodo` on 
+The above code applies three new behaviors to our application: it applies the CSS class `editing` when the controller's `isEditing` property is true and removes it when the `isEditing` property is false. We add a new `{{action}}` helper to the `<label>` so double-clicks will call `editTodo` on
 this todo's controller. Finally, we wrap our todo in a Handlebars `{{if}}` helper so a text `<input>` will display when we are editing and the todos title will display when we are not editing.
 
 Inside `js/controllers/todo_controller.js` we'll implement the matching logic for this template behavior:
@@ -29,7 +29,7 @@ Todos.TodoController = Ember.ObjectController.extend({
       this.set('isEditing', true);
     }
   },
- 
+
   isEditing: false,
 
 // ... additional lines truncated for brevity ...
@@ -40,8 +40,8 @@ Above we defined an initial `isEditing` value of `false` for controllers of this
 Reload your web browser to ensure that no errors occur. You can now double-click a todo to edit it.
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/usiXemu/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
-  
+<a class="jsbin-embed" href="http://jsbin.com/tucapa/1/embed?output">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+
 ### Additional Resources
 
   * [Changes in this step in `diff` format](https://github.com/emberjs/quickstart-code-sample/commit/616bc4f22900bbaa2bf9bdb8de53ba41209d8cc0)

--- a/source/guides/getting-started/using-other-adapters.md
+++ b/source/guides/getting-started/using-other-adapters.md
@@ -25,7 +25,7 @@ In `index.html` include `js/libs/localstorage_adapter.js` as a dependency:
 Reload your application. Todos you manage will now persist after the application has been closed.
 
 ### Live Preview
-<a class="jsbin-embed" href="http://jsbin.com/aZIXaYo/1/embed?live">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
+<a class="jsbin-embed" href="http://jsbin.com/pewiki/1/embed?output">Ember.js • TodoMVC</a><script src="http://static.jsbin.com/js/embed.js"></script>
 
 ### Additional Resources
 


### PR DESCRIPTION
The Jsbins now match the getting started guide (no more context switching `#each` helpers).
