### PR TITLE
Add Ember Twiddle option

### DIFF
--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -29,7 +29,7 @@ title: "Community"
     <a href="https://github.com/emberjs/ember.js/issues">issue tracker</a> and create a new
     issue. Great bug reports include a clear description of what is not happening and what
     you expected to happen. Issues that include a failing test or a reduced test case
-    created on <a href="http://jsfiddle.net/6Evrq/">JSFiddle</a> or
+    created on <a href="https://ember-twiddle.com">Ember Twiddle</a>, <a href="http://jsfiddle.net/6Evrq/">JSFiddle</a> or
     <a href="http://emberjs.jsbin.com/">JSBin</a> are much more likely to receive attention.
     See the <a href="https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md">full guidelines</a>
     for more information.</p>


### PR DESCRIPTION
Add Ember Twiddle option to places you can host a failing or a reduced test case.