### PR TITLE
Add `{{#render` block deprecation.

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -314,6 +314,29 @@ export default Ember.Helper.extend({
 });
 ```
 
+### Deprecations Added in 2.4
+
+#### {{#render}} helper with block
+
+The `{{render}}` helper was never intended to support a block form, but unfortunatley (mostly
+due to various refactorings in 1.10 and 1.13) it started working in block form. Since this was
+not properly engineered, there are a number of caveats (i.e. the `controller` and `target` values of
+anything inside the block are incorrect) that prevent continued support.
+
+Support the following forms will be removed after 2.4:
+
+```hbs
+{{#render 'foo'}}
+  <p>Stuff Here</p>
+{{/render}}
+```
+
+```hbs
+{{#render 'foo' someModel}}
+  <p>Stuff Here</p>
+{{/render}}
+```
+
 ### Deprecations Added in 2.6
 
 #### Use Ember.String.htmlSafe over Ember.Handlebars.SafeString


### PR DESCRIPTION
Partially addresses #2538.

![screenshot](http://assets.rwjblue.com/snapshots/2016-04-10-21-52-57_Ember.js_-_Deprecations_for_v2.x.png)