### PR TITLE
fix Handlebars namespace in helper example

### DIFF
--- a/source/guides/templates/writing-helpers.md
+++ b/source/guides/templates/writing-helpers.md
@@ -4,7 +4,7 @@ For example, imagine you are frequently wrapping certain values in a `<span>` ta
 
 ```javascript
 Ember.Handlebars.helper('highlight', function(value, options) {
-  var escaped = Handlebars.Utils.escapeExpression(value);
+  var escaped = Ember.Handlebars.Utils.escapeExpression(value);
   return new Ember.Handlebars.SafeString('<span class="highlight">' + escaped + '</span>');
 });
 ```


### PR DESCRIPTION
Use `Ember.Handlebars` instead of `Handlebars`, for consistency with the rest of the code example.