### PR TITLE
Fix Ember.keys Deprecation Example

### DIFF
--- a/source/deprecations/v1.x.html.md
+++ b/source/deprecations/v1.x.html.md
@@ -476,8 +476,7 @@ regarding `Object.keys`, please
 
 ```js
 const food = Ember.keys({
-  yellow: 'banana'
-}, {
+  yellow: 'banana',
   green: 'pickle'
 });
 ```
@@ -486,8 +485,7 @@ to
 
 ```js
 const food = Object.keys({
-  yellow: 'banana'
-}, {
+  yellow: 'banana',
   green: 'pickle'
 });
 ```


### PR DESCRIPTION
`Object.keys` only takes a single parameter, but the example was passing multiple objects for some reason, rather than a single hash with multiple attributes.