### PR TITLE
Clean up 1.12 deprecations

### DIFF
--- a/source/deprecations/v1.x.html.md
+++ b/source/deprecations/v1.x.html.md
@@ -319,7 +319,9 @@ App.instanceInitializer({
 
 Added in [PR #10256](https://github.com/emberjs/ember.js/pull/10256).
 
-#### Warning When Binding Style Attributes
+### Warnings Added in 1.11
+
+#### Binding Style Attributes
 
 Content in Handlebars templates is automatically HTML-escaped to help
 developers prevent inadvertently introducing cross-site scripting (XSS)
@@ -357,44 +359,49 @@ Helpers](http://emberjs.com/guides/templates/writing-helpers/) guide.
 
 ### Deprecations Added in 1.12
 
-#### Deprecate non-block-params {{each}} helper syntax
+#### `in` syntax for `{{each}}`
 
-Now that we have the new block params helper syntax, this old syntax has become redundant.
+The `in` syntax is used to name an iterated value with `{{each}}`. Block
+params, introduced Ember 1.10, obsoletes the `in` syntax.
 
-Before:
+Each helpers should be udpated to use block params. For example this helper:
 
 ```handlebars
 {{#each foo in bar}}
 ```
 
-After:
+Can be converted as follows:
 
 ```handlebars
 {{#each bar as |foo|}}
 ```
 
-#### Deprecate non-block-params {{with}} syntax
+#### `as` sytnax for `{{with}}`
 
-Now that we have the new block helper syntax, this old syntax has become redundant.
+Renaming a value using `{{with}}` has been possible using the `as` syntax. Block params,
+introduces in Ember 1.10, obsolete the `as` syntax.
 
-Before:
+With helpers should be updated to use block params. For example this helper:
 
 ```handlebars
 {{#with foo as bar}}
 ```
 
-After:
+Can be converted as follows:
 
 ```handlebars
 {{#with foo as |bar|}}
 ```
 
-#### Deprecate using the same function as getter and setter in Computed Properties
+#### Computed Properties With a Shared Getter And Setter
 
-Now that we have the new computed property syntax ([RFC](https://github.com/emberjs/rfcs/blob/master/active/0001-improved-cp-syntax.md))
-using the same function as getter and setter is deprecated.
+Ember.js 1.12 introduces an improved syntax for computed properties with
+a setter. Previously, computed properties with a setter implemented that
+setter by inspecting the number of arguments passed to the computed
+property's descriptor.
 
-Before:
+For example, this computed property splits a full name into two
+parts when set:
 
 ```js
   fullName: Ember.computed("firstName", "lastName", function(key, newName) {
@@ -407,7 +414,9 @@ Before:
     }
   });
 ```
-After:
+
+These uses should be converted to use the new discrete getter and setter
+syntax introduced in 1.12:
 
 ```js
   fullName: Ember.computed("firstName", "lastName", {
@@ -421,3 +430,5 @@ After:
     }
   });
 ```
+
+For further reading, review the [RFC](https://github.com/emberjs/rfcs/blob/master/active/0001-improved-cp-syntax.md) describing this feature and the [pull request of the initial implementation](https://github.com/emberjs/ember.js/pull/9527).


### PR DESCRIPTION
/cc @trek @wagenet @rwjblue @cibernox

This generally cleans up some 1.12 guides. Most significant, IMO is that I am changing the headlines to not repeat `Deprecate some foo` for each headline. Repeating a single word makes the text very hard to scan. This is just an example, though it is not the headlines I am changing:

![](https://api.monosnap.com/rpc/file/download?id=kXNgYd1k3sWbksMgeXxX6Z2U8SYMek)

vs

![](https://api.monosnap.com/rpc/file/download?id=sJF5GqAa8mQ27nwZzpgfOx09S1dKAL)

Just wanted to note it for the future, since once we write a headline it is painful to change it (the links from deprecation in old versions of Ember would break).

I'll follow up this PR with one to Ember ensuring the linking is correct.

