### PR TITLE
Fix survey graph label

### DIFF
--- a/source/ember-community-survey-2016.html.erb
+++ b/source/ember-community-survey-2016.html.erb
@@ -218,7 +218,7 @@ $(function () {
     },
     yAxis: {
       title: {
-        text: 'Months'
+        text: 'Percent'
       }
     },
     series: [{


### PR DESCRIPTION
The vertical axis on the first graph "How long have you been working with Ember?" is labeled "Months", but it seems that it should be "Percent".