### PR TITLE
reduce duplication in the diversity statement

### DIFF
--- a/source/guidelines.html.erb
+++ b/source/guidelines.html.erb
@@ -29,7 +29,7 @@ title: "Community"
 	We are committed to being a community that everyone feels good about joining. Although we may not be able to satisfy everyone, we will always work to treat everyone well.
 </p>
 <p>
-	We’ll avoid a laundry list of all the things you may and may not be, what classes are legally protected, etc etc etc. Whoever you are, wherever you’re from, whatever you look like or identify as, believe in or don’t believe in, and so on and so forth, know that you’re welcome. 
+	We’ll avoid a laundry list of all the things you may and may not be, what classes are legally protected, etc. Whoever you are, wherever you’re from, whatever you look like or identify as, believe in or don’t believe in, know that you’re welcome.
 </p>
 
 <h3>Leadership, Authority and Responsibility</h3>


### PR DESCRIPTION
I found the duplication in the diversity statement to have the effect of sounding a little too informal.  I think this makes it sound a little cleaner and more serious.

Since the line is long, the changes are:
etc ~~etc etc~~
~~and so on and so forth~~