### PR TITLE
Deprecation guide for `Ember.oneWay`.

### DIFF
--- a/source/deprecations/v1.x.html.md
+++ b/source/deprecations/v1.x.html.md
@@ -492,6 +492,27 @@ const food = Object.keys({
 });
 ```
 
+#### Ember.oneWay
+
+`Ember.oneWay` is deprecated in favor for `Ember.computed.oneWay`. Please
+change all instances of `Ember.oneWay` from:
+
+```js
+let User = Ember.Object.extend({
+  firstName: null,
+  nickName: Ember.oneWay('firstName')
+});
+```
+
+to
+
+```js
+let User = Ember.Object.extend({
+  firstName: null,
+  nickName: Ember.computed.oneWay('firstName')
+});
+```
+
 #### Ember.View
 
 Ember 1.x encouraged a Model-View-Controller-Route architecture. Since then,


### PR DESCRIPTION
See: #2256