### PR TITLE
Update Columbus meetup

### DIFF
--- a/data/meetups.yml
+++ b/data/meetups.yml
@@ -379,12 +379,10 @@ locations:
     - organizer: Tom Zellman
       profileImage: http://photos2.meetupstatic.com/photos/member/d/a/c/c/member_91316012.jpeg
   - location: Columbus, OH
-    url: http://embercolumbus.com
+    url: http://www.meetup.com/ember-columbus/
     lat: 40.098794
     lng: -83.105245
     organizers:
-    - organizer: Ricky Gilbert
-      profileImage: http://photos2.meetupstatic.com/photos/member/e/1/9/a/highres_245577754.jpeg
     - organizer: Kevin Pfefferle
       profileImage: http://photos2.meetupstatic.com/photos/member/d/1/0/8/member_139613512.jpeg
     - organizer: James Martinez


### PR DESCRIPTION
This PR updates 2 things for the Ember Columbus meetup:

1. Removes Ricky Gilbert from the organizer list as he is moving away
2. Updates the URL to use the Meetup URL (which hopefully will improve crawling by aggregators like Ember Weekly)