### PR TITLE
Added deprecation for `Ember.SortableMixin`

### DIFF
--- a/source/deprecations/v1.x.html.md
+++ b/source/deprecations/v1.x.html.md
@@ -1001,7 +1001,7 @@ In many cases you can move your logic later in the component lifecycle by implem
     this._super(...arguments);
     this.set('myValue', value);
   }
-``` 
+```
 
 #### beforeObserver
 
@@ -1074,6 +1074,38 @@ by the framework, it will **not** throw a deprecation message even if the
 proxying behavior is being used.
 
 Added in [PR #11476](https://github.com/emberjs/ember.js/pull/11476).
+
+#### SortableMixin
+
+Along with `Ember.ArrayController`, `Ember.SortableMixin` will be removed in Ember 2.0.
+
+You can migrate away from using `Ember.SortableMixin` by using `Ember.computed.sort`. Using this example:
+
+```
+const SongsController = Ember.ArrayController.extend(Ember.SortableMixin, {
+  model: null,
+  sortProperties: ['trackNumber'],
+  sortAscending: false
+});
+
+let songsController = SongsController.create({ songs: songList });
+```
+
+You can transition to using `Ember.computed.sort` like this:
+
+```
+const SongsController = Ember.Controller.extend({
+  model: null,
+  sortedSongs: Ember.computed.sort('model', 'songSorting'),
+  songSorting: ['trackNumber:desc']
+});
+
+let songsController = SongsController.create({ songs: songList });
+```
+
+You can [read more about `Ember.computed.sort` in the Ember API documentation](http://emberjs.com/api/classes/Ember.computed.html#method_sort)
+
+Legacy support of `Ember.SortableMixin` will be provided via the [ember-legacy-controllers](https://github.com/emberjs/ember-legacy-controllers) addon.
 
 #### RenderBuffer
 
@@ -1590,4 +1622,3 @@ go away in Ember 2.x.  Modifications to Ember rendering should be made by
 overriding Ember's new
 [component lifecycle hooks](http://emberjs.com/blog/2015/06/12/ember-1-13-0-released.html#toc_component-lifecycle-hooks)
 , introduced in version 1.13.
-


### PR DESCRIPTION
Documentation isn't my strong suit, happy to make any changes.

Also, I added this deprecation immediately after Ember.ArrayController because they are some what related and it seemed like they should be next to each other.