### PR TITLE
Added deprecation warning about using class bound dasherized values

### DIFF
--- a/source/deprecations/v1.x.html.md
+++ b/source/deprecations/v1.x.html.md
@@ -1153,6 +1153,33 @@ Ember 1.11 made it possible to intuitively represent dynamic content in attribut
 
 This makes it possible to express a number of concepts directly in the template that previously were awkward to represent and required computer properties, and could even require `itemController`.
 
+##### Dasherized boolean values
+
+Ember 1.11 new syntax no longer supports dasherizing for boolean values. For example:
+
+```component
+// app/components/user-profile.js
+export default Ember.Component.extend({
+  isActiveUser: true
+});
+```
+
+```handlebars
+{{! app/templates/components/user-profile.hbs }}
+<div {{bind-attr class="isActiveUser"}}>
+</div>
+```
+
+Should be replaced with:
+
+```handlebars
+{{! app/templates/components/user-profile.hbs }}
+<div class="{{if isActiveUser 'is-active-user'}}">
+</div>
+```
+
+##### Legacy `bind-attr`
+
 Ember 1.13 deprecated `bind-attr` in favor of the new syntax.
 
 To aid in the migration, you can use the [legacy-bind-attr plugin](https://github.com/emberjs/legacy-bind-attr) to restore this behavior in Ember 2.0 and silence the deprecation warning.


### PR DESCRIPTION
We were slightly burned by this when removing all legacy usage of `{{bind-attr}}` and @locks suggested I open this pull. 