### PR TITLE
Update Minneapolis / St. Paul Meetup Listing

### DIFF
--- a/data/meetups.yml
+++ b/data/meetups.yml
@@ -214,14 +214,18 @@ locations:
     - organizer: Merrilee Luke-Ebbeler
       profileImage: http://photos4.meetupstatic.com/photos/member/5/a/0/c/thumb_157403052.jpeg
   - location: Minneapolis / St. Paul, MN
-    url: http://www.meetup.com/Ember-Twin-Cities
-    lat: 44.9716692
-    lng: -93.2806134
+    url: http://www.meetup.com/EmberMN/
+    lat: 44.965775
+    lng: -93.185274
     organizers:
     - organizer: Jacob Quant
       profileImage: http://photos4.meetupstatic.com/photos/member/d/9/5/a/thumb_168415642.jpeg
     - organizer: Seth Phillips
-      profileImage: http://photos4.meetupstatic.com/photos/member/6/4/3/e/thumb_218605662.jpeg
+      profileImage: http://photos1.meetupstatic.com/photos/member/9/b/8/f/thumb_251319823.jpeg
+    - organizer: Ben Rosas
+      profileImage: http://photos4.meetupstatic.com/photos/member/d/c/2/0/thumb_164336352.jpeg
+    - organizer: Doug DeBold
+      profileImage: http://photos2.meetupstatic.com/photos/member/6/8/6/2/thumb_218846722.jpeg
   - location: Portland, OR
     url: http://www.meetup.com/Ember-PDX/
     lat: 45.5230622


### PR DESCRIPTION
We changed our Meetup name some time ago, so I was surprised that the Ember Community page still listed the old link. Although it redirects to the proper/new Meetup page, I think it needs to be corrected for Ember Weekly to pull our dates. I also updated our organizers while I was at it, and refined the lat/lng coordinates to our common meetup location.

Here is my member page if you need verification (technically not an organizer but a loyal attendee): http://www.meetup.com/EmberMN/members/124187072/