### PR TITLE
Fix indent for sample code on '/understanding-ember/debugging'

### DIFF
--- a/source/guides/understanding-ember/debugging.md
+++ b/source/guides/understanding-ember/debugging.md
@@ -164,13 +164,13 @@ Ember.LOG_STACKTRACE_ON_DEPRECATION = true
 
 ```javascript
 Ember.onerror = function(error) {
-    Em.$.ajax('/error-notification', {
-      type: 'POST',
-      data: {
-        stack: error.stack,
-        otherInformation: 'exception message'
-      }
-    });
+  Ember.$.ajax('/error-notification', {
+    type: 'POST',
+    data: {
+      stack: error.stack,
+      otherInformation: 'exception message'
+    }
+  });
 }
 ```
 


### PR DESCRIPTION
The indent size equal 2 is better than 4.

Before:
![2014-12-15 4 08 25](https://cloud.githubusercontent.com/assets/290782/5428681/7325824c-8410-11e4-8f8c-6151c412d59b.png)

After:
![2014-12-15 4 08 59](https://cloud.githubusercontent.com/assets/290782/5428683/76b70c8c-8410-11e4-99a4-8c9697d4906d.png)
