### PR TITLE
Point to in and as deprecations from context-switching

### DIFF
--- a/source/deprecations/v1.x.html.md
+++ b/source/deprecations/v1.x.html.md
@@ -128,7 +128,7 @@ This ability will be removed quickly to allow us to mimick the browser's behavio
 
 #### More Consistent Handlebars Scope
 
-In today's Ember, the `each` and `with` helpers come in two flavors: a "context-switching" flavor and a "named-parameter" flavor.
+In Ember 1.9, the `each` and `with` helpers come in two flavors: a "context-switching" flavor and a "named-parameter" flavor.
 
 ```handlebars
 {{#each post in posts}}
@@ -158,7 +158,7 @@ context that may be important.
 Because the helper itself offers no clue about the context-shifting behavior, it is easy (even for more experienced
 Ember developers) to get confused when skimming a template about which object a value refers to.
 
-The context-shifting forms of `#each` and `#with` have been deprecated in favor of the named-parameter forms.
+The context-shifting forms of `#each` and `#with` have been deprecated in favor of the named-parameter forms. In Ember 1.12, the `in` and `as` syntax are further deprecated in favor of block params syntax. See the [deprecation notes for in](/deprecations/v1.x/#toc_code-in-code-syntax-for-code-each-code) and [deprecation notes for as](/deprecations/v1.x/#toc_code-in-code-syntax-for-code-each-code).
 
 ##### Transition Plan
 


### PR DESCRIPTION
Mention that `in` and `as` are deprecated in the context switching section.