### PR TITLE
Move beforeObserver deprecation entry from 1.10 to 1.13

### DIFF
--- a/source/deprecations/v1.x.html.md
+++ b/source/deprecations/v1.x.html.md
@@ -222,26 +222,6 @@ You should now be using:
 </ul>
 ```
 
-### Deprecations Added in 1.10
-
-#### beforeObserver
-
-Before observers are deprecated due to the negative performance implications they have for Ember internals and applications.
-
-Typically they were used to have access to the old value of a property when it's about to change, but you can get same functionality in an even more efficient way with just a few lines of code:
-
-```js
-function fooObserver(obj){
-  var newFoo = obj.get('foo');
-  if (obj._oldFoo !== newFoo) {
-    // do your stuff here
-    obj._oldFoo = newFoo;
-  }
-}
-addObserver(obj, 'foo', fooObserver);
-fooObserver(obj); // Optionally call the observer immediately
-```
-
 ### Deprecations Added in 1.11
 
 #### ObjectController
@@ -710,12 +690,12 @@ export default Ember.Component.extend({
   didInitAttrs(attrs) {
     this._super(...arguments);
     var content = this.get('content');
-    
+
     if (!content) {
       this.set('content', []);
     }
   },
-  
+
   actions: {
     change() {
       const changeAction = this.get('action');
@@ -782,3 +762,23 @@ over the native counterparts.
 They will be extracted as an ember addon in case you need to keep using them, but the recomendation now is to
 just use the native array methods or those in libraries like Underscore/Lodash.
 
+#### beforeObserver
+
+Before observers are deprecated due to the negative performance implications they have for Ember internals and applications.
+
+Typically they were used to have access to the old value of a property when it's about to change, but you can get same functionality in an even more efficient way with just a few lines of code:
+
+```js
+function fooObserver(obj){
+  var newFoo = obj.get('foo');
+  if (obj._oldFoo !== newFoo) {
+    // do your stuff here
+    obj._oldFoo = newFoo;
+  }
+}
+addObserver(obj, 'foo', fooObserver);
+fooObserver(obj); // Optionally call the observer immediately
+```
+
+The related function `Ember.addBeforeObserver`, `Ember.removeBeforeObserver` and `Ember.beforeObserversFor`
+are deprecated too.


### PR DESCRIPTION
Following discussion here: https://github.com/emberjs/ember.js/pull/11671

/cc @mixonic 