### PR TITLE
Corrected incorrect yielded block param in example

### DIFF
--- a/source/blog/2015-02-07-ember-1-10-0-released.md
+++ b/source/blog/2015-02-07-ember-1-10-0-released.md
@@ -163,8 +163,8 @@ export default Ember.Component.extend({
 ```handlebars
 {{! app/templates/index.hbs }}
 <div class="layout">
-  {{#x-customer customer=model birthday=model.birthday as |name age|}}
-    Hello, {{name}}. You are {{age}} years old.
+  {{#x-customer customer=model birthday=model.birthday as |fullName age|}}
+    Hello, {{fullName}}. You are {{age}} years old.
   {{/x-customer}}
 </div>
 ```


### PR DESCRIPTION
The block params introduction example incorrectly uses `name` in the template instead of `fullName`.

http://emberjs.com/blog/2015/02/07/ember-1-10-0-released.html#toc_block-params