### PR TITLE
Fix broken jsbin examples in testing guide - Issue #1881

### DIFF
--- a/source/guides/testing/test-helpers.md
+++ b/source/guides/testing/test-helpers.md
@@ -164,4 +164,4 @@ Ember.Test.registerAsyncHelper('addContact',
 Here is an example using both `registerHelper` and
 `registerAsyncHelper`.
 
-<a class="jsbin-embed" href="http://jsbin.com/jesuyeri/20/embed?output">Custom Test Helpers</a>
+<a class="jsbin-embed" href="http://jsbin.com/yoyatiluta/1/embed?output">Custom Test Helpers</a>

--- a/source/guides/testing/testing-components.md
+++ b/source/guides/testing/testing-components.md
@@ -95,7 +95,7 @@ test('template is rendered with the color name', function(){
 
 #### Live Example
 
-<a class="jsbin-embed" href="http://jsbin.com/bafologixi/1/embed?output">Unit Testing 
+<a class="jsbin-embed" href="http://jsbin.com/xagowicabu/1/embed?output">Unit Testing
 Components</a>
 
 ### Interacting with Components in the DOM
@@ -145,7 +145,7 @@ test('clicking link updates the title', function() {
 
 #### Live Example
 
-<a class="jsbin-embed" href="http://jsbin.com/xuladiyili/1/embed?output">Unit 
+<a class="jsbin-embed" href="http://jsbin.com/kolumurite/1/embed?output">Unit
 Testing Components</a>
 
 ### Components with embedded layout
@@ -198,7 +198,7 @@ test('clicking link updates the title', function() {
 
 #### Live Example
 
-<a class="jsbin-embed" href="http://jsbin.com/honuyeyoga/1/embed?output">Testing 
+<a class="jsbin-embed" href="http://jsbin.com/kexeladayo/1/embed?output">Testing
 Components with Built-in Layout</a>
 
 ### Programmatically interacting with components
@@ -230,7 +230,7 @@ test('sending changeName message updates the title', function() {
 
 #### Live Example
 
-<a class="jsbin-embed" href="http://jsbin.com/zudafevize/1/embed?output">Programatically 
+<a class="jsbin-embed" href="http://jsbin.com/kuwanafale/1/embed?output">Programatically
 Testing Components</a>
 
 ### `sendAction` validation in components
@@ -290,7 +290,7 @@ test('trigger external action when button is clicked', function() {
 
 #### Live Example
 
-<a class="jsbin-embed" href="http://jsbin.com/zizehimema/1/embed?output">sendAction 
+<a class="jsbin-embed" href="http://jsbin.com/fulibifore/1/embed?output">sendAction
 Validation in Components</a>
 
 ### Components Using Other Components
@@ -361,7 +361,7 @@ test('renders kittens', function() {
 
 #### Live Example
 
-<a class="jsbin-embed" href="http://jsbin.com/kokubexoma/1/embed?output">Components 
+<a class="jsbin-embed" href="http://jsbin.com/jirizimeru/1/embed?output">Components
 with Embedded Components</a>
 
 <script src="http://static.jsbin.com/js/embed.js"></script>

--- a/source/guides/testing/testing-controllers.md
+++ b/source/guides/testing/testing-controllers.md
@@ -65,7 +65,7 @@ test('calling the action setProps updates props A and B', function() {
 
 #### Live Example
 
-<a class="jsbin-embed" href="http://jsbin.com/ruletipazo/1/embed?output">Unit Testing 
+<a class="jsbin-embed" href="http://jsbin.com/pulenamuwu/1/embed?output">Unit Testing
 Controllers "Actions"</a>
 
 ### Testing Controller Needs
@@ -126,7 +126,7 @@ test('modify the post', function() {
 
 #### Live Example
 
-<a class="jsbin-embed" href="http://jsbin.com/didajamadi/1/embed?output">Unit Testing Controllers "Needs"</a>
+<a class="jsbin-embed" href="http://jsbin.com/loluhixoya/1/embed?output">Unit Testing Controllers "Needs"</a>
 
 <script src="http://static.jsbin.com/js/embed.js"></script>
 

--- a/source/guides/testing/testing-models.md
+++ b/source/guides/testing/testing-models.md
@@ -43,7 +43,7 @@ test('levelUp', function() {
 
 #### Live Example
 
-<a class="jsbin-embed" href="http://jsbin.com/yuguyibaso/1/embed?output">Unit Testing 
+<a class="jsbin-embed" href="http://jsbin.com/roqurabiva/1/embed?output">Unit Testing
 Ember Data Models</a>
 
 ## Testing Relationships
@@ -80,7 +80,7 @@ test('profile relationship', function() {
 
 #### Live Example
 
-<a class="jsbin-embed" href="http://jsbin.com/cequredoke/1/embed?output">Unit Testing Models (Relationships : One-to-One)</a>
+<a class="jsbin-embed" href="http://jsbin.com/luvoyibeba/1/embed?output">Unit Testing Models (Relationships : One-to-One)</a>
 
 <script src="http://static.jsbin.com/js/embed.js"></script>
 

--- a/source/guides/testing/testing-routes.md
+++ b/source/guides/testing/testing-routes.md
@@ -67,7 +67,7 @@ test('Alert is called on displayAlert', function() {
 
 #### Live Example
 
-<a class="jsbin-embed" href="http://jsbin.com/liratahuzo/1/embed?output">Custom Test Helpers</a>
+<a class="jsbin-embed" href="http://jsbin.com/kazenefuku/1/embed?output">Custom Test Helpers</a>
 
 <script src="http://static.jsbin.com/js/embed.js"></script>
 

--- a/source/guides/testing/testing-user-interaction.md
+++ b/source/guides/testing/testing-user-interaction.md
@@ -36,7 +36,7 @@ test('add new post', function() {
 
 #### Live Example
 
-<a class="jsbin-embed" href="http://jsbin.com/gokor/embed?output">Testing User 
+<a class="jsbin-embed" href="http://jsbin.com/habekupomu/1/embed?output">Testing User
 Interaction</a>
 
 ### Testing Transitions
@@ -80,6 +80,6 @@ test('redirect to login if not authenticated', function() {
 
 #### Live Example
 
-<a class="jsbin-embed" href="http://jsbin.com/nulif/embed?output">Testing Transitions</a>
+<a class="jsbin-embed" href="http://jsbin.com/hiyicadewi/1/embed?output">Testing Transitions</a>
 
 <script src="http://static.jsbin.com/js/embed.js"></script>

--- a/source/guides/testing/unit-testing-basics.md
+++ b/source/guides/testing/unit-testing-basics.md
@@ -39,7 +39,7 @@ test('computedFoo correctly concats foo', function() {
 
 #### Live Example
 
-<a class="jsbin-embed" href="http://jsbin.com/miziz/embed?output">Unit Testing 
+<a class="jsbin-embed" href="http://jsbin.com/dubiyexiqe/1/embed?output">Unit Testing
 Basics: Computed Properties</a>
 
 ### Testing Object Methods
@@ -73,7 +73,7 @@ test('calling testMethod updates foo', function() {
 
 #### Live Example
 
-<a class="jsbin-embed" href="http://jsbin.com/weroh/embed?output">Unit Testing 
+<a class="jsbin-embed" href="http://jsbin.com/bobaropega/1/embed?output">Unit Testing
 Basics: Method Side Effects</a>
 
 In the event the object's method returns a value you can simply assert that the
@@ -104,7 +104,7 @@ test('testMethod returns incremented count', function() {
 
 #### Live Example
 
-<a class="jsbin-embed" href="http://jsbin.com/qutar/embed?output">Unit Testing 
+<a class="jsbin-embed" href="http://jsbin.com/vigehojahi/1/embed?output">Unit Testing
 Basics: Method Side Effects</a>
 
 ### Testing Observers
@@ -136,6 +136,6 @@ test('doSomething observer sets other prop', function() {
 
 #### Live Example
 
-<a class="jsbin-embed" href="http://jsbin.com/daxok/embed?output">Unit Testing Basics: Observers</a>
+<a class="jsbin-embed" href="http://jsbin.com/yajejicopu/1/embed?output">Unit Testing Basics: Observers</a>
 
 <script src="http://static.jsbin.com/js/embed.js"></script>


### PR DESCRIPTION
Fixed the broken jsbins in the testing guide - they were referencing an older version of handlebars. 