### PR TITLE
Remove a superfluous 'that'

### DIFF
--- a/source/blog/2013-08-29-ember-1-0-rc8.md
+++ b/source/blog/2013-08-29-ember-1-0-rc8.md
@@ -139,7 +139,7 @@ naming conventions a lot easier.
 
 <img src="/images/blog/rc8-routes.png">
 
-And finally, a view tree that shows an overlay in your app with the
+And finally, a view tree showing an overlay in your app with the
 associated controller and model for your application's templates.
 
 <img src="/images/blog/rc8-view-tree.png">
@@ -308,7 +308,7 @@ App.Person = Ember.Object.extend({
 
 #### Computed Property Performance Improvements
 
-The latest release of Ember.js contains a change to the way observers and
+The latest release of Ember.js contains a change to the way that observers and
 computed properties interact. This may be a breaking change in apps that
 relied on the previous behavior.
 


### PR DESCRIPTION
The word 'that' did not make sense in the sentence, I therefore removed it.