### PR TITLE
Avoid confusion by making Classic version explicit

### DIFF
--- a/source/guides/cookbook/helpers_and_components/adding_google_analytics_tracking.md
+++ b/source/guides/cookbook/helpers_and_components/adding_google_analytics_tracking.md
@@ -5,7 +5,7 @@ You want to add analytics to your Ember application.
 ### Solution
 Subscribe to the `didTransition` event inside your application router.
 
-In the following examples we're using Google Analytics but it could be any other analytics product.
+In the following examples we're using Google Analytics (Classic) but it could be any other analytics product.
 Add google analytic's base code to the html file that renders your ember app.
 
 ```html


### PR DESCRIPTION
This bit me on the bottom because I was adding a Universal Analytics tracking code to the Classic Analytics snippet in this article. My own fault for copying and pasting, but I thought it might be useful to be explicit to avoid further confusion for anyone else.

Classic: https://developers.google.com/analytics/devguides/collection/gajs/ (`ga.js`)
Universal Analytics: https://developers.google.com/analytics/devguides/collection/analyticsjs/ (`analytics.js`)

I'd be happy to update the code to the new Google UA snippet if anyone things its worth it.