### PR TITLE
Move safe string deprecation to 'future' section

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -365,36 +365,6 @@ Support the following forms will be removed after 2.4:
 
 ### Deprecations Added in 2.6
 
-#### Use Ember.String.htmlSafe over Ember.Handlebars.SafeString
-
-##### until: 3.0.0
-##### id: ember-htmlbars.ember-handlebars-safestring
-
-Before:
-
-```js
-import Ember from 'ember';
-const { computed } = Ember;
-
-export default Ember.Component.extend({
-  myString: computed(function(){
-    return new Ember.Handlebars.SafeString(someString);
-  });
-})
-```
-
-After:
-
-```js
-import Ember from 'ember';
-const { computed } = Ember;
-export default Ember.Component.extend({
-  myString: computed(function(){
-    return Ember.String.htmlSafe(someString);
-  });
-)};
-```
-
 #### Ember.Component#didInitAttrs
 
 ##### until: 3.0.0
@@ -614,4 +584,34 @@ export default Router.map(function() {
     serialize: serializePostRoute
   });
 });
+```
+
+#### Use Ember.String.htmlSafe over Ember.Handlebars.SafeString
+
+##### until: 3.0.0
+##### id: ember-htmlbars.ember-handlebars-safestring
+
+Before:
+
+```js
+import Ember from 'ember';
+const { computed } = Ember;
+
+export default Ember.Component.extend({
+  myString: computed(function(){
+    return new Ember.Handlebars.SafeString(someString);
+  });
+})
+```
+
+After:
+
+```js
+import Ember from 'ember';
+const { computed } = Ember;
+export default Ember.Component.extend({
+  myString: computed(function(){
+    return Ember.String.htmlSafe(someString);
+  });
+)};
 ```


### PR DESCRIPTION
This feature is not deprecated in 2.6. It has been deferred until we have a proper RFC for safe strings.