### PR TITLE
add Rake task to only generate Ember Data docs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -138,6 +138,11 @@ task :generate_docs do
   generate_ember_data_docs
 end
 
+desc "Generate Ember Data docs only"
+task :generate_ember_data_docs do
+  generate_ember_data_docs
+end
+
 desc "Build the website"
 task :build => :generate_docs do
   build


### PR DESCRIPTION
This is nice when you only want to build/publish ember data docs.

Because Middleman will generate docs for ember with ember data,
this often leads to accidentally changing the ember docs when updating
ember data.