### PR TITLE
Add survey reminder to layout — WIP

### DIFF
--- a/source/_survey-reminder.html.erb
+++ b/source/_survey-reminder.html.erb
@@ -1,0 +1,9 @@
+<% if !current_page.data.no_survey_reminder %>
+  <div class="survey-reminder-wrapper">
+    <div class="survey-reminder-container">
+      Only a <strong>4 days left</strong> to
+      <% link_to '/ember-community-survey-2016' do %>
+        submit your community survey response<% end %>!
+    </div>
+  </div>
+<% end %>

--- a/source/ember-community-survey-2016.html.erb
+++ b/source/ember-community-survey-2016.html.erb
@@ -1,8 +1,14 @@
 ---
 title: "Ember Community Survey 2016"
 responsive: true
+no_survey_reminder: true
 ---
 <% content_for :outside_wrapper do %>
+<div class="survey-reminder-wrapper">
+  <div class="survey-reminder-container">
+    Only a <strong>4 days left</strong> to submit your response!
+  </div>
+</div>
 <div class="survey-wrapper survey-wrapper-header">
   <div class="survey-header survey-container">
     <h1 class="survey-h1">

--- a/source/layout.erb
+++ b/source/layout.erb
@@ -32,6 +32,8 @@
 
     <%= partial "header" %>
 
+    <%= partial "survey-reminder" %>
+
     <%= yield_content :outside_wrapper %>
 
     <div id="content-wrapper">

--- a/source/stylesheets/_survey-reminder.scss
+++ b/source/stylesheets/_survey-reminder.scss
@@ -1,0 +1,23 @@
+.survey-reminder-wrapper {
+  background: white;
+  color: $orange-color;
+  text-align: center;
+  line-height: 2.2;
+  font-size: 0.8rem;
+  border-bottom: 1px solid #e5dbd6;
+  a {
+    border-bottom: 1px dotted #f23818;
+  }
+}
+.survey-reminder-container {
+  width: 960px;
+  margin: auto;
+}
+
+@media screen and (max-width: 53.75rem) {
+  .responsive .survey-reminder-container {
+    width: inherit;
+    line-height: 1.5;
+    padding: 0.8rem 1rem;
+  }
+}

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -5,6 +5,7 @@
 @import 'fonts';
 @import 'colors';
 @import 'header';
+@import 'survey-reminder';
 @import 'footer';
 @import 'examples';
 @import 'about';


### PR DESCRIPTION
This adds a simple reminder bar to the website to remind folks to fill out their 2016 survey. Preview below.

@mixonic can you give me some direction on the copy? Also, should I use a hard date as the stopping point or a little Javascript for something like "2 days left"?

Preview:
![ember_js_-_a_framework_for_creating_ambitious_web_applications_](https://cloud.githubusercontent.com/assets/1318878/13869705/6611d458-eca5-11e5-8422-a57ea0e4258b.jpg)

Mobile (responsive page): 
![9bby70rq8ciaaaaasuvork5cyii](https://cloud.githubusercontent.com/assets/1318878/13869686/4ffcdd34-eca5-11e5-82e9-bd8c2af2d3f4.png)

Mobile (unresponsive page):
![ember_js_-_a_framework_for_creating_ambitious_web_applications_ 2](https://cloud.githubusercontent.com/assets/1318878/13869696/58ffca90-eca5-11e5-803b-c1aa48031f23.jpg)