### PR TITLE
Add instructions for high-resolution Ember user logos

### DIFF
--- a/data/users.yml
+++ b/data/users.yml
@@ -9,7 +9,8 @@
 # and adequate whitespace so it's not crammed against the edges. The size
 # of the space you're filling is max 210 x 103. To best control
 # appearance, submit an image this exact size that already includes
-# the whitespace you want.
+# the whitespace you want. To support high-resolution displays, consider
+# submitting your image at twice this resolution with dimensions of 420 x 206.
 
 # Please do not post links to pages selling Ember consulting
 # services. They will be removed.


### PR DESCRIPTION
I noticed that most logos on the Ember users list are submitted with the exact display dimensions of 210x103 (as recommended in the instructions). With the growing popularity of high-resolution displays, it may be beneficial to recommend that these logos be uploaded at a higher resolution (420x206). They will still be displayed at 210x103, but with a sharper appearance on retina-quality displays.

I noticed that the Acorns logo is already doing this: https://github.com/emberjs/website/pull/2390
I have submitted the Test Double logo to do this as well: https://github.com/emberjs/website/pull/2439