### PR TITLE
Use consistent `type` attributes for JSON-API data

### DIFF
--- a/source/blog/2015-06-18-ember-data-1-13-released.md
+++ b/source/blog/2015-06-18-ember-data-1-13-released.md
@@ -393,7 +393,7 @@ becomes
 store.push({
   data: {
     id: '1', 
-    type: 'user', 
+    type: 'users', 
     attributes: { 
       name: 'Pangratz' 
     }
@@ -446,28 +446,28 @@ For example a Serializer responsible for normalizing the above sample payload wo
 {
   data: { 
     id: '1', 
-    type: 'user', 
+    type: 'users', 
     attributes: {
       name: 'wecc'
     }, 
     relationships: {
       accounts: {
         data: [
-          { id: '1', type: 'account' },
-          { id: '2', type: 'account' }
+          { id: '1', type: 'accounts' },
+          { id: '2', type: 'accounts' }
         ]
       }
     }
   },
   included: [{ 
     id: '1',
-    type: 'account',
+    type: 'accounts',
     attributes: {
       email: 'wecc@sweden.se'
     }
   }, {
     id: '2',
-    type: 'account',
+    type: 'accounts',
     attributes: {
       email: 'wecc@greece.gr'
     }


### PR DESCRIPTION
I think these names must be consistent, i.e. cannot mix singular and plural (which is currently the case).

The spec is agnostic to singular/plural as long as they are consistent, but seem to use plurals so I did likewise.

I guess Ember Data is using either singular or plural to match with models. If it's using singular, we need to switch these.