### PR TITLE
Fix EmbeddedRecordsMixin import path

### DIFF
--- a/source/blog/2016-03-13-ember-data-2-4-released.md
+++ b/source/blog/2016-03-13-ember-data-2-4-released.md
@@ -21,11 +21,11 @@ details.
 
 #### Importing Modules
 
-[@pangratz](https://github.com/pangratz) added public paths to make it easy to import the `DS.EmbeddedRecordsMixin` and `DS.Serializer` modules.
+[@pangratz](https://github.com/pangratz) [added public paths](https://github.com/emberjs/data/pull/4125) to make it easy to import the `DS.EmbeddedRecordsMixin` and `DS.Serializer` modules.
 
 ```js
 // DS.EmbeddedRecordsMixin
-import EmbeddedRecordsMixin from 'ember-data/mixins/embedded-records';
+import EmbeddedRecordsMixin from 'ember-data/serializers/embedded-records-mixin';
 
 // DS.Serializer
 import Serializer from 'ember-data/serializer';


### PR DESCRIPTION
The embedded records mixin is located at `'ember-data/serializers/embedded-records-mixin'` not `'ember-data/mixins/embedded-records'` as I found out when copy/pasting the example. This fixes the example code and adds a reference to the pull request that introduced the changes.