### PR TITLE
Only load google maps libraries on meetups page

### DIFF
--- a/source/community/meetups.html.erb
+++ b/source/community/meetups.html.erb
@@ -44,4 +44,6 @@ title: "Meetups"
   </p>
 </div>
 
+<script src="//maps.google.com/maps/api/js?v=3.13&amp;sensor=false&amp;libraries=geometry" type="text/javascript"></script>
+<script src="//google-maps-utility-library-v3.googlecode.com/svn/tags/markerclustererplus/2.0.14/src/markerclusterer_packed.js" type="text/javascript"></script>
 <script src="/javascripts/meetups.js"></script>

--- a/source/layout.erb
+++ b/source/layout.erb
@@ -13,8 +13,6 @@
 
   <body class="<%= page_classes %>">
 
-    <script src="//maps.google.com/maps/api/js?v=3.13&amp;sensor=false&amp;libraries=geometry" type="text/javascript"></script>
-    <script src="//google-maps-utility-library-v3.googlecode.com/svn/tags/markerclustererplus/2.0.14/src/markerclusterer_packed.js" type="text/javascript"></script>
 
     <!--[if lt IE 9]>
       <script type="text/javascript" src="/javascripts/common-old-ie.js"></script>


### PR DESCRIPTION
In response to https://github.com/emberjs/website/issues/2103 this commit moves the inclusion of the google maps libraries from layout.erb to meetups.html.erb