### PR TITLE
Add `id` and `until` information to 2.x deprecation guide items

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -16,6 +16,9 @@ For more information on deprecations in Ember, see the [main deprecations page]
 
 #### Initializer Arity
 
+###### until: 3.0.0
+###### id: ember-application.app-initializer-initialize-arguments
+
 In prior versions of Ember initializers have taken two arguments (generally labeled as
 `container` and `application`). Starting with Ember 2.1 providing two arguments to an
 `initializer` will trigger a deprecation.
@@ -64,6 +67,9 @@ export default {
 
 #### Ember.Application#registry / Ember.ApplicationInstance#registry
 
+##### until: 3.0.0
+##### id: ember-application.app-instance-registry
+
 When the container and registry were split, the registry was added to `Ember.Application` instances (provided to
 initializers as the first argument in 2.1) and `Ember.ApplicationInstance` instances (provided to instance initializers
 as the first argument). Unfortunately, this was done without making it clear that the `.registry` property on
@@ -86,6 +92,9 @@ The following list can be used to migrate from `app.registry.*` usage to the new
 * `app.registry.injection` -> `app.inject`
 
 #### Ember.ApplicationInstance#container
+
+##### until: 3.0.0
+##### id: ember-application.app-instance-container
 
 When instance initializers were added, using `appInstance.container.lookup` was suggested in lieu of using the first argument
 to initializers. Unfortunately, the `container` system has always been private and the previous initializer deprecation led
@@ -132,6 +141,9 @@ export default {
 
 #### Ember debug function options
 
+##### until: 3.0.0
+##### id: ember-debug.deprecate-options-missing, ember-debug.deprecate-id-missing, ember-debug.deprecate-until-missing, ember-debug.warn-options-missing, ember-debug.warn-id-missing
+
 Starting in Ember 2.1 various debug functions now require a third argument (commonly called `options`).
 
 `id` is required by all methods listed below, and the deprecation related methods also require an `until` property.
@@ -149,6 +161,9 @@ The goal of these changes is to allow tools like
 these deprecations and warnings much easier (by matching on the `id` instead of the full deprecation/warn message).
 
 #### Ember.Component#defaultLayout
+
+##### until: 3.0.0
+##### id: ember-views.component.defaultLayout
 
 Specifying a `defaultLayout` to a component is deprecated in favor of specifying `layout` directly. `defaultLayout` was
 often used in order to allow inheriting components to fallback to their parents `defaultLayout` if a custom `layout` was
@@ -180,6 +195,9 @@ export default Ember.Component.extend({
 
 #### Ember.Component#currentState
 
+##### until: 2.3.0
+##### id: ember-view.current-state
+
 The `currentState` property on `Ember.Component` instances is a private property that Ember uses
 internally to deal with the various states a component can be in (in DOM, pre-render, destroying, etc). Unfortunately,
 this removes a pretty common term (`currentState` might be used for many things in a user-land component).
@@ -193,6 +211,8 @@ outside of Ember internals.
 
 #### Function as test in Ember.deprecate, Ember.warn, Ember.assert
 
+##### until: 2.5.0
+##### id: ember-debug.deprecate-test-as-function
 ##### Deprecated behavior
 
 Calling `Ember.deprecate`, `Ember.warn` or `Ember.assert` with a function as test argument is deprecated.
@@ -253,6 +273,9 @@ In a future version functions will be treated as truthy values instead of being 
 ### Deprecations added in 2.3
 
 #### Injected container access
+
+##### until: 3.0.0
+##### id: ember-application.injected-container
 
 `this.container` has been private API since at least Ember 1.0.0. Unfortunately, there was not a public API available
 to use as an alternative.  In the Ember 2.1 cycle a number of public API's were added to instance initializers
@@ -318,6 +341,9 @@ export default Ember.Helper.extend({
 
 #### {{#render}} helper with block
 
+##### until: 2.4.0
+##### id: ember-template-compiler.deprecate-render-block
+
 The `{{render}}` helper was never intended to support a block form, but unfortunatley (mostly
 due to various refactorings in 1.10 and 1.13) it started working in block form. Since this was
 not properly engineered, there are a number of caveats (i.e. the `controller` and `target` values of
@@ -341,6 +367,9 @@ Support the following forms will be removed after 2.4:
 
 #### Ember.merge
 
+##### until: 3.0.0
+##### id: ember-metal.merge
+
 `Ember.merge` is deprecated in favor of `Ember.assign`, which is now a public API since Ember 2.5. For typical usages, this
 should be a 1-to-1 replacement:
 
@@ -359,6 +388,9 @@ Ember.assign({}, defaultOptions);
 ### Deprecations Added in 2.6
 
 #### Use Ember.String.htmlSafe over Ember.Handlebars.SafeString
+
+##### until: 3.0.0
+##### id: ember-htmlbars.ember-handlebars-safestring
 
 Before:
 
@@ -386,6 +418,9 @@ export default Ember.Component.extend({
 ```
 
 #### Ember.Component#didInitAttrs
+
+##### until: 3.0.0
+##### id: ember-views.did-init-attrs
 
 Using `didInitAttrs` is deprecated in favour of using `init`. When `init` is called the attrs sent in with the component will be
 available after calling `this._super(...arguments)`
@@ -419,6 +454,9 @@ export default Ember.Component.extend({
 ```
 
 #### Model param in `{{render` helper
+
+##### until: 3.0.0
+##### id: ember-template-compiler.deprecate-render-model
 
 Using the model param in the `{{render` helper is deprecated in favor of using
 components. Please refactor to a component and invoke thusly:
@@ -481,6 +519,9 @@ Once view and controller deprecations are removed, you can remove the addons wit
 ### Deprecations Added in 2.7
 
 #### Ember.Backburner
+
+##### until: 2.8.0
+##### id: ember-metal.ember-backburner
 
 `Ember.Backburner` was private throughout the Ember 2.x series and will be
 removed _after_ 2.8.


### PR DESCRIPTION
Added `id` and `until` to each item just below the header. Not listed in the original issue, but I also added `id` and `until` to Ember.Backburner under 2.7

Issue https://github.com/emberjs/website/issues/2543