### PR TITLE
Fix example code in `2015-06-12-ember-1-13-0-released.md`

### DIFF
--- a/source/blog/2015-06-12-ember-1-13-0-released.md
+++ b/source/blog/2015-06-12-ember-1-13-0-released.md
@@ -267,7 +267,7 @@ given this component:
 
 ```hbs
 {{! app/components/show-full-name.hbs }}
-{{if hasBlock}}
+{{#if hasBlock}}
   {{yield fullName}}
 {{else}}
   {{fullName}}


### PR DESCRIPTION
The block helper should be beginning with `#`.