### PR TITLE
Emphasize style attribute binding should not be quoted

### DIFF
--- a/source/deprecations/v1.x.html.md
+++ b/source/deprecations/v1.x.html.md
@@ -345,9 +345,12 @@ making the content a `SafeString`. For example:
 ```js
   myStyle: Ember.computed('color', function() {
     var color = escapeCSS(this.get('color'));
-    return new Ember.Handlebars.SafeString("color: " + color);
+    return Ember.String.htmlSafe("color: " + color);
   })
 ```
+
+Make sure you don't put quotes around the sanitized string, `myStyle`, when you
+bound it in the template. This would prevent Ember from seeing it as safe.
 
 You can learn more about `SafeString`s and writing code that prevents XSS
 attacks by reading the [Writing
@@ -1001,7 +1004,7 @@ In many cases you can move your logic later in the component lifecycle by implem
     this._super(...arguments);
     this.set('myValue', value);
   }
-``` 
+```
 
 #### beforeObserver
 


### PR DESCRIPTION
I've spent quite some time debugging this (see [my blog post](http://balinterdi.com/2016/02/03/binding-style-attributes-warning-in-ember.html)), and although the section in the guides is correct, I think others would benefit by having this emphasized.