### PR TITLE
Add  to deprecation guide

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -525,3 +525,54 @@ Once view and controller deprecations are removed, you can remove the addons wit
 
 `Ember.Backburner` was private throughout the Ember 2.x series and will be
 removed _after_ 2.8.
+
+### Deprecations Added in Pending Features
+
+#### Route#serialize
+
+##### until: 3.0.0
+##### id: ember-routing.serialize-function
+
+The `Route#serialize` function was deprecated in favor of passing a `serialize` function into the route's definition in the router map. For more detailed information see the [Route Serializers RFC](https://github.com/emberjs/rfcs/blob/master/text/0120-route-serializers.md).
+
+As an example, given a route like:
+
+```js
+// app/routes/post.js
+import Ember from 'ember';
+export default Ember.Route.extend({
+  // ...
+  serialize(model) {
+    return { post_id: model.id };
+  }
+});
+
+// app/router.js
+export default Router.map(function() {
+  this.route('post', {
+    path: '/post/:post_id'
+  });
+});
+```
+
+You would refactor it like so:
+
+```js
+// app/routes/post.js
+import Ember from 'ember';
+export default Ember.Route.extend({
+  // ...
+});
+
+// app/router.js
+function serializePostRoute(model) {
+  return { post_id: model.id };
+}
+
+export default Router.map(function() {
+  this.route('post', {
+    path: '/post/:post_id',
+    serialize: serializePostRoute
+  });
+});
+```


### PR DESCRIPTION
From emberjs/ember.js#13016. Put it under ~~the 2.7 deprecations because I was unsure when this would actually be active~~ a new section for pending features.