### PR TITLE
Documentation for deprecation of model param in `{{render` helper

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -375,3 +375,22 @@ export default Ember.Component.extend({
   }
 });
 ```
+
+### Deprecations added in 2.5
+
+#### Model param in `{{render` helper
+
+Using the model param in the `{{render` helper is deprecated in favor of using
+components. Please refactor to a component and invoke thusly:
+
+Before:
+
+```handlebars
+{{render "foo-bar" someModel}}
+```
+
+After:
+
+```handlebars
+{{foo-bar model=someModel}}
+```


### PR DESCRIPTION
Documents [this PR](https://github.com/emberjs/ember.js/pull/13268) originating from [this issue](https://github.com/emberjs/ember.js/issues/13183). I presume this change will be in 2.5.x so I documented it as such. I can obviously change this though.