### PR TITLE
Fix Sep 14 blog post date

### DIFF
--- a/source/blog/2014-09-13-core-team-meeting-minutes-2014-08-14.md
+++ b/source/blog/2014-09-13-core-team-meeting-minutes-2014-08-14.md
@@ -1,5 +1,5 @@
 ---
-title: Core Team Meeting Minutes - 2014/08/01
+title: Core Team Meeting Minutes - 2014/08/14
 author: Trek Glowacki
 tags: Core Team Meeting Minutes
 ---


### PR DESCRIPTION
September 14th's core team meeting minutes appears with a September 1st date. This PR fixes that :dancer: 

![image](https://cloud.githubusercontent.com/assets/88163/6202199/b72f4e48-b4a1-11e4-894a-5bf46b4a5499.png)
