### PR TITLE
Add example using model to 1.9 deprecations around context-switching

### DIFF
--- a/source/guides/deprecations/index.md
+++ b/source/guides/deprecations/index.md
@@ -208,6 +208,14 @@ You should now be using:
   {{/each}}
 </ul>
 ```
+or, if you're just going off the model rather than a property in the controller:
+```handlebars
+<ul>
+  {{#each person in model}}
+    <li>{{person.name}}</li>
+  {{/each}}
+</ul>
+```
 
 ### Deprecations Added in 1.10
 


### PR DESCRIPTION
For newer folk, the use of the word 'model' is helpful, especially for those that are just coming into Ember by following a tutorial.