### PR TITLE
[FEATURE] removing bind-attr from the build ember app

### DIFF
--- a/source/javascripts/app/builds/templates/_files_table.js.hbs
+++ b/source/javascripts/app/builds/templates/_files_table.js.hbs
@@ -2,20 +2,20 @@
 {{#if project.isEmberBeta}}
   <div class="release-progress clear">
     <div class="left">
-      <div class="small-release-image" {{bind-attr title=project.lastStableVersion}}></div>
+      <div class="small-release-image" title={{project.lastStableVersion}}></div>
       <div class="release-version">{{project.lastStableVersion}}</div>
       <div class="release-date">Released {{format-date-time project.lastStableDate "MMM Do"}}</div>
     </div>
     <div class="float-left-container">
       <div class="release-cycle-title">The path to {{project.finalVersion}}...</div>
-      <div {{bind-attr class=":left project.beta1Completed::future-image"}}>
+      <div class="left {{if project.beta1Completed '' 'future-image'}}">
         <div class="tiny-beta-image"></div>
         <div class="beta-version">beta 1</div>
         {{#if project.isBeta1}}
           <div class="beta-current-version">(current beta)</div>
         {{/if}}
       </div>
-      <div {{bind-attr class=":left project.beta2Completed::future-image"}}>
+      <div class="left {{if project.beta2Completed '' 'future-image'}}">
         <div class="tiny-beta-image"></div>
         <div class="beta-version">beta 2</div>
         {{#if project.isBeta2}}
@@ -25,7 +25,7 @@
           <div class="beta-current-version">(coming {{format-date-time project.nextDate "MMM Do"}})</div>
         {{/if}}
       </div>
-      <div {{bind-attr class=":left project.beta3Completed::future-image"}}>
+      <div class="left {{if project.beta3Completed '' 'future-image'}}">
         <div class="tiny-beta-image"></div>
         <div class="beta-version">beta 3</div>
         {{#if project.isBeta3}}
@@ -35,7 +35,7 @@
           <div class="beta-current-version">(coming {{format-date-time project.nextDate "MMM Do"}})</div>
         {{/if}}
       </div>
-      <div {{bind-attr class=":left project.beta4Completed::future-image"}}>
+      <div class="left {{if project.beta4Completed '' 'future-image'}}">
         <div class="tiny-beta-image"></div>
         <div class="beta-version">beta 4</div>
         {{#if project.isBeta4}}
@@ -45,7 +45,7 @@
           <div class="beta-current-version">(coming {{format-date-time project.nextDate "MMM Do"}})</div>
         {{/if}}
       </div>
-      <div {{bind-attr class=":left project.beta5Completed::future-image"}}>
+      <div class="left {{if project.beta5Completed '' 'future-image'}}">
         <div class="tiny-beta-image"></div>
         <div class="beta-version">beta 5</div>
         {{#if project.isBeta5}}
@@ -93,7 +93,7 @@
     </tr>
   </thead>
   <tbody>
-    {{#each file in project.files}}
+    {{#each project.files as |file|}}
       <tr>
         <td><a {{bind-attr href=file.url}}>{{file.name}}</a></td>
         <td>{{format-date-time file.lastModified}}</td>

--- a/source/javascripts/app/builds/templates/_project_listing.js.hbs
+++ b/source/javascripts/app/builds/templates/_project_listing.js.hbs
@@ -1,5 +1,5 @@
 {{#if filesPresent }}
-  {{#each project in projects}}
+  {{#each projects as |project|}}
     {{partial 'filesTable'}}
   {{/each}}
 {{ else }}

--- a/source/javascripts/app/builds/templates/application.js.hbs
+++ b/source/javascripts/app/builds/templates/application.js.hbs
@@ -1,13 +1,13 @@
 <div id="sidebar">
   <ol id="toc-list">
-    <li {{bind-attr class=":level-1 isIndexActive:selected"}}>{{#link-to 'index'}}Home{{/link-to}}</li>
-    <li {{bind-attr class=":level-1 isTaggedActive:selected"}}>{{#link-to 'tagged'}}Tagged Releases{{/link-to}}</li>
-    <li {{bind-attr class=":level-1 isChannelsActive:selected"}}>
+    <li class="level-1 {{if isIndexActive 'selected'}}">{{#link-to 'index'}}Home{{/link-to}}</li>
+    <li class="level-1 {{if isTaggedActive 'selected'}}">{{#link-to 'tagged'}}Tagged Releases{{/link-to}}</li>
+    <li class="level-1 {{if isChannelsActive 'selected'}}">
       <a>Channels</a>
       <ol style="display:block">
-        <li {{bind-attr class=":level-3 isReleaseActive:sub-selected"}}>{{#link-to 'release'}}Release{{/link-to}}</li>
-        <li {{bind-attr class=":level-3 isBetaActive:sub-selected"}}>{{#link-to 'beta'}}Beta{{/link-to}}</li>
-        <li {{bind-attr class=":level-3 isCanaryActive:sub-selected"}}>{{#link-to 'canary'}}Canary{{/link-to}}</li>
+        <li class="level-3 {{if isReleaseActive 'sub-selected'}}">{{#link-to 'release'}}Release{{/link-to}}</li>
+        <li class="level-3 {{if isBetaActive 'sub-selected'}}">{{#link-to 'beta'}}Beta{{/link-to}}</li>
+        <li class="level-3 {{if isCanaryActive 'sub-selected'}}">{{#link-to 'canary'}}Canary{{/link-to}}</li>
       </ol>
     </li>
   </ol>

--- a/source/javascripts/app/builds/templates/components/copy-clipboard.js.hbs
+++ b/source/javascripts/app/builds/templates/components/copy-clipboard.js.hbs
@@ -1,5 +1,5 @@
 {{#if hasFlash}}
-  <button {{bind-attr data-clipboard-text=text}} {{bind-attr data-label=label}}>{{label}}</button>
+  <button data-clipboard-text={{text}} data-label={{label}}>{{label}}</button>
 {{else}}
-  <input type="text" class="name-input" readonly="readonly" {{bind-attr value=text}}>
+  <input type="text" class="name-input" readonly="readonly" value={{text}}>
 {{/if}}


### PR DESCRIPTION
RIP `bind-attr` 

Also updated to block params in each helpers

@rwjblue I don't really like the empty string for the truth case.
```js
<div class="left {{if project.beta1Completed '' 'future-image'}}">
```
But this is not any better.

```js 
<div class="left {{unless project.beta1Completed 'future-image'}}">
```

Where is `beta1Completed` coming from?

Cheers