### PR TITLE
Add "itemController" description for {{each}}

### DIFF
--- a/source/deprecations/v1.x.html.md
+++ b/source/deprecations/v1.x.html.md
@@ -387,7 +387,16 @@ Can be converted as follows:
 ```handlebars
 {{#each bar as |foo|}}
 ```
+For "itemController" :
 
+```handlebars
+{{#each foo in bar itemController="abc"}}
+```
+Can be converted as follows:
+
+```handlebars
+{{#each bar itemController="abc" as |foo|}}
+```
 #### `as` sytnax for `{{with}}`
 
 Renaming a value using `{{with}}` has been possible using the `as` syntax. Block params,


### PR DESCRIPTION
Added description of how to use the itemController when you switch from "in" syntax to "as" syntax for {{each}}.