### PR TITLE
Correct example in Handlebars Helpers docs

### DIFF
--- a/data/api.yml
+++ b/data/api.yml
@@ -16107,8 +16107,8 @@ classitems:
     ```
 
     ```handlebars
-    {{#link-to 'photoGallery' aPhotoId}}
-      {{aPhoto.title}}
+    {{#link-to 'photoGallery' 42}}
+      Tomster
     {{/link-to}}
     ```
 


### PR DESCRIPTION
The existing example was confusing for me as it's indeterminate whether "aPhotoId" is a static value or a model reference. I modified the example to be more explicit about setting a particular value in the dynamic portion of the href.

I know there's an effort to make the docs more accessible to new developers - I hope this helps! Thanks!