### PR TITLE
Stop using multiple `source` in primary

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,4 @@
 source 'https://rubygems.org'
-source 'https://rails-assets.org'
 
 gem "redcarpet"
 gem "activesupport"
@@ -14,12 +13,15 @@ gem "listen"
 gem "builder"
 gem "middleman-alias", github: "wagenet/middleman-alias", branch: "keep-search-and-hash"
 gem "ember-middleman"
-gem "rails-assets-js-md5"
-gem "rails-assets-moment"
 gem "underscore-rails"
 gem "gmaps4rails"
 gem "geocoder"
 gem "faraday"
+
+source 'https://rails-assets.org' do
+  gem "rails-assets-js-md5"
+  gem "rails-assets-moment"
+end
 
 group :development, :test do
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -237,8 +237,8 @@ DEPENDENCIES
   poltergeist
   pry
   rack
-  rails-assets-js-md5
-  rails-assets-moment
+  rails-assets-js-md5!
+  rails-assets-moment!
   rake
   redcarpet
   rspec


### PR DESCRIPTION
The following warning is shown since bundler 1.7.

```
Warning: this Gemfile contains multiple primary sources. Using `source`
more than once without a block is a security risk, and may result in
installing unexpected gems. To resolve this warning, use a block to
indicate which gems should come from the secondary source. To upgrade
this warning to an error, run `bundle config disable_multisource true`.
```

See detail: https://github.com/bundler/bundler/blob/master/CHANGELOG.md#170-2014-08-13