### PR TITLE
add return value for setter

### DIFF
--- a/source/blog/2015-05-13-ember-1-12-released.md
+++ b/source/blog/2015-05-13-ember-1-12-released.md
@@ -77,6 +77,7 @@ export default Ember.Object.extend({
     },
     set(key, value) {
       this.set('height', value / 1.618);
+      return value;
     }
   })
 


### PR DESCRIPTION
Setters expect the value to be returned, see [docs](http://emberjs.com/api/classes/Ember.ComputedProperty.html#method_set).
I got bit by this and wasted about half a day trying to figure out why property changes weren't being fired.