### PR TITLE
Ember 1.12 blog post, fix instance initializers example

### DIFF
--- a/source/blog/2015-05-13-ember-1-12-released.md
+++ b/source/blog/2015-05-13-ember-1-12-released.md
@@ -158,7 +158,7 @@ Ember-CLI 0.2.3 supports instance initializers. For example:
 ```javascript
 // app/instance-initializers/sleep.js
 
-export default function initialize(application) {
+export function initialize(application) {
   application.deferReadiness();
   // Wait 3s before continuing to boot the app
   Ember.run.later(application, 'advanceReadiness', 3000);


### PR DESCRIPTION
`export default` should only be used once, the example uses it twice. I tried that and an an error.