### PR TITLE
Change method/property/event ordering from linewise to columnwise

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -2137,11 +2137,14 @@ a.edit-page {
   ul.index-list {
     margin-left: 1.5em;
     overflow: hidden; /* Clearfix */
+    -moz-column-count: 2;
+    -moz-column-gap: 1em;
+    -webkit-column-count: 2;
+    -webkit-column-gap: 1em;
+    column-count: 2;
+    column-gap: 1em;
 
     li {
-      float: left;
-      width: 300px;
-      padding-right: 1em;
       display: block;
       overflow: hidden;
       @include ellipsis;


### PR DESCRIPTION
Fixes #2263 
Style changes only.
[Browser Support](http://caniuse.com/#feat=multicolumn)
This should work in all major browsers. In <= IE9 I believe this will fall back to a single column twice as tall. I think the increase in comprehensibility for everyone else is worth the tradeoff.
Before:
<img width="706" alt="screen shot 2015-07-26 at 8 05 13 pm" src="https://cloud.githubusercontent.com/assets/1588273/8896662/a8f7436c-33d1-11e5-92a3-cd9f822cf1f8.png">

After:
<img width="709" alt="screen shot 2015-07-26 at 8 05 53 pm" src="https://cloud.githubusercontent.com/assets/1588273/8896666/bf3ebfec-33d1-11e5-83de-0fc758325588.png">

