### PR TITLE
Hide private and deprecated classes and namespaces from sidebar.

### DIFF
--- a/source/layouts/api.erb
+++ b/source/layouts/api.erb
@@ -33,8 +33,10 @@
         <a href='#'>Namespaces</a>
         <% ol_for(:namespaces) do %>
           <% api_namespaces.each do |id, data| %>
-            <% li_for(:namespaces, name: data['name'], class: 'sub-selected') do %>
-              <%= api_namespace_link data['name'] %>
+            <% unless data['access'] === 'private' or data['deprecated'] %>
+              <% li_for(:namespaces, name: data['name'], class: 'sub-selected') do %>
+                <%= api_namespace_link data['name'] %>
+              <% end %>
             <% end %>
           <% end %>
         <% end %>
@@ -44,8 +46,10 @@
         <a href='#'>Classes</a>
         <% ol_for(:classes) do %>
           <% api_classes.each do |id, data| %>
-            <% li_for(:classes, name:data['name'], class: 'sub-selected') do %>
-              <%= api_class_link data['name'] %>
+            <% unless data['access'] === 'private' or data['deprecated'] %>
+              <% li_for(:classes, name:data['name'], class: 'sub-selected') do %>
+                <%= api_class_link data['name'] %>
+              <% end %>
             <% end %>
           <% end %>
         <% end %>


### PR DESCRIPTION
WIP

- [x] hide private and deprecated from side list
- [ ] hide from private and deprecated from list under module page (maybe just remove this?)
- [ ] hide empty classes/namespaces that had no documentation only made visible by private members (maybe just enforce this on code side?)
- [ ] make deprecated stuff styled instead of hiding (ensure deprecated 1.x is marked private)
- [ ] style private and public at top more noticeable fashion
