### PR TITLE
Add entry in guide for Ember.Handlebars.SafeString

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -313,3 +313,21 @@ export default Ember.Helper.extend({
   }
 });
 ```
+
+### Deprecations added in 2.6
+
+#### Ember.Handlebars.SafeString
+
+The old `SafeString` API had a common pitfall of not working when `new` was omitted. In addition, the `Ember.Handlebars` namespace is legacy code that will be going away.
+
+Before:
+
+```js
+new Ember.Handlebars.SafeString(someString);
+```
+
+After:
+
+```js
+Ember.String.htmlSafe(someString);
+```


### PR DESCRIPTION
Deprecation guide entry for https://github.com/emberjs/ember.js/pull/13204