### PR TITLE
Add deprecation guide for all the each helper options

### DIFF
--- a/source/deprecations/v1.x.html.md
+++ b/source/deprecations/v1.x.html.md
@@ -1202,3 +1202,46 @@ let Hamster = Ember.Object.extend({
 });
 ```
 
+#### View and Controller options on the `{{each}}` helper
+
+The options `itemView`, `itemViewClass`, `tagName`, `emptyView`,
+`emptyViewClass` and `itemControler` on the `{{each}}` helper have been deprecated.
+
+The usage of all the above mentioned options can be replaced using a compontent.
+
+##### An example
+
+```handlebars
+{{each view.comments itemController="comment"
+                     itemView="commentView"
+                     emptyView="noCommentsView"
+                     tagName="ul"}}
+```
+
+Can be replaced with:
+
+```handlebars
+<ul>
+  {{#each comments as |comment|}}
+    {{post-comment comment=comment}}
+  {{else}}
+    {{no-comments}}
+  {{/each}}
+</ul>
+```
+
+##### Breaking the example down
+
+The `comment` controller and `commentView` view have been refactored into the
+`{{post-comment}}` component.
+
+The `noCommentsView` has been refactored in to the `{{no-comments}} component.
+
+Instead of the `itemController="comment"` and `itemView="commentView"` we use
+the newly created `{{post-comment}}` component.
+
+Instead of the `emptyView="noCommentsView"` we use the `{{no-comments}}`
+component.
+
+We replaced `tagName="ul"` part by just surrounding the `{{each}}` block with
+`<ul>` tags.


### PR DESCRIPTION
See #2256 
Fixes:
> Options to the {{#each helper that trigger a legacy and poorly performing legacy layer. These options 
> are: itemView, itemViewClass, tagName, emptyView and emptyViewClass