### PR TITLE
Redirect to latest guides instead of specific

### DIFF
--- a/source/documentation.md
+++ b/source/documentation.md
@@ -1,3 +1,3 @@
-<meta http-equiv="refresh" content="0;URL='http://guides.emberjs.com/v1.10.0/'">
+<meta http-equiv="refresh" content="0;URL='http://guides.emberjs.com/'">
 
-Redirecting to [http://guides.emberjs.com/v1.10.0/](http://guides.emberjs.com/v1.10.0/)
+Redirecting to [http://guides.emberjs.com/](http://guides.emberjs.com/)

--- a/source/layouts/guide.erb
+++ b/source/layouts/guide.erb
@@ -2,7 +2,10 @@
 <html lang="en">
   <%
     @path = current_page.url.gsub(/^\/guides/, '')
-    @new_url = "http://guides.emberjs.com/v1.10.0#{@path}"
+    @new_url = "http://guides.emberjs.com/"
+    unless @path == '/'
+      @new_url.concat("v1.10.0#{@path}")
+    end
   %>
 
   <head>


### PR DESCRIPTION
If you go to `http://emberjs.com/guides` manually, it will take you to v1.10.0 of the guides. This changes that to go to `http://guides.emberjs.com/`, which redirects to the latest version.

If there was a path, it'll still take you to v10 so old links don't stop working.