### PR TITLE
Add missing lat long for meetup in Riverside, CA

### DIFF
--- a/data/meetups.yml
+++ b/data/meetups.yml
@@ -329,9 +329,11 @@ locations:
       profileImage: http://photos3.meetupstatic.com/photos/member/6/a/2/4/thumb_241647172.jpeg
   - location: Riverside, CA
     url: http://www.meetup.com/Ember-Riverside-Meetup/
+    lat: 33.981040
+    lng: -117.376674
     organizers:
-      organizer: Judd Lillestrand
-      profileImage: http://photos2.meetupstatic.com/photos/member/2/1/d/6/thumb_59348662.jpeg
+      - organizer: Judd Lillestrand
+        profileImage: http://photos2.meetupstatic.com/photos/member/6/b/8/9/thumb_248067529.jpeg
   - location: Raleigh, NC
     url: http://triangleember.com/
     lat: 35.77791


### PR DESCRIPTION
The missing lat / long data was causing the link on http://emberjs.com/community/meetups/ to go directly to the meetup's page instead of interacting with the google map (like the other links do). 

I pulled the lat/long from the address they typically host their startup from as seen on: http://www.meetup.com/Ember-Riverside-Meetup/events/224108684/, or directly on the image http://photos1.meetupstatic.com/photos/event/9/d/8/2/600_371440322.jpeg

I also fixed the url for the organizer's profile image.