### PR TITLE
Add legacy anchors to deprecations

### DIFF
--- a/source/deprecations/v1.x.html.md
+++ b/source/deprecations/v1.x.html.md
@@ -19,11 +19,13 @@ ContainerViews have been observable as arrays, where the items in
 the array are childViews. This introduces complexity into container
 views despite the feature being a rarely used one.
 
+<a name="toc_deprecate-ember-deferredmixin-and-ember-deferred"></a>
 #### Ember.DeferredMixin and Ember.Deferred.
 
 `Ember.DeferredMixin` and `Ember.Deferred` have been deprecated in favor
 of using `RSVP.Promise`s.
 
+<a name="toc_deprecate-code-then-code-on-ember-application"></a>
 #### `.then` on Ember.Application.
 
 As part of the `Ember.DeferredMixin` deprecation, using `.then` on an
@@ -282,6 +284,7 @@ behavior is being used.
 
 Added in [PR #10062](https://github.com/emberjs/ember.js/pull/10062).
 
+<a name="toc_deprecate-access-to-instances-in-initializers"></a>
 #### Access to Instances in Initializers
 
 Previously, initializers had access to an object that allowed them to
@@ -401,6 +404,7 @@ Can be converted as follows:
 {{#with foo as |bar|}}
 ```
 
+<a name="toc_deprecate-using-the-same-function-as-getter-and-setter-in-computed-properties"></a>
 #### Computed Properties With a Shared Getter And Setter
 
 Ember.js 1.12 introduces an improved syntax for computed properties with


### PR DESCRIPTION
To match recent changes in Ember.