### PR TITLE
Doc: fixing a typo in the documentation

### DIFF
--- a/data/api.yml
+++ b/data/api.yml
@@ -7208,7 +7208,7 @@ classitems:
         // failure
       } else {
         try {
-          findBoooksByAuthor(author, function(books, err) {
+          findBooksByAuthor(author, function(books, err) {
             if (err) {
               failure(err);
             } else {


### PR DESCRIPTION
Just found a typo while reading some docs today. Thanks for the awesome work on the documentation!
