### PR TITLE
Amend the 1.9 block post to show `pauseTest` used with `return`

### DIFF
--- a/source/blog/2014-12-08-ember-1-9-0-released.md
+++ b/source/blog/2014-12-08-ember-1-9-0-released.md
@@ -103,7 +103,7 @@ test execution.
 ```javascript
 test('clicking login authenticates', function(){
   visit('/');
-  pauseTest();
+  return pauseTest();
   // The test will never proceed to execute this click
   click('a:contains(Login)');
 });


### PR DESCRIPTION
As requested https://github.com/emberjs/website/pull/1856#issuecomment-66329059

@rwjblue I assumed this is what you wanted me to pr, correct me if I am wrong. 
