### PR TITLE
[On Hold] Removed `Ember.merge` from the list of 2.x deprecations. 

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -363,28 +363,6 @@ Support the following forms will be removed after 2.4:
 {{/render}}
 ```
 
-### Deprecations Added in 2.5
-
-#### Ember.merge
-
-##### until: 3.0.0
-##### id: ember-metal.merge
-
-`Ember.merge` is deprecated in favor of `Ember.assign`, which is now a public API since Ember 2.5. For typical usages, this
-should be a 1-to-1 replacement:
-
-Before:
-
-```js
-Ember.merge({}, defaultOptions);
-```
-
-After:
-
-```js
-Ember.assign({}, defaultOptions);
-```
-
 ### Deprecations Added in 2.6
 
 #### Use Ember.String.htmlSafe over Ember.Handlebars.SafeString


### PR DESCRIPTION
Per emberjs/ember.js#13344 it is being undeprecated.

EDIT: Do not merge just yet. We should wait at least until Ember 2.5.1 has shipped with the deprecation removed. 