### PR TITLE
Match docs to code diffs

### DIFF
--- a/source/guides/getting-started/accepting-edits.md
+++ b/source/guides/getting-started/accepting-edits.md
@@ -31,8 +31,8 @@ In `index.html` replace the static `<input>` element with our custom `{{edit-tod
 
 ```handlebars
 {{! ... additional lines truncated for brevity ... }}
-{{#if todo.isEditing}}
-  {{edit-todo class="edit" value=todo.title focus-out="acceptChanges"
+{{#if isEditing}}
+  {{edit-todo class="edit" value=title focus-out="acceptChanges"
                            insert-newline="acceptChanges"}}
 {{else}}
 {{! ... additional lines truncated for brevity ... }}

--- a/source/guides/getting-started/adding-child-routes.md
+++ b/source/guides/getting-started/adding-child-routes.md
@@ -7,13 +7,13 @@ In `index.html` move the entire `<ul>` of todos into a new template named `todos
 <body>
 <script type="text/x-handlebars" data-template-name="todos/index">
   <ul id="todo-list">
-    {{#each todo in model itemController="todo"}}
-      <li {{bind-attr class="todo.isCompleted:completed todo.isEditing:editing"}}>
-        {{#if todo.isEditing}}
-          {{edit-todo class="edit" value=todo.title focus-out="acceptChanges" insert-newline="acceptChanges"}}
+    {{#each itemController="todo"}}
+      <li {{bind-attr class="isCompleted:completed isEditing:editing"}}>
+        {{#if isEditing}}
+          {{edit-todo class="edit" value=title focus-out="acceptChanges" insert-newline="acceptChanges"}}
         {{else}}
-          {{input type="checkbox" checked=todo.isCompleted class="toggle"}}
-          <label {{action "editTodo" on="doubleClick"}}>{{todo.title}}</label><button {{action "removeTodo"}} class="destroy"></button>
+          {{input type="checkbox" checked=isCompleted class="toggle"}}
+          <label {{action "editTodo" on="doubleClick"}}>{{title}}</label><button {{action "removeTodo"}} class="destroy"></button>
         {{/if}}
       </li>
     {{/each}}

--- a/source/guides/getting-started/displaying-model-data.md
+++ b/source/guides/getting-started/displaying-model-data.md
@@ -20,10 +20,10 @@ Update `index.html` to replace the static `<li>` elements with a Handlebars `{{e
 ```handlebars
 {{! ... additional lines truncated for brevity ... }}
 <ul id="todo-list">
-  {{#each todo in model}}
+  {{#each}}
     <li>
       <input type="checkbox" class="toggle">
-      <label>{{todo.title}}</label><button class="destroy"></button>
+      <label>{{title}}</label><button class="destroy"></button>
     </li>
   {{/each}}
 </ul>

--- a/source/guides/getting-started/marking-a-model-as-complete-incomplete.md
+++ b/source/guides/getting-started/marking-a-model-as-complete-incomplete.md
@@ -4,10 +4,10 @@ In `index.html` update your template to wrap each todo in its own controller by 
 
 ```handlebars
 {{! ... additional lines truncated for brevity ... }}
-{{#each todo in model itemController="todo"}}
-  <li {{bind-attr class="todo.isCompleted:completed"}}>
-    {{input type="checkbox" checked=todo.isCompleted class="toggle"}}
-    <label>{{todo.title}}</label><button class="destroy"></button>
+{{#each itemController="todo"}}
+  <li {{bind-attr class="isCompleted:completed"}}>
+    {{input type="checkbox" checked=isCompleted class="toggle"}}
+    <label>{{title}}</label><button class="destroy"></button>
   </li>
 {{/each}}
 {{! ... additional lines truncated for brevity ... }}

--- a/source/guides/getting-started/toggle-todo-editing-state.md
+++ b/source/guides/getting-started/toggle-todo-editing-state.md
@@ -4,13 +4,13 @@ We'll update the application to allow users to toggle into this editing state fo
 
 ```handlebars
  {{! ... additional lines truncated for brevity ... }}
-{{#each todo in model itemController="todo"}}
-  <li {{bind-attr class="todo.isCompleted:completed todo.isEditing:editing"}}>
-    {{#if todo.isEditing}}
+{{#each itemController="todo"}}
+  <li {{bind-attr class="isCompleted:completed isEditing:editing"}}>
+    {{#if isEditing}}
       <input class="edit">
     {{else}}
       {{input type="checkbox" checked=todo.isCompleted class="toggle"}}
-      <label {{action "editTodo" on="doubleClick"}}>{{todo.title}}</label><button class="destroy"></button>
+      <label {{action "editTodo" on="doubleClick"}}>{{title}}</label><button class="destroy"></button>
     {{/if}}
   </li>
 {{/each}}


### PR DESCRIPTION
When I was going through the tutorials, I had to follow the code in the Github diffs, instead of the code in the tutorials. There is already a PR in for 'displaying-model-data', but the rest of the files in here did not match the diffs on Github, so I went ahead and changed all the discrepancies I saw so that it was all in one place. Thanks!