### PR TITLE
Fix ribbon on blog post titles that don't wrap.

### DIFF
--- a/source/stylesheets/blog.css.scss
+++ b/source/stylesheets/blog.css.scss
@@ -1,5 +1,6 @@
 article.blog-post {
   h1 {
+    min-height: 24px;
     padding-left: 25px;
   }
 


### PR DESCRIPTION
This fixes a regression on single line post titles caused by #2146