### PR TITLE
Fix broken meetups map

### DIFF
--- a/source/community/meetups.html.erb
+++ b/source/community/meetups.html.erb
@@ -45,5 +45,5 @@ title: "Meetups"
 </div>
 
 <script src="//maps.google.com/maps/api/js?v=3.13&amp;sensor=false&amp;libraries=geometry" type="text/javascript"></script>
-<script src="//google-maps-utility-library-v3.googlecode.com/svn/tags/markerclustererplus/2.0.14/src/markerclusterer_packed.js" type="text/javascript"></script>
+<script src="https://cdn.rawgit.com/mahnunchik/markerclustererplus/2.1.4/dist/markerclusterer.min.js" type="text/javascript"></script>
 <script src="/javascripts/meetups.js"></script>


### PR DESCRIPTION
The map on the meetups page (http://emberjs.com/community/meetups/) is broken because the linked markerclusterer script returns a 404. The google code repo is shut down, in favor of github. This PR fixes the URL.