### PR TITLE
Add deprecation guide for Controller#needs

### DIFF
--- a/source/deprecations/v1.x.html.md
+++ b/source/deprecations/v1.x.html.md
@@ -814,3 +814,36 @@ by the framework, it will **not** throw a deprecation message even if the
 proxying behavior is being used.
 
 Added in [PR #11476](https://github.com/emberjs/ember.js/pull/11476).
+
+#### Controller.needs 
+
+`needs` for controllers will be removed in Ember 2.0. You can migrate away from this using `Ember.inject.controller`
+
+Lets say you have a `post` controller like this:
+
+```javascript
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  needs: ['comments'],
+  newComments: Ember.computed.alias('controllers.comments.newest')
+});
+```
+
+You can upgrade to `Ember.inject.controller` like this:
+
+```javascript
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  comments: Ember.inject.controller(),
+  newComments: Ember.computed.alias('comments.newest')
+});
+```
+
+You can [read more about `Ember.inject.controller` in the Ember API documentation](http://emberjs.com/api/classes/Ember.inject.html#method_controller)
+  
+
+
+
+


### PR DESCRIPTION
Again, i'm not a great writer, but at least there is some documentation.

See emberjs/ember.js#11767