### PR TITLE
Add Ember-CLI welcome script

### DIFF
--- a/source/javascripts/ember-cli-welcome.js
+++ b/source/javascripts/ember-cli-welcome.js
@@ -1,0 +1,88 @@
+// Used as part of the initial Ember-CLI application.hbs template to welcome new folks
+// This is fairly visible, so change with care! :-)
+
+jQuery('#title').hide();
+
+jQuery('head').append('<style>' +
+  'body {' +
+  '  font-family: "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;' +
+  '  font-size: 16px;' +
+  '  line-height: 1.35em;' +
+  '  background: #FFFBF5;' +
+  '}' +
+  'p {' +
+  '  margin: 0 0 .75em;' +
+  '}' +
+  'a {' +
+  '  color: #dd6a58;' +
+  '  text-decoration: none;' +
+  '}' +
+  'a:hover {' +
+  '  color: #c13c27;' +
+  '}' +
+  'h2 {' +
+  '  color: #dd6a58;' +
+  '  margin-top: 1em;' +
+  '  font-size: 1.75em;' +
+  '}' +
+  '.welcome-box {' +
+  '  width: 800px;' +
+  '  color: #865931;' +
+  '  margin: 2em auto 0;' +
+  '}' +
+  '.welcome-box img {' +
+  '  float: left;' +
+  '  margin-right: 3em;' +
+  '  width: 300px;' +
+  '  height: 336px;' +
+  '}' +
+  '.welcome {' +
+  '  width: 450px;' +
+  '  float: left;' +
+  '}' +
+  '.welcome ul {' +
+  '  list-style: disc;' +
+  '  padding-left: 2em;' +
+  '  margin-bottom: .75em;' +
+  '}' +
+  '.welcome > ul > li {' +
+  '  padding-bottom: .5em;' +
+  '}' +
+  '.postscript {' +
+  '  clear: both;' +
+  '  text-align: center;' +
+  '  padding-top: 3em;' +
+  '  font-size: 12px;' +
+  '  color: #aaa;' +
+  '  font-style: italic;' +
+  '}' +
+  '.postscript code {' +
+  '  background-color: #F8E7CF;' +
+  '  border-radius: 3px;' +
+  '  font-family: Menlo, Courier, monospace;' +
+  '  font-size: 0.9em;' +
+  '  padding: 0.2em 0.5em;' +
+  '  margin: 0 0.1em;' +
+  '}' +
+  '</style>');
+
+$('#title').after(
+  '<div class="welcome-box" style="display:none">' +
+  '  <img src="http://emberjs.com/images/tomsters/construction.png" alt="Under construction">' +
+  '  <div class="welcome">' +
+  '  <h2 id="new-title">Welcome to Ember!</h2>' +
+  '  <p>Don\'t mind the dust, but make yourself at home!</p>' +
+  '  <p>Seriously though, there isn\'t much to look at here. Below are a few resources to help you get started:</p>' +
+  '  <ul>' +
+  '    <li><a href="http://guides.emberjs.com">Ember Guides</a> - learn more about Ember</li>' +
+  '    <li><a href="http://emberjs.com/api">Ember API</a> - in-depth information about core apis</li>' +
+  '    <li><a href="http://www.emberobserver.com">Ember Observer</a> - useful community add-ons</li>' +
+  '  </ul>' +
+  '  <p>And if you run into problems, please check <a href="http://stackoverflow.com/questions/tagged/ember.js">Stack Overflow</a> or <a href="http://discuss.emberjs.com">our forums</a> for answers.  If you don\'t find what you are looking for, post a question, people love to help new folks get started!</p>' +
+  '  </div>' +
+  '</div>' +
+  '<p class="postscript" style="display:none">To remove this welcome message, remove the <code>ember-cli-welcome.js</code> line in <code>app/templates/application.hbs</code></p>').remove();
+
+$('.welcome-box').fadeIn(1000, function() {
+  $('.postscript').delay(500).fadeIn(500);
+});


### PR DESCRIPTION
This file is going to be referenced from the Ember-CLI `application.hbs` file.  We're trying to achieve a few things here:

- provide a nice 'getting started' experience for folks new to the Ember ecosystem
- keep from unnecessarily cluttering the Ember default template in any way that would make upgrades more painful for folks already using Ember

We ( @mixonic and I ) are hoping that referencing this script from the Ember-CLI `application.hbs` will be a reasonable compromise.

Before:
![before](https://cloud.githubusercontent.com/assets/802505/13208749/2aee2776-d8d9-11e5-90d5-b9720bcefebc.png)

After:
![screen shot 2016-02-21 at 8 40 30 pm](https://cloud.githubusercontent.com/assets/802505/13208945/6a383e06-d8db-11e5-9fd7-417768cf7ec1.png)

Questions:
- Is this the text that we want to put in? Is it warm and friendly enough?  Representative of the Tomster way of saying things? :smile:  Anything we are leaving out?  
- Do we want to link to anything else?  I've heard recommendations to link to the Ember Inspector, but was trying to avoid linking to anything specifically called out in the Guides and also avoid linking to Slack so we don't run into size problems there ...  Plus, linking to specific sub-sections of the guides requires additional 'version' info as we don't currently have a `/current/` url yet ;-)
- I'm assuming we'd want to localize this for different languages.  That seems like a v2 of this, but any thoughts on how to handle that?

Additional thoughts:
- we decided to skip worrying about the 'offline experience' of this as the only time folks would see this page would be immediately after an `npm install` (unless this is shown while at a conference without Internet access, in which case the page should load as normal but throw a 404 behind the scenes due to the inability to load the external script)

/cc @locks @wifelette @mixonic @tomdale 