### PR TITLE
Add Ember Weekly to community links

### DIFF
--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -71,6 +71,9 @@ title: "Community"
   <p>
     For a curated list of Ember learning resources (podcasts, videos, blog posts, books, etc) check out <a href="http://emberwatch.com/">EmberWatch</a>.
   </p>
+  <p>
+    Stay up to date with the latest news and resources with the regular email newsletter, <a href="http://emberweekly.com">Ember Weekly</a>.
+  </p>
 </div>
 
 <div class="community section meetup">


### PR DESCRIPTION
The community page used to link to Ember Weekly before the Meetup page redesign, where the community links were removed. It looks like a few have been added back on now and I was hoping Ember Weekly could potentially be linked? The community page used to drive quite a bit of traffic to Ember Weekly in the past. 

Let me know if you think it's appropriate or not. Thanks!