### PR TITLE
Fix blog title formatting when the line wraps.

### DIFF
--- a/source/stylesheets/blog.css.scss
+++ b/source/stylesheets/blog.css.scss
@@ -1,6 +1,5 @@
 article.blog-post {
   h1 {
-    height: 24px;
     padding-left: 25px;
   }
 


### PR DESCRIPTION
This is just a small tweak for the blog titles on actual blog post pages. The [IE8 Support Update](http://emberjs.com/blog/2015/04/20/ie8-support-update.html) post, in particular.

Here's the before:
![screenshot 2015-04-21 08 56 04](https://cloud.githubusercontent.com/assets/136013/7256565/ae61ef32-e804-11e4-9c94-1a09fa5aa8d9.png)

And with this commit:
![screenshot 2015-04-21 09 00 56](https://cloud.githubusercontent.com/assets/136013/7256611/f2eed8d6-e804-11e4-9cff-33ac16cf0494.png)
