### PR TITLE
Fixing input event sentence to match current syntax

### DIFF
--- a/source/guides/templates/input-helpers.md
+++ b/source/guides/templates/input-helpers.md
@@ -56,10 +56,10 @@ current context.
 To dispatch an action on specific events, such as `enter` or `key-press`, use the following
 
 ```handlebars
-{{input value=firstName action="updateFirstName" on="key-press"}}
+{{input value=firstName enter="submit" key-press="updateFirstName"}}
 ```
 
-[Event Names](/api/classes/Ember.View.html#toc_event-names) must be dasherized when assigned to `on`.
+[Event Names](/api/classes/Ember.View.html#toc_event-names) must be dasherized when assigned to an action.
 
 ### Checkboxes
 


### PR DESCRIPTION
Example: http://jsbin.com/variwevuje/2/edit

`on` as an argument to `{{input}}` is no longer valid for most of the events, which the docs suggest to use.