### PR TITLE
Fix typo in ED release announcement

### DIFF
--- a/source/blog/2015-06-18-ember-data-1-13-released.md
+++ b/source/blog/2015-06-18-ember-data-1-13-released.md
@@ -648,7 +648,7 @@ New format:
 new DS.InvalidError([
   {
     source: { pointer: 'data/attributes/first_name' },
-    details: 'is invalid'
+    detail: 'is invalid'
   }
 ]);
 ```


### PR DESCRIPTION
JSON API spec requires this to be called `detail` not `details`, c.f http://jsonapi.org/format/#error-objects