### PR TITLE
Use GitHub Pagination for the loading example

### DIFF
--- a/source/javascripts/app/examples/loading/app.js
+++ b/source/javascripts/app/examples/loading/app.js
@@ -1,7 +1,5 @@
 App.ApplicationRoute = Ember.Route.extend({
   model: function() {
-    return Ember.$.getJSON('https://api.github.com/repos/emberjs/ember.js/pulls').then(function(data) {
-      return data.splice(0, 3);
-    });
+    return Ember.$.getJSON('https://api.github.com/repos/emberjs/ember.js/pulls?page=1&per_page=3');
   }
 });


### PR DESCRIPTION
Currently, the example grabs all of Ember's PRs over the network then splices out all but the 3 most current. GitHub's API has pagination, so this isn't necessary and just increases network load.