### PR TITLE
Remove deprecated code example from Cookbook

### DIFF
--- a/source/guides/cookbook/user_interface_and_interaction/using_modal_dialogs.md
+++ b/source/guides/cookbook/user_interface_and_interaction/using_modal_dialogs.md
@@ -12,7 +12,7 @@ to handle the main outlet and a modal outlet:
 
 ```handlebars
 {{outlet}}
-{{outlet modal}}
+{{outlet 'modal'}}
 ```
 
 Then you can render a controller and template into the `modal` outlet.  Sending


### PR DESCRIPTION
Using `{{outlet modal}}` produces warning:
~~~~
DEPRECATION: Using {{outlet}} with an unquoted name is not supported. Please update to quoted usage '{{outlet "modal"}}'.
        at outletHelper (http://localhost:4200/assets/vendor.js:34983:13)
        at Object.__exports__.default.Ember.Handlebars.template.main (grruca/templates/application.js:10:105)
        at ret (http://localhost:4200/assets/vendor.js:11023:32)
        at CoreView.extend.render (http://localhost:4200/assets/vendor.js:56437:20)
        at EmberRenderer_createElement [as createElement] (http://localhost:4200/assets/vendor.js:53540:16)
        at EmberRenderer.Renderer_renderTree [as renderTree] (http://localhost:4200/assets/vendor.js:23631:24)
        at EmberRenderer.scheduledRenderTree (http://localhost:4200/assets/vendor.js:23708:16)
        at Queue.invoke (http://localhost:4200/assets/vendor.js:14393:18)
        at Object.Queue.flush (http://localhost:4200/assets/vendor.js:14458:13)
~~~~