### PR TITLE
Update Ember Columbus meetup location

### DIFF
--- a/data/meetups.yml
+++ b/data/meetups.yml
@@ -380,8 +380,8 @@ locations:
       profileImage: http://photos2.meetupstatic.com/photos/member/d/a/c/c/member_91316012.jpeg
   - location: Columbus, OH
     url: http://www.meetup.com/ember-columbus/
-    lat: 40.098794
-    lng: -83.105245
+    lat: 39.9678407
+    lng: -82.9961547
     organizers:
     - organizer: Kevin Pfefferle
       profileImage: http://photos2.meetupstatic.com/photos/member/d/1/0/8/member_139613512.jpeg


### PR DESCRIPTION
We're changing the location of our Columbus meetup to be more centrally located downtown, so this updates the Meetups map to reflect that change.