### PR TITLE
Add deprecation docs for Ember.Handlebars.SafeString

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -313,3 +313,32 @@ export default Ember.Helper.extend({
   }
 });
 ```
+
+#### Use Ember.String.htmlSafe over Ember.Handlebars.SafeString
+
+Before:
+
+```js
+// Ember < 2.3
+import Ember from 'ember';
+const { computed } = Ember;
+
+export default Ember.Component.extend({
+  myString: computed(function(){
+    return new Ember.Handlebars.SafeString(someString);
+  });
+})
+```
+
+After:
+
+```js
+// Ember 2.3 and later
+import Ember from 'ember';
+const { computed } = Ember;
+export default Ember.Component.extend({
+  myString: computed(function(){
+    return Ember.String.htmlSafe(someString);
+  });
+)};
+```


### PR DESCRIPTION
Adding documentation for planned deprecation of Ember.Handlebars.SafeString as discussed in this issue: https://github.com/emberjs/ember.js/issues/13191