### PR TITLE
Add Bourbon

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem "underscore-rails"
 gem "gmaps4rails"
 gem "geocoder"
 gem "faraday"
+gem "bourbon"
 
 source 'https://rails-assets.org' do
   gem "rails-assets-js-md5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,9 @@ GEM
     barber (0.9.2)
       ember-source (>= 1.0, < 3)
       execjs (>= 1.2, < 3)
+    bourbon (4.2.7)
+      sass (~> 3.4)
+      thor (~> 0.19)
     builder (3.2.2)
     byebug (2.7.0)
       columnize (~> 0.3)
@@ -224,6 +227,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
+  bourbon
   builder
   capybara
   coderay!

--- a/source/stylesheets/builds.css.scss
+++ b/source/stylesheets/builds.css.scss
@@ -1,4 +1,5 @@
-@import "compass";
+@import "bourbon";
+@import "compass/css3/transform";
 @import "variables";
 @import "mixins/hidpi";
 
@@ -107,7 +108,7 @@
   }
 
   .future-image {
-    @include opacity(0.35);
+    opacity: 0.35;
   }
 
   .clear {

--- a/source/stylesheets/examples.css.scss
+++ b/source/stylesheets/examples.css.scss
@@ -1,4 +1,4 @@
-@import "compass/css3";
+@import "bourbon";
 @import "solarized_light";
 @import "variables";
 @import "mixins/hidpi";
@@ -82,7 +82,7 @@
   display: inline-block;
   font-size: 14px;
   border-radius: 0;
-  @include background-clip(padding-box);
+  background-clip: padding-box;
   box-shadow: 0 0 0 rgba(0,0,0,0);
   border-top: none;
   border-left: none;

--- a/source/stylesheets/guides.css.scss
+++ b/source/stylesheets/guides.css.scss
@@ -1,4 +1,3 @@
-@import "compass/css3";
 @import "variables";
 @import "mixins/hidpi";
 

--- a/source/stylesheets/highlight.css.scss
+++ b/source/stylesheets/highlight.css.scss
@@ -1,4 +1,4 @@
-@import "compass";
+@import "bourbon";
 @import "variables";
 @import "shared";
 

--- a/source/stylesheets/shared.css.scss
+++ b/source/stylesheets/shared.css.scss
@@ -1,4 +1,4 @@
-@import "compass/css3";
+@import "bourbon";
 @import "variables";
 @import "mixins/hidpi";
 

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -1,6 +1,6 @@
-@import 'compass';
 @import 'compass/reset';
 @import 'compass/typography/text/ellipsis';
+@import 'bourbon';
 @import 'variables';
 @import 'mixins/hidpi';
 @import 'fonts';
@@ -397,7 +397,7 @@ p {
         text-transform: uppercase;
         color: #faf2ee;
 
-        @include text-shadow(rgba(0, 0, 0, 0.3) 0px 1px 0px);
+        text-shadow: rgba(0, 0, 0, 0.3) 0px 1px 0px;
         display: block;
         padding: 0px 1em;
         height: 26px;
@@ -410,7 +410,7 @@ p {
 
       &.active a {
         color: #331915;
-        @include text-shadow(rgba(255, 255, 255, 0.2) 0 1px 0px);
+        text-shadow: rgba(255, 255, 255, 0.2) 0 1px 0px;
         background-color: #bf4737;
         background-color: rgba(0, 0, 0, 0.2);
         border-radius: 3px;
@@ -458,7 +458,7 @@ p {
       font-size: 12px;
       text-transform: uppercase;
       color: #faf2ee;
-      @include text-shadow(rgba(0, 0, 0, 0.3) 0px 1px 0px);
+      text-shadow: rgba(0, 0, 0, 0.3) 0px 1px 0px;
 
       display: block;
       padding: 0px 1em 0 0.5em;
@@ -466,7 +466,6 @@ p {
       line-height: 28px;
 
       background-color: #ff6e56;
-      @include filter-gradient(#ff6e56, #ed4f35, vertical);
       @include background-image(linear-gradient(to bottom, #ff6e56 0%, #ed4f35 100%));
 
       border: 1px solid #a93926;
@@ -2207,14 +2206,13 @@ body.team {
   font-size: 14px;
   color: #f6ece8;
   text-align: center;
-  @include text-shadow(rgba(0, 0, 0, 0.3) 0 1px 0);
+  text-shadow: rgba(0, 0, 0, 0.3) 0 1px 0;
 
   &.orange {
     border: 1px solid #cb6352;
     border-top-color: #ea7a68;
     border-bottom-color: #a04332;
 
-    @include filter-gradient(#fe845a, #d14e37, vertical);
     @include background-image( linear-gradient(to bottom, #fe845a, #d14e37) );
     border-radius: 5px;
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
@@ -2223,7 +2221,6 @@ body.team {
       border-color: #e27260;
       border-top-color: #ea7a68;
       border-bottom-color: #c1513d;
-      @include filter-gradient(#fc906b, #e2654e, vertical);
       @include background-image( linear-gradient(to bottom, #fc906b, #e2654e) );
     }
 
@@ -2231,10 +2228,9 @@ body.team {
       border-color: #c9533d;
       border-top-color: #92473a;
       border-bottom-color: #e1583f;
-      @include filter-gradient(#b2412e, #ed7249, vertical);
       @include background-image( linear-gradient(to bottom, #b2412e, #ed7249) );
       box-shadow: none;
-      @include text-shadow(rgba(0, 0, 0, 0.2) 0 -1px 0);
+      text-shadow: rgba(0, 0, 0, 0.2) 0 -1px 0;
     }
   }
 
@@ -2248,7 +2244,7 @@ body.team {
 
     &:active {
       background-position: 0 -92px;
-      @include text-shadow(rgba(0, 0, 0, 0.3) 0 -1px 0);
+      text-shadow: rgba(0, 0, 0, 0.3) 0 -1px 0;
     }
   }
 }
@@ -2262,7 +2258,7 @@ body.team {
   color: #ffffff;
   line-height: 24px;
   text-transform: uppercase;
-  @include text-shadow(rgba(0, 0, 0, 0.3) 0 1px 0);
+  text-shadow: rgba(0, 0, 0, 0.3) 0 1px 0;
 
   &.orange {
     background-image: url('/images/small-orange-button.png');

--- a/source/stylesheets/survey.css.scss
+++ b/source/stylesheets/survey.css.scss
@@ -1,4 +1,4 @@
-@import "compass";
+@import "bourbon";
 @import "variables";
 @import "mixins/hidpi";
 


### PR DESCRIPTION
This PR aims to transition the website's codebase to match the [guides repo](https://github.com/emberjs/guides).

- There were some incompatibilities between Compass & Bourbon. Compass is now `@import`ed feature-by-feature to ensure there are no name collision with Bourbon.
- Since browser support has gotten better, a few things like `text-shadow`, `background-clip` are now simply CSS properties, replacing Compass mixins.