### PR TITLE
Stick footer to the bottom of the document

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -38,6 +38,17 @@ body {
   color: #444444;
   font-weight: normal;
   -webkit-font-smoothing: antialiased;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  min-height: 100vh;
+  min-height: calc(100vh - 60px);
 }
 
 /* Typography */
@@ -496,6 +507,10 @@ p {
   padding: 0px 0px 20px 0px;
   margin: 0 auto;
   position: relative;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
 
   &.grid {
     background-image: url('/images/grid.png');


### PR DESCRIPTION
Improves the appearance of the site's layout when viewed with tall monitors, or when sections such as Builds are in the process of loading.