### PR TITLE
Added link to the API documentation for the model hook

### DIFF
--- a/source/guides/routing/asynchronous-routing.md
+++ b/source/guides/routing/asynchronous-routing.md
@@ -161,6 +161,8 @@ App.FunkyRoute = Ember.Route.extend({
 });
 ```
 
+[See the API Docs for `model`](http://emberjs.com/api/classes/Ember.Route.html#method_model)
+
 ### beforeModel and afterModel
 
 The `model` hook covers many use cases for pause-on-promise transitions,


### PR DESCRIPTION
I'm not sure if this is the absolutely best place to put it, but I definitely feel that we should have the link in here somewhere. We already have links for `beforeModel` and `afterModel`.