### PR TITLE
Deprecated keywords

### DIFF
--- a/source/deprecations/v1.x.html.md
+++ b/source/deprecations/v1.x.html.md
@@ -652,10 +652,22 @@ export default Ember.Component.extend({
 });
 ```
 
+##### view and controller template keywords
+
+View and controller keywords provided a way to access the view or controller
+backing a template, even across scopes that you might expect to be isolated. In
+many ways their behavior is emergent, and generally is poorly designed.
+
+Accessing data via `{{view.someProp}}` or `{{controller.thisThing}}` can
+nearly always be replaced by proper use of data passing and block params. See
+the guide on [differences in yielded blocks](http://emberjs.com/deprecations/v1.x#toc_differences-in-yielded-blocks)
+for a complete example of using block params over the `{{view}}` keyword.
+
 #### Ember.LinkView
 
-As a consecuence of the deprecation of `Ember.View`, many internal classes what used to be views are
-now components. Notably `Ember.LinkView`, that is the class that backs the `{{link-to}}` helper is
-now `Ember.LinkComponent`.
+As a consecuence of the deprecation of `Ember.View`, many internal views have
+been ported to component. `Ember.LinkView`, the class that backs the
+`{{link-to}}` helper, have been ported to `Ember.LinkComponent`.
 
-The old `Ember.View` is still available but will throw deprecation warnings when instantiated or reopened.
+Most uses of `Ember.LinkView` can be directly ported to the `Ember.LinkComponent`
+class.


### PR DESCRIPTION
`{{view}}` and `{{controller}}` are deprecated.