### PR TITLE
Move some community page sections, according to priority

### DIFF
--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -8,39 +8,6 @@ title: "Community"
   <iframe width="640" height="360" src="https://www.youtube.com/embed/rY5D38RQoEg?rel=0" frameborder="0" allowfullscreen></iframe>
 </div>
 
-<div class="community section contribute">
-  <h2>In a Giving Mood? Contribute to the Project</h2>
-
-  <div class="image"></div>
-
-  <p>The Ember.js source is hosted on <a href="https://github.com/emberjs/ember.js/">Github</a>.
-    To contribute patches, create a fork of the project on GitHub and submit a pull request.
-    Please be sure to include unit tests and documentation for any new features you add.
-    See the <a href="https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md">full guidelines</a>
-    for more information.</p>
-</div>
-
-<div class="community section bugs">
-  <h2>Something Fishy? Report it to the Team</h2>
-
-  <div class="image"></div>
-
-  <p>If you've found a bug or issue in Ember.js, please let us know. To file a bug, go to the
-    <a href="https://github.com/emberjs/ember.js/issues">issue tracker</a> and create a new
-    issue. Great bug reports include a clear description of what is not happening and what
-    you expected to happen. Issues that include a failing test or a reduced test case
-    created on <a href="https://ember-twiddle.com">Ember Twiddle</a>, <a href="http://jsfiddle.net/6Evrq/">JSFiddle</a> or
-    <a href="http://emberjs.jsbin.com/">JSBin</a> are much more likely to receive attention.
-    See the <a href="https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md">full guidelines</a>
-    for more information.</p>
-
-    <p>Please do not report security vulnerabilities on the public GitHub issue tracker. The <a href="/security">Ember.js Security Policy</a> details the procedure for disclosing security issues.</p>
-
-    <p>The source code for this website is also <a href="https://github.com/emberjs/website">available on GitHub</a>. If you have found a typo or incorrect documentation, please file an issue on the GitHub project page, or even better, submit a pull request.</p>
-
-    <p>Ember is an inclusive community that welcomes (and benefits from!) people of all backgrounds. If you're having a non-code issue, <a href="mailto:ombudsman@emberjs.com?subject=Website Help Link">reach out</a>. We do our very best to be sure every Ember user has pleasant interactions and positive experiences. If we can help make you feel more comfortable or help navigate a trying situation, let us know.</p>
-</div>
-
 <div class="community section help">
   <h2>Stuck? Lost? Get Help from the Community</h2>
 
@@ -70,6 +37,39 @@ title: "Community"
   <p>
     For a curated list of Ember learning resources (podcasts, videos, blog posts, books, etc) check out <a href="http://emberwatch.com/">EmberWatch</a>.
   </p>
+</div>
+
+<div class="community section bugs">
+  <h2>Something Fishy? Report it to the Team</h2>
+
+  <div class="image"></div>
+
+  <p>If you've found a bug or issue in Ember.js, please let us know. To file a bug, go to the
+    <a href="https://github.com/emberjs/ember.js/issues">issue tracker</a> and create a new
+    issue. Great bug reports include a clear description of what is not happening and what
+    you expected to happen. Issues that include a failing test or a reduced test case
+    created on <a href="https://ember-twiddle.com">Ember Twiddle</a>, <a href="http://jsfiddle.net/6Evrq/">JSFiddle</a> or
+    <a href="http://emberjs.jsbin.com/">JSBin</a> are much more likely to receive attention.
+    See the <a href="https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md">full guidelines</a>
+    for more information.</p>
+
+    <p>Please do not report security vulnerabilities on the public GitHub issue tracker. The <a href="/security">Ember.js Security Policy</a> details the procedure for disclosing security issues.</p>
+
+    <p>The source code for this website is also <a href="https://github.com/emberjs/website">available on GitHub</a>. If you have found a typo or incorrect documentation, please file an issue on the GitHub project page, or even better, submit a pull request.</p>
+
+    <p>Ember is an inclusive community that welcomes (and benefits from!) people of all backgrounds. If you're having a non-code issue, <a href="mailto:ombudsman@emberjs.com?subject=Website Help Link">reach out</a>. We do our very best to be sure every Ember user has pleasant interactions and positive experiences. If we can help make you feel more comfortable or help navigate a trying situation, let us know.</p>
+</div>
+
+<div class="community section contribute">
+  <h2>In a Giving Mood? Contribute to the Project</h2>
+
+  <div class="image"></div>
+
+  <p>The Ember.js source is hosted on <a href="https://github.com/emberjs/ember.js/">Github</a>.
+    To contribute patches, create a fork of the project on GitHub and submit a pull request.
+    Please be sure to include unit tests and documentation for any new features you add.
+    See the <a href="https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md">full guidelines</a>
+    for more information.</p>
 </div>
 
 <div class="community section meetup">


### PR DESCRIPTION
Moves the community sections around according to priority.  Specific instructions came from this issue: https://github.com/emberjs/website/issues/2520

> Flip the the Stuck? Lost? header (and content) to be immediately beneath the meetup video

<img width="614" alt="screen shot 2016-03-28 at 2 15 08 pm" src="https://cloud.githubusercontent.com/assets/10037587/14090490/9aaacefc-f4ef-11e5-862f-9f4b9172a428.png">

>  move the "in a giving mood?" section down to where the Stuck? Lost? section was

<img width="580" alt="screen shot 2016-03-28 at 2 16 59 pm" src="https://cloud.githubusercontent.com/assets/10037587/14090540/e1c0c1c0-f4ef-11e5-8ac7-7a7d3ce73c7f.png">
