### PR TITLE
Add more explicit referencing of deprecations guide

### DIFF
--- a/source/javascripts/app/builds/templates/_project_listing.js.hbs
+++ b/source/javascripts/app/builds/templates/_project_listing.js.hbs
@@ -1,6 +1,8 @@
 {{#if model.filesPresent }}
   {{#each projects as |project|}}
-    {{partial 'filesTable'}}
+    <div class="files-table">
+      {{partial 'filesTable'}}
+    </div>
   {{/each}}
 {{ else }}
   <br/>

--- a/source/javascripts/app/builds/templates/index.js.hbs
+++ b/source/javascripts/app/builds/templates/index.js.hbs
@@ -21,3 +21,9 @@
     <p>Canary builds are the bleeding edge of Ember development. Please do not use these builds unless you are absolutely certain that you need fixes and/or features not available in the Release or Beta builds.</p>
   </div>
 </div>
+
+<hr>
+
+<h3>Versioning and Deprecations</h3>
+
+<p>Periodically, various APIs in Ember.js may be deprecated. Ember.js uses <a href="http://semver.org" title="Semantic Versioning">Semantic Versioning</a> to indicate these changes. As new releases of Ember and Ember Data are released, be sure to review the <a href="/deprecations">deprecation guides</a> alongside the current version of the <a href="http://guides.emberjs.com">documentation guides</a> as they may often be more in line with the channel you are using.</p>

--- a/source/stylesheets/builds.css.scss
+++ b/source/stylesheets/builds.css.scss
@@ -2,7 +2,7 @@
 @import "mixins/hidpi";
 
 // the builds page is an ember app inserted into the master layout, replicate styling
-// content -> builds page ( sidebar / subcontent ) 
+// content -> builds page ( sidebar / subcontent )
 #subcontent {
   @extend #content;
 }
@@ -24,6 +24,11 @@
     &:after {
       width: $sidebar-width;
     }
+  }
+
+  #subcontent {
+    margin-left: 30px;
+    width: 770px;
   }
 
   .float-left-container {
@@ -68,8 +73,9 @@
   }
 
   .release-progress {
-    padding-top: 40px;
     display: table;
+    margin: 0 auto;
+    padding-top: 40px;
   }
 
   .beta-version {
@@ -133,7 +139,7 @@
   }
 
   .features {
-    margin-top: 15%;
+    margin-top: 5%;
   }
 
   .feature {
@@ -176,14 +182,12 @@
   }
 
   .project-name {
-    margin-top: 0.5em;
-    float: left;
+    margin-top: 0;
   }
 
   .description {
     border-top: 1px dotted #E5DBD6;
     padding-top: 10px;
-    clear: both;
   }
 
   .table {
@@ -212,6 +216,12 @@
     td {
       vertical-align: middle;
       border-top: 1px solid #dddddd;
+    }
+
+    td, th {
+      &:last-child {
+        text-align: right;
+      }
     }
   }
 
@@ -289,5 +299,31 @@
 
   .loading-spinner {
     text-align: center;
+  }
+
+  hr {
+    height: 1px;
+    border: none;
+    margin: 40px 0;
+    background-color: #dfd7d4;
+  }
+
+  .centered {
+    text-align: center;
+  }
+
+  .files-table {
+    margin-bottom: 4em;
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+
+  #download {
+    width: 100%;
+    #download-ember {
+      left: auto;
+      margin: 2.5em 0;
+    }
   }
 }

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -1080,6 +1080,10 @@ body.community #content {
   margin: 3em auto 0 auto;
   width: 54em;
 
+  > h1 {
+    text-align: center;
+  }
+
   .section {
     width: auto;
     .image {
@@ -1547,6 +1551,16 @@ body.security #content {
 }
 
 /**
+  Deprecations Page
+**/
+
+body.deprecations {
+  #content {
+    margin-top: 38px;
+  }
+}
+
+/**
   Tomster Page
 **/
 
@@ -1639,7 +1653,7 @@ body.tomster_faq #content {
     margin: 2em 0;
     background-color: #dfd7d4;
   }
-  
+
   #back-to-top {
     padding-left: 13px;
     text-align: center;


### PR DESCRIPTION
The deprecations guide is chock-full of useful information for those working with builds other than stable. Let's reference it on that page.

Also includes some CSS cleanup in the "builds" application. Looked like there were some leftovers.