### PR TITLE
Fix Ember Data API docs build script

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -76,7 +76,7 @@ def generate_ember_data_docs
       sha = describe =~ /-g(.+)/ ? $1 : describe
     end
 
-    sh("npm install && npm run dist")
+    sh("npm install && npm run build:production")
   end
 
   # JSON is valid YAML


### PR DESCRIPTION
Ember Data's build tools were refactored recently and `npm run dist`
no longer works. This pr updates the generate_ember_data_docs script
to call `npm run build:production`