### PR TITLE
Run 'npm install' before generating the documentation for Ember.js

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -50,7 +50,7 @@ def generate_ember_docs
       sha = describe =~ /-g(.+)/ ? $1 : describe
     end
 
-    sh('npm run docs')
+    sh('npm install && npm run docs')
   end
 
   # JSON is valid YAML


### PR DESCRIPTION
Running `bundle exec rake generate_docs` with a fresh clone of the Ember.js repository fails because the package `ember-cli-yuidoc` is not installed.

````
$ bundle exec rake generate_docs
Generating docs data from /home/yoran/Projects/emberjs/ember.js... npm run docs

> ember@1.13.0-beta.1 docs /home/yoran/Projects/emberjs/ember.js
> ember yuidoc

version: 0.2.3
The specified command yuidoc is invalid. For available options, see `ember help`.
````

Solved by running `npm install` before generating the docs.