### PR TITLE
add documentation for didinitattrs deprecation

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -342,3 +342,36 @@ export default Ember.Component.extend({
   });
 )};
 ```
+
+#### Ember.Component#didInitAttrs
+
+Using `didInitAttrs` is deprecated in favour of using `init`. When `init` is called the attrs sent in with the component will be
+available after calling `this._super(...arguments)`
+
+Given a htmlbars template like this:
+
+```hbs
+{{my-component handle="@tomdale"}}
+```
+
+Before:
+
+```js
+export default Ember.Component.extend({
+  didInitAttrs() {
+    this._super(...arguments);
+    this.get('handle'); // @tomdale
+  }
+});
+```
+
+After:
+
+```js
+export default Ember.Component.extend({
+  init() {
+    this._super(...arguments);
+    this.get('handle'); // @tomdale
+  }
+});
+```


### PR DESCRIPTION
this adds the documentation for the deprecation of didInitAttrs.


<img width="750" alt="screen shot 2016-03-29 at 07 06 48" src="https://cloud.githubusercontent.com/assets/94960/14110786/da1050a2-f57c-11e5-9a30-5afd6a5c3cd4.png">

