### PR TITLE
Fix unexpected toggling of displayed items in the API panes.

### DIFF
--- a/source/javascripts/app/api/api.js
+++ b/source/javascripts/app/api/api.js
@@ -23,9 +23,13 @@ $(function() {
       ls.setItem('api-options-' + type, this.checked);
   }
 
+  function confirmPaneInputs() {
+    $(this).closest('#api-options').find('input').each(toggleType);
+  }
+
   $('#api-options input').each(initApiOptions);
   $('#api-options input').each(toggleType);
-  $('#api-options input').on('change', toggleType);
+  $('#api-options input').on('change', confirmPaneInputs);
 
   // Tabs
   $('.tabs .pane').hide();

--- a/source/javascripts/app/api/api.js
+++ b/source/javascripts/app/api/api.js
@@ -18,6 +18,7 @@ $(function() {
     var type = this.getAttribute('data-type');
 
     $('.'+type).toggle(this.checked);
+    $('#api-options input[data-type='+type+']').prop('checked', this.checked);
 
     if(ls)
       ls.setItem('api-options-' + type, this.checked);


### PR DESCRIPTION
In response to #2264: Now we're going through each of the pane's api-option inputs and confirming that they're toggled appropriately on each change. This appears to fix the issue of "Show inherited, show private, unshow inherited, wait why's that still there, oh god make them go away."

Hope this helps!