### PR TITLE
Deprecate store.find(type) and store.find(type, query)

### DIFF
--- a/source/guides/concepts/naming-conventions.md
+++ b/source/guides/concepts/naming-conventions.md
@@ -104,7 +104,7 @@ Here's an example:
 App.FavoritesRoute = Ember.Route.extend({
   model: function() {
     // the model is an Array of all of the posts
-    return this.store.find('post');
+    return this.store.findAll('post');
   }
 });
 ```

--- a/source/guides/controllers/index.md
+++ b/source/guides/controllers/index.md
@@ -93,9 +93,9 @@ throughout the lifetime of the application without requiring that
 the view knows anything about those mechanics.
 
 For example, if the user navigates from `/posts/1` to `/posts/2`,
-the `PostController` will change its model from `Post.find(1)` to
-`Post.find(2)`. The template will update its representations of any
-properties on the model, as well as any computed properties on the
+the `PostController` will change its model from `store.find('post', 1)`
+to `store.find('post', 2)`. The template will update its representations
+of any properties on the model, as well as any computed properties on the
 controller that depend on the model.
 
 This makes it easy to test a template in isolation by rendering it 

--- a/source/guides/getting-started/displaying-model-data.md
+++ b/source/guides/getting-started/displaying-model-data.md
@@ -6,7 +6,7 @@ Inside the file `js/router.js` implement a `TodosRoute` class with a `model` fun
 // ... additional lines truncated for brevity ...
 Todos.TodosRoute = Ember.Route.extend({
   model: function() {
-    return this.store.find('todo');
+    return this.store.findAll('todo');
   }
 });
 ```

--- a/source/guides/models/finding-records.md
+++ b/source/guides/models/finding-records.md
@@ -1,14 +1,11 @@
 The Ember Data store provides a simple interface for finding records of a single
-type through the `store` object's `find` method. Internally, the `store`
-uses `find`, `findAll`, and `findQuery` based on the supplied arguments.
+type through the `store` object's `find`, `findAll` and `findQuery` methods.
 
-The first argument to `store.find()` is always the record type. The optional second
-argument determines if a request is made for all records, a single record, or a query.
 
 ### Finding All Records of a Type
 
 ```javascript
-var posts = this.store.find('post'); // => GET /posts
+var posts = this.store.findAll('post'); // => GET /posts
 ```
 
 To get a list of records already loaded into the store, without making
@@ -18,7 +15,7 @@ another network request, use `all` instead.
 var posts = this.store.all('post'); // => no network request
 ```
 
-`find` returns a `DS.PromiseArray` that fulfills to a `DS.RecordArray` and `all`
+`findAll` returns a `DS.PromiseArray` that fulfills to a `DS.RecordArray` and `all`
 directly returns a `DS.RecordArray`.
 
 It's important to note that `DS.RecordArray` is not a JavaScript array.
@@ -30,25 +27,24 @@ will not work--you'll have to use `objectAt(index)` instead.
 
 ### Finding a Single Record
 
-If you provide a number or string as the second argument to `store.find()`,
-Ember Data will assume that you are passing in an ID and attempt to retrieve a record of the type passed in as the first argument with that ID. This will
-return a promise that fulfills with the requested record:
-
 ```javascript
 var aSinglePost = this.store.find('post', 1); // => GET /posts/1
 ```
 
+`find` will return a promise that fulfills with the requested record.
+
+
 ### Querying For Records
 
-If you provide a plain object as the second argument to `find`, Ember Data will
-make a `GET` request with the object serialized as query params. This method returns
-`DS.PromiseArray` in the same way as `find` with no second argument.
+Using `findQuery`, Ember Data will make a `GET` request with the object
+serialized as query params. This method returns `DS.PromiseArray` in the same
+way as `findAll`.
 
 For example, we could search for all `person` models who have the name of
 `Peter`:
 
 ```javascript
-var peters = this.store.find('person', { name: "Peter" }); // => GET to /persons?name='Peter'
+var peters = this.store.findQuery('person', { name: "Peter" }); // => GET to /persons?name='Peter'
 ```
 
 ### Integrating with the Route's Model Hook
@@ -75,7 +71,7 @@ App.Router.map(function() {
 
 App.PostsRoute = Ember.Route.extend({
   model: function() {
-    return this.store.find('post');
+    return this.store.findAll('post');
   }
 });
 

--- a/source/guides/models/handling-metadata.md
+++ b/source/guides/models/handling-metadata.md
@@ -3,7 +3,7 @@ Along with the records returned from your store, you'll likely need to handle so
 Pagination is a common example of using metadata. Imagine a blog with far more posts than you can display at once. You might query it like so:
 
 ```js
-var result = this.store.find("post", {
+var result = this.store.findQuery("post", {
   limit: 10,
   offset: 0
 });

--- a/source/guides/models/index.md
+++ b/source/guides/models/index.md
@@ -88,7 +88,7 @@ a restaurant, you might have models like `Order`, `LineItem`, and
 Fetching orders becomes very easy:
 
 ```js
-this.store.find('order');
+this.store.findAll('order');
 ```
 
 Models define the type of data that will be provided by your server. For

--- a/source/guides/routing/defining-your-routes.md
+++ b/source/guides/routing/defining-your-routes.md
@@ -220,7 +220,7 @@ route handler might look like this:
 ```js
 App.PostsRoute = Ember.Route.extend({
   model: function() {
-    return this.store.find('post');
+    return this.store.findAll('post');
   }
 });
 ```

--- a/source/guides/understanding-ember/dependency-injection-and-service-lookup.md
+++ b/source/guides/understanding-ember/dependency-injection-and-service-lookup.md
@@ -19,7 +19,7 @@ App.IndexController = Ember.ObjectController.extend({
     findItems: function(){
       var controller = this;
       // Dependency injection provides the store object to the controller instance.
-      this.store.find('item').then(function(items){
+      this.store.findAll('item').then(function(items){
         controller.set('items', items);
       });
     }


### PR DESCRIPTION
Update guides to reflect deprecation of store.find(type) and store.find(type, query)

_Don't merge until https://github.com/emberjs/data/pull/2728 has been merged._