### PR TITLE
Remove incorrect instruction to append with `Id`

### DIFF
--- a/source/guides/models/the-rest-adapter.md
+++ b/source/guides/models/the-rest-adapter.md
@@ -179,8 +179,7 @@ The JSON should encode the relationship as an array of IDs:
 will send a `GET` request to `/comments?ids[]=1&ids[]=2&ids[]=3`.
 
 Any `belongsTo` relationships in the JSON representation should be the
-camelized version of the Ember Data model's name, with the string
-`Id` appended. For example, if you have a model:
+camelized version of the Ember Data model's name. For example, if you have a model:
 
 ```js
 App.Comment = DS.Model.extend({


### PR DESCRIPTION
The model name should no longer be appended with `Id`, and this is reflected in the example code but not in the text.