### PR TITLE
Singularize store.find() example

### DIFF
--- a/source/guides/routing/defining-your-routes.md
+++ b/source/guides/routing/defining-your-routes.md
@@ -220,7 +220,7 @@ route handler might look like this:
 ```js
 App.PostsRoute = Ember.Route.extend({
   model: function() {
-    return this.store.find('posts');
+    return this.store.find('post');
   }
 });
 ```


### PR DESCRIPTION
This was confusing a user on StackOverflow [here](http://stackoverflow.com/questions/27178231/inflection-usage-for-fetching-model-in-emberjs).  Given that the model in question is `Post`, we should reference the singular instead of the plural version.
