### PR TITLE
fix typo in 2.2 blog post

### DIFF
--- a/source/blog/2015-11-16-ember-2-2-released.md
+++ b/source/blog/2015-11-16-ember-2-2-released.md
@@ -131,7 +131,7 @@ of the `alert-box-button` component and the attribute `onclick`:
 
 ```handlebars
 {{! app/templates/index.hbs }}
-{{alert-box as |box|}}
+{{#alert-box as |box|}}
   Danger, Will Robinson!
   <div style="float:right">
     {{#box.close-button}}


### PR DESCRIPTION
Contextual components example is missing a `#` on the opening component tag.