### PR TITLE
Remove 15 non version files from tagged releases on builds page

### DIFF
--- a/source/javascripts/app/builds/app.js
+++ b/source/javascripts/app/builds/app.js
@@ -427,7 +427,7 @@ App.TaggedRoute = Ember.Route.extend(App.BuildCategoryMixin, {
   model: function() {
     var bucket = App.S3Bucket.create({
       title: 'Tagged Release Builds',
-      prefix: 'tags/',
+      prefix: 'tags/v',
       delimiter: '',
     });
     return bucket;


### PR DESCRIPTION
In the tagged releases page there are 15 total ember and ember-data files that I believe can be removed.

1. removes /tags//ember.min.js (a year ago)
- removes /tags//ember.prod.js (a year ago)
- removes /tags//ember-template-compile.js (a year ago)
- removes /tags//ember.js (a year ago)
- removes tags/_ribbon/ember-data.min.js (22 days ago)
- removes tags/_ribbon/ember-data.prod.js (22 days ago)
- removes tags/_ribbon/ember-data.js.map (22 days ago)
- removes tags/_ribbon/ember-data.js (22 days ago)
- removes tags/1.13.0/ember-data.prod.js (a month ago)
- removes tags/1.13.0/ember-data.js.map (a month ago)
- removes tags/1.13.0/ember-data.js (a month ago)
- removes tags/1.13.0/ember-data-min.js (a month ago)
- removes tags/1.0.0-beta.6/ember-data.prod.js (a year ago)
- removes tags/1.0.0-beta.6/ember-data-min.js (a year ago)
- removes tags/1.0.0-beta.6/ember-data.js (a year ago)

- //ember says it is a canary version of 1.7.0-beta.1
- ribbon/ember-data matches v1.13.4/ember-data
- 1.13.0/ember-data matches v1.13.0/ember-data
- 1.0.0-beta.6 matches v1.0.0-beta.6
