### PR TITLE
Deprecation guide for `Ember.create` and `Ember.keys`

### DIFF
--- a/source/deprecations/v1.x.html.md
+++ b/source/deprecations/v1.x.html.md
@@ -443,6 +443,52 @@ For further reading, review the [RFC](https://github.com/emberjs/rfcs/blob/maste
 Ember.js 1.13 is the last minor release of Ember 1.x before 2.0. Consequently,
 it has a rather large number of notable deprecations.
 
+#### Ember.create
+
+`Ember.create` is deprecated in favor for `Object.create`. For more information
+regarding `Object.create`, please
+[read the MDN documentataion](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create).
+
+Please change this:
+
+```js
+const doug = Ember.create({
+  firstName: 'Doug'
+});
+```
+
+to
+
+```js
+const doug = Object.create({
+  firstName: 'Doug'
+});
+```
+
+#### Ember.keys
+
+`Ember.keys` is deprecated in favor for `Object.keys`. For more information
+regarding `Object.keys`, please
+[read the MDN documentation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys).
+
+```js
+const food = Ember.keys({
+  yellow: 'banana'
+}, {
+  green: 'pickle'
+});
+```
+
+to
+
+```js
+const food = Object.keys({
+  yellow: 'banana'
+}, {
+  green: 'pickle'
+});
+```
+
 #### Ember.View
 
 Ember 1.x encouraged a Model-View-Controller-Route architecture. Since then,


### PR DESCRIPTION
- Adds links out to MDN for more information.
- Apologies for the uninventive examples.

See #2256