### PR TITLE
Specify the component helper example in the Ember 1.11.0 blog

### DIFF
--- a/source/blog/2015-03-27-ember-1-11-0-released.md
+++ b/source/blog/2015-03-27-ember-1-11-0-released.md
@@ -193,11 +193,9 @@ in a template:
 ```handlebars
 {{#if isRed}}
   {{x-red}}
-{{/if}}
-{{if isBlue}}
+{{else if isBlue}}
   {{x-blue}}
-{{/if}}
-{{if isGreen}}
+{{else if isGreen}}
   {{x-green}}
 {{/if}}
 ```
@@ -208,7 +206,7 @@ Can now be replaced by a computed property and the `component` helper.
 {{component colorComponentName}}
 ```
 
-The property `colorComponentName` should have a value of `x-red`, `x-blue` etc. As
+The property `colorComponentName` should either have a value of `x-red`, or `x-blue` etc. As
 the value of the property changes, the rendered component will also change.
 
 A big thank you to [@lukemelia](https://twitter.com/lukemelia) for shipping


### PR DESCRIPTION
the 'either' word would be very helpful for me when I tested this feature, so I wanted to underline that this is an alternative and only 1 colorComponent is rendered.