### PR TITLE
can't find ember.js/docs/data.json when rake preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,17 @@ the same directory:
 
 Notice that the name of the data project needs to use `ember-data` not `data`
 
-In the website directory execute `bundle exec rake generate_docs`
+To generate docs you should run `npm install` in your `ember.js` and `ember-data` local repos and only after that run `bundle exec rake generate_docs`:
+
+```
+$ cd ember-data
+$ git pull && npm install
+$ cd../ember.js
+$ git pull && npm install
+$ cd ../website
+$ git pull && npm install
+$ bundle exec rake generate_docs
+```
 
 You can launch the website via `bundle exec middleman` to preview the generated docs.
 


### PR DESCRIPTION
I put ember.js/ember-data/website repos on one directory tree level, when I do rake preview I get:

Generating docs data from /Users/xamenrax/code/ember.js... npm run docs

> ember@1.10.0-beta.1 docs /Users/xamenrax/code/ember.js
> ember yuidoc

version: 0.0.46
The specified command yuidoc is invalid, for available options see ember help.
rake aborted!
Errno::ENOENT: No such file or directory @ rb_sysopen - /Users/xamenrax/code/ember.js/docs/data.json
/Users/xamenrax/code/ember-website/Rakefile:56:in `generate_ember_docs'
/Users/xamenrax/code/ember-website/Rakefile:98:in `block in <top (required)>'
/Users/xamenrax/.rvm/gems/ruby-2.1.1@rails-4/bin/ruby_executable_hooks:15:in `eval'
/Users/xamenrax/.rvm/gems/ruby-2.1.1@rails-4/bin/ruby_executable_hooks:15:in `<main>'
Tasks: TOP => generate_docs