### PR TITLE
Fix broken rfpolicy link

### DIFF
--- a/source/security/index.md
+++ b/source/security/index.md
@@ -23,7 +23,7 @@ descriptive subject line to avoid having your report be missed.  After
 the initial reply to your report, the security team will endeavor to
 keep you informed of the progress being made towards a fix and full
 announcement. As recommended by
-[RFPolicy](http://www.wiretrip.net/p/libwhisker.html), these updates will
+[RFPolicy](http://www.wiretrip.net/p/rfpolicy.html), these updates will
 be sent at least every five days. In reality, this is more likely to be
 every 24-48 hours.
 


### PR DESCRIPTION
The RFPolicy link on the website is currently broken.