### PR TITLE
Using proper options with bower install

### DIFF
--- a/source/javascripts/app/builds/app.js
+++ b/source/javascripts/app/builds/app.js
@@ -229,7 +229,7 @@ App.Project.reopenClass({
       enableTestURL: true,
       debugFileName: ".debug.js",
       ignoreFiles: ['ember.js'],
-      installWithEmberCLI: '# Install Ember %s:\nbower install --dev ember#v%s\n# Or, install the latest build of this channel which may include unreleased incremental changes:\nbower install --dev ember#beta'
+      installWithEmberCLI: '# Install Ember %s:\nbower install --save ember#v%s\n# Or, install the latest build of this channel which may include unreleased incremental changes:\nbower install --save ember#beta'
     }, {
       projectName: "Ember Data",
       baseFileName: 'ember-data',
@@ -264,7 +264,7 @@ App.Project.reopenClass({
       enableTestURL: true,
       debugFileName: ".debug.js",
       ignoreFiles: ['ember.js'],
-      installWithEmberCLI: '# Install the latest Ember canary:\nbower install --dev ember#canary'
+      installWithEmberCLI: '# Install the latest Ember canary:\nbower install --save ember#canary'
     }, {
       projectName: "Ember Data",
       baseFileName: 'ember-data',

--- a/source/javascripts/app/builds/app.js
+++ b/source/javascripts/app/builds/app.js
@@ -212,7 +212,7 @@ App.Project.reopenClass({
       enableTestURL: true,
       debugFileName: ".debug.js",
       ignoreFiles: ['ember.js'],
-      installWithEmberCLI: '# Install Ember %s:\nbower install --dev ember#v%s\n# Or, install the latest build of this channel which may include unreleased incremental changes:\nbower install --dev ember#release'
+      installWithEmberCLI: '# Install Ember %s:\nbower install --save ember#v%s\n# Or, install the latest build of this channel which may include unreleased incremental changes:\nbower install --save ember#release'
     }, {
       projectName: "Ember",
       baseFileName: 'ember',


### PR DESCRIPTION
Per bowers documentation `--dev` is not an install option: http://bower.io/docs/api/#install