### PR TITLE
Add guide for Ember.immediateObserver deprecation

### DIFF
--- a/source/deprecations/v1.x.html.md
+++ b/source/deprecations/v1.x.html.md
@@ -946,6 +946,25 @@ fooObserver(obj); // Optionally call the observer immediately
 The related function `Ember.addBeforeObserver`, `Ember.removeBeforeObserver` and `Ember.beforeObserversFor`
 are deprecated too.
 
+#### Ember.immediateObserver
+
+`Ember.immediateObserver` is deprecated in favor of `Ember.observer`. Please change all instances of `Ember.immediateObserver` from:
+
+```javascript
+Ember.Object.extend({
+  valueObserver: Ember.immediateObserver('value', function() {
+  })
+});
+```
+to
+
+```javascript
+Ember.Object.extend({
+  valueObserver: Ember.observer('value', function() {
+  })
+});
+```
+
 #### ArrayController
 
 Just like `Ember.ObjectController`, `Ember.ArrayController` will be removed in


### PR DESCRIPTION
As part of #2256