### PR TITLE
Add deprecation for reversed observer arguments

### DIFF
--- a/source/deprecations/v1.x.html.md
+++ b/source/deprecations/v1.x.html.md
@@ -1069,3 +1069,24 @@ c.swapNames();  // returns c
 Object.freeze(c);
 c.swapNames();  // EXCEPTION
 ```
+
+#### Reversed Ember.observer Arguments
+
+A little known feature of the observer function allowed for the arguments to be
+listed in the opposite order, with function first:
+
+```javascript
+Ember.observer(function() {
+  // React to observer firing here
+}, 'property1', 'property2')
+```
+
+This syntax was deprecated in Ember 1.13.5. The above code sample should be
+replaced with the standard syntax that lists the observed properties, then
+the function as the last argument:
+
+```javascript
+Ember.observer('property1', 'property2', function() {
+  // React to observer firing here
+})
+```


### PR DESCRIPTION
Adds missing deprecation description for Ember 1.13.5 - Deprecate reverse argument ordering in ```Ember.observer```.

See #2256 for checklist of all missing deprecations.