### PR TITLE
Blog post for CVE-2015-7565

### DIFF
--- a/source/blog/2016-01-14-security-releases-ember-1-11-4-1-12-2-1-13-12-2-0-3-2-1-2-2-2-1.md
+++ b/source/blog/2016-01-14-security-releases-ember-1-11-4-1-12-2-1-13-12-2-0-3-2-1-2-2-2-1.md
@@ -1,0 +1,51 @@
+---
+title: Security Releases - Ember 1.11.4, 1.12.2, 1.13.12, 2.0.3, 2.1.2, 2.2.1
+author: Tom Dale
+tags: Releases, Security
+---
+
+Because developers trust Ember.js to handle sensitive customer data in
+production, we take the security of the project seriously. The Ember
+project maintains a [clearly outlined security policy](/security/) and a
+[low-traffic mailing list exclusively for security
+announcements](https://groups.google.com/forum/#!forum/ember-security).
+
+## Security Releases: Ember.js 1.11.4, 1.12.2, 1.13.12, 2.0.3, 2.1.2, 2.2.1
+
+Today we are announcing the release of Ember.js 1.11.4, 1.12.2, 1.13.12,
+2.0.3, 2.1.2 and 2.2.1, which contain an important security fix.
+
+* 1.11.4 -- [Compare View](https://github.com/emberjs/ember.js/compare/v1.11.3...v1.11.4)
+* 1.12.2 -- [Compare View](https://github.com/emberjs/ember.js/compare/v1.12.1...v1.12.2)
+* 1.13.12 -- [Compare View](https://github.com/emberjs/ember.js/compare/v1.13.11...v1.13.12)
+* 2.0.3 -- [Compare View](https://github.com/emberjs/ember.js/compare/v2.0.2...v2.0.3)
+* 2.1.2 -- [Compare View](https://github.com/emberjs/ember.js/compare/v2.1.1...v2.1.2)
+* 2.2.1 -- [Compare View](https://github.com/emberjs/ember.js/compare/v2.2.0...v2.2.1)
+* Additionally, the stable, beta and master branches have been patched.
+
+These releases contain a fix for an XSS vulnerability that you can learn
+more about on our security mailing list:
+
+* [CVE-2015-7565](https://groups.google.com/forum/#!topic/ember-security/OfyQkoSuppY)
+
+It is recommended that you update immediately. In order to ease
+upgrading, the only change in each release is the security fix.
+
+We would like to thank Roman Shafigullin at LinkedIn for reporting the
+issue, as well as core team member Robert Jackson at Twitch for patching
+the vulnerability and doing the release engineering.
+
+If you discover what you believe may be a security issue in Ember.js, we
+ask that you follow our [responsible disclosure
+policy](/security/).
+
+If you are using Ember.js in production, please consider subscribing to
+our [security announcements mailing
+list](https://groups.google.com/forum/#!forum/ember-security).  It is
+extremely low-traffic and only contains announcements such as these.
+
+#### Additional Reading
+
+* [Ember.js Security Policy Announcement](/blog/2013/04/05/announcing-the-ember-security-policy.html)
+* [Ember.js Security Policy](/security/)
+* [Ember.js Security Group](https://groups.google.com/forum/#!forum/ember-security)


### PR DESCRIPTION
This is the blog post announcing the patched Ember releases that contain a fix for CVE-2015-7565. This PR can be merged once we verify:

1. `master`, `stable` and `beta` branches have been patched
2. The corresponding releases have had their tags pushed to GitHub (the Compare links won't work until then)

@rwjblue 