### PR TITLE
Expose rake task to generate just the ember docs (not data)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -143,6 +143,11 @@ task :generate_ember_data_docs do
   generate_ember_data_docs
 end
 
+desc "Generate Ember docs only"
+task :generate_ember_docs do
+  generate_ember_docs
+end
+
 desc "Build the website"
 task :build => :generate_docs do
   build


### PR DESCRIPTION
Create rake task to just generate the ember side of the docs.
(There's already one for just the ember-data side.)
This is helpful if you're testing doc changes to only one side of the project.