### PR TITLE
Add info about deprecated function as second argument in deprecate/warn/assert

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -188,3 +188,64 @@ In Ember 2.1 the internal `.currentState` property has been moved to `_currentSt
 
 Please keep in mind that `.currentState` / `._currentState` is still private and should not be used/relied upon
 outside of Ember internals.
+
+### Deprecations Added in 2.2
+
+#### Function as test in Ember.deprecate, Ember.warn, Ember.assert
+
+##### Deprecated behavior
+
+Calling `Ember.deprecate`, `Ember.warn` or `Ember.assert` with a function as test argument is deprecated.
+
+You can no longer pass arguments of type `function` to these methods. Following calls will trigger deprecations:
+
+```javascript
+const message = 'Test message.';
+const options = { id: 'test', until: '3.0.0' };
+
+// passing function
+Ember.deprecate(message, function() {
+  return true;
+}, options);
+
+const myConstructor = {}.constructor;
+
+// passing constructor (also a function)
+Ember.warn(message, myConstructor, options);
+
+// passing function with double arrow syntax
+Ember.assert(message, () => true, options);
+```
+
+[Demo.](http://ember-twiddle.com/34d36b9121e017d2388f)
+
+##### Refactoring
+
+You have 3 options to refactor second argument from `function` to `boolean`:
+
+1. Use [IIFE](https://en.wikipedia.org/wiki/Immediately-invoked_function_expression).
+2. Use `!!Constructor` for constructors.
+3. Pass `boolean` directly instead of wrapping it in function.
+
+Example:
+
+``` javascript
+// ... message, options ommited for brevity
+
+// passing IIFE (1)
+Ember.deprecate(message, (function() {
+	return true;
+})(), options);
+
+const myConstructor = {}.constructor;
+
+// passing !!constructor (2)
+Ember.warn(message, !!myConstructor, options);
+
+// passing boolean directly (3)
+Ember.assert(message, true, options);
+```
+
+[Demo.](http://ember-twiddle.com/ed90d0c7812914f09a3f)
+
+In a future version functions will be treated as truthy values instead of being executed.


### PR DESCRIPTION
As requested by @rwjblue in [comment](https://github.com/emberjs/ember.js/pull/12370#issuecomment-145419368) in [pull request](https://github.com/emberjs/ember.js/pull/12370) which added deprecations.