### PR TITLE
Fix typo in Ember 2.4.0 release post

### DIFF
--- a/source/blog/2016-02-29-ember-2-4-released.md
+++ b/source/blog/2016-02-29-ember-2-4-released.md
@@ -45,11 +45,11 @@ objects to a target object. For example:
 ```javascript
 let a = {first: 'John'};
 let b = {last: 'Lennon'};
-let c = {band: 'The Bealtes'};
+let c = {band: 'The Beatles'};
 
 Ember.assign(a, b, c);
 
-// a === {first: 'John', last: 'Lennon', band: 'The Bealtes'}
+// a === {first: 'John', last: 'Lennon', band: 'The Beatles'}
 // b === {last: 'Lennon'}
 // c === {band: 'The Beatles'}
 ```


### PR DESCRIPTION
Fixes a typo in `Ember.assign` example.