### PR TITLE
Remove G+ link from home page

### DIFF
--- a/source/about.html.erb
+++ b/source/about.html.erb
@@ -46,13 +46,6 @@ ember new my-app
     <li class="twitter">
       <a href="https://twitter.com/emberjs" class="twitter-follow-button" data-show-count="false" data-lang="en">Follow @emberjs</a>
     </li>
-
-    <li class="gplus">
-      <a href="https://plus.google.com/101668252557697758617" rel="publisher">
-        Follow on
-        <img src="//ssl.gstatic.com/images/icons/gplus-32.png" alt="Google+" width="20" height="20" />
-      </a>
-    </li>
   </ul>
 </div>
 


### PR DESCRIPTION
The last time the G+ page was updated was in 2013.  Seems best to remove it ;-)