### PR TITLE
change comment to match preceding step in tutorial

### DIFF
--- a/source/guides/getting-started/show-only-incomplete-todos.md
+++ b/source/guides/getting-started/show-only-incomplete-todos.md
@@ -21,7 +21,7 @@ In `js/router.js` update the router to recognize this new path and implement a m
 ```javascript
 Todos.Router.map(function() {
   this.resource('todos', { path: '/' }, function() {
-    // additional child routes
+    // additional child routes will go here later
     this.route('active');
   });
 });


### PR DESCRIPTION
the comment, as it was, implied (to me) that the code snippet was hiding existing code for brevity, but actually, there are no other child routes at this point.