### PR TITLE
Add missing transition plan in handlebars scope deprecation

### DIFF
--- a/source/deprecations/v1.x.html.md
+++ b/source/deprecations/v1.x.html.md
@@ -205,6 +205,14 @@ You should now be using:
 
 ```handlebars
 <ul>
+  {{#each person in this}}
+    <li>{{person.name}}</li>
+  {{/each}}
+</ul>
+```
+
+```handlebars
+<ul>
   {{#each person in people}}
     <li>{{person.name}}</li>
   {{/each}}


### PR DESCRIPTION
Under ["More Consistent Handlebars Scope - Transition Plan"](http://emberjs.com/guides/deprecations#toc_transition-plan), there's no corresponding transition for using just `{{#each}}`:

```handlebars
<ul>
  {{#each}}
    <li>{{name}}</li>
  {{/each}}
</ul>
```

For consistency, it would be better to also add sample code using the new syntax with `this` (or `controller`) as the context. For instance, when you're using an `ArrayController` and you want to proxy instead of calling `model` directly.