### PR TITLE
new responsive styles and markup for Showcase component (ember-users and sponsors)

### DIFF
--- a/source/ember-users.html.erb
+++ b/source/ember-users.html.erb
@@ -1,5 +1,6 @@
 ---
 title: "Users"
+responsive: true
 ---
 
 <h1>
@@ -15,19 +16,15 @@ title: "Users"
 
 <div class="users section">
 
-<table class="showcase">
-  <% data.users.each_slice(3) do |slice| %>
-    <tr>
-      <% slice.each do |user| %>
-        <td>
-          <a href="<%= user.url %>" rel="nofollow" target="_blank">
-            <img src="/images/about/<%= user.image %>" width="210" height="103" alt="<%= user.alt %>">
-          </a>
-        </td>
-      <% end %>
-    </tr>
+<ul class="showcase">
+  <% data.users.each do |user| %>
+    <li>
+      <a href="<%= user.url %>" rel="nofollow" target="_blank">
+        <img src="/images/about/<%= user.image %>" alt="<%= user.alt %>">
+      </a>
+    </li>
   <% end %>
-</table>
+</ul>
 
 <!-- <a class="orange button" href="mailto:hello@emberjs.com">
   GET LISTED

--- a/source/sponsors.html.erb
+++ b/source/sponsors.html.erb
@@ -14,39 +14,31 @@ responsive: true
 <div class="sponsors section">
   <h2>Current Sponsors</h2>
 
-  <table class="showcase">
-    <% current_sponsors.each_slice(3) do |slice| %>
-      <tr>
-        <% slice.each do |user| %>
-          <td>
-            <a href="<%= user.url %>" rel="nofollow">
-              <img src="/images/about/<%= user.image %>">
-            </a>
-            <h5><%=user.term %></h5>
-            <p id="sponsorType"><%=user.type %></p>
-          </td>
-        <% end %>
-      </tr>
+  <ul class="showcase">
+    <% current_sponsors.each do |user| %>
+      <li>
+        <a href="<%= user.url %>" rel="nofollow">
+          <img src="/images/about/<%= user.image %>">
+        </a>
+        <h5><%=user.term %></h5>
+        <p id="sponsorType"><%=user.type %></p>
+    </li>
     <% end %>
-  </table>
+  </ul>
 
 <h2>Past Sponsors</h2>
 
-  <table class="showcase">
-    <% past_sponsors.each_slice(3) do |slice| %>
-      <tr>
-        <% slice.each do |user| %>
-          <td>
-            <a href="<%= user.url %>" rel="nofollow">
-              <img src="/images/about/<%= user.image %>">
-            </a>
-            <h5><%=user.term %></h5>
-            <p id="sponsorType"><%=user.type %></p>
-          </td>
-        <% end %>
-      </tr>
+  <ul class="showcase">
+    <% past_sponsors.each do |user| %>
+      <li>
+        <a href="<%= user.url %>" rel="nofollow">
+          <img src="/images/about/<%= user.image %>">
+        </a>
+        <h5><%=user.term %></h5>
+        <p id="sponsorType"><%=user.type %></p>
+    </li>
     <% end %>
-  </table>
+  </ul>
 
   <p class="thanks">A special thanks to <a href="https://dribbble.com/mg">Matt Grantham</a> for design of the original (this) Ember website.</p>
 

--- a/source/stylesheets/components/sponsors.css.scss
+++ b/source/stylesheets/components/sponsors.css.scss
@@ -7,21 +7,11 @@ body.sponsors_index.responsive > #content-wrapper {
 }
 
 body.sponsors_index.responsive #content {
-  width: auto;
+  width: 90%;
 }
 
 @media screen and (max-width: 460px) {
   body.sponsors_index.responsive > #content-wrapper {
-    padding: 2em 1em 1em 1em;
-  }
-}
-
-@media screen and (max-width: 760px) {
-  .section table.showcase td {
-    display: block;
-  }
-
-  .showcase td a {
-    margin: 0 auto;
+    padding: 2em 0 1em;
   }
 }

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -508,6 +508,11 @@ p {
   }
 }
 
+.responsive #content-wrapper {
+    max-width: 960px;
+    width: 100%;
+}
+
 #content {
   &.has-sidebar {
     margin: 38px 0 90px 2.1em;
@@ -1517,7 +1522,8 @@ body.security #content {
 
   #content {
     margin: 3em auto 0 auto;
-    width: 54em;
+    max-width: 54em;
+    width: 90%;
   }
 
   .button {
@@ -1537,27 +1543,81 @@ body.security #content {
   width: 100%;
 }
 
-#content .showcase tr {
+ul.showcase {
+  @include clearfix;
+  list-style-type: none;
+}
+
+#content ul.showcase {
+  margin: 0;
+}
+
+#content .showcase li {
   background: transparent;
   border-bottom: none;
 }
 
-.showcase td {
+@media screen and (max-width: 780px) {
+  #content {
+    .showcase > li {
+      width: 50%;
 
-  &:nth-child(2) a {
-    margin: 0 auto;
+      a {
+        margin: 0 auto;
+      }
+    }
   }
+}
 
-  &:nth-child(3) a {
-    margin-left: auto;
+
+@media screen and (max-width: 560px) {
+  #content {
+    .showcase > li {
+      display: block;
+      float: none;
+      margin: 20px auto;
+      width: 100%;
+
+      a {
+        margin: 0 auto;
+      }
+    }
   }
+}
 
-  padding: 10px;
+.showcase > li {
+
+  float: left;
+
+  width: 33.333%;
+  margin: 10px 0;
+  &:nth-child(3n+1) {
+    a {
+      margin: 0 auto 0 0;
+    }
+  }
+  &:nth-child(3n+2) {
+    a {
+      margin: 0 auto 0 auto;
+    }
+  }
+  &:nth-child(3n+3) {
+    a {
+      margin: 0 0 0 auto;
+    }
+  }
   a {
     background-image: url('/images/about/user_bg.png');
     display: block;
     height: 103px;
     width: 210px;
+
+    img {
+      height: auto;
+      width: auto;
+      max-height: 103px;
+      max-width: 210px;
+    }
   }
 }
 
@@ -1837,18 +1897,22 @@ body.tomster_payment-sent #content {
   Sponsors Page
 **/
 
+#content {
+  .sponsors.section {
+    h2:nth-of-type(2) {
+      margin-top: 50px;
+    }
+  }
+}
+
 .sponsors {
   .section {
     width: 100%;
     margin-top: 0px;
-    padding: 0 2em 2em 2em;
+    padding: 0 0 2em;
 
     h2 {
       margin: 30px 0;
-    }
-
-    h2:nth-of-type(2) {
-      margin-top: 50px;
     }
   }
 


### PR DESCRIPTION
Helping at the Denver Ember Meet-up Open Source Night.

I updated the emberjs.com/ember-users page to add responsive styling, this page utilizes the showcase component for displaying user logos. The update involved adding some new css rules, and I updated the markup for the showcase component from a table-based layout to a unordered list, which is a more appropriate and semantic markup structure for this content. 

The Showcase component is also used on the emberjs.com/sponsors page (which was already responsive) so I updated the markup structure there too, and made a few necessary CSS changes related to the sponsors page. I ended up moving some showcase-related styles from the sponsors scss partial to the main site scss partial so that all the showcase styles are co-located.

The Showcase component's visual layout is by-and-large identical with these changes. The new responsive layout shows the logos in a single column on small screens, in rows of two on medium screens, and rows of three of larger screens. There are a couple very minor differences in some padding and text sizes on the Sponsors Showcase due to some inherited styles from the ul/li elements, probably not worth the trouble of fixing.