### PR TITLE
Add Ember Data beta 16.1 release to the builds page.

### DIFF
--- a/source/javascripts/app/builds/app.js
+++ b/source/javascripts/app/builds/app.js
@@ -224,10 +224,10 @@ App.Project.reopenClass({
       baseFileName: 'ember-data',
       projectFilter: [ /ember-data\./ ],
       projectRepo: 'emberjs/data',
-      lastRelease: "1.0.0-beta.16",
+      lastRelease: "1.0.0-beta.16.1",
       futureVersion: "1.0.0-beta.17",
       channel: "beta",
-      date: "2014-12-31",
+      date: "2015-03-24",
       changelogPath: "CHANGELOG.md",
       debugFileName: ".js"
     }, {


### PR DESCRIPTION
Credit goes to @knownasilya for pointing it out and @fivetanley for uploading the missing files to s3.