### PR TITLE
Updated the deprecation for `ember-htmlbars.ember-handlebars-safestring`

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -591,7 +591,7 @@ export default Router.map(function() {
 ##### until: 3.0.0
 ##### id: ember-htmlbars.ember-handlebars-safestring
 
-Before:
+Creating safe strings. Before:
 
 ```js
 import Ember from 'ember';
@@ -609,9 +609,48 @@ After:
 ```js
 import Ember from 'ember';
 const { computed } = Ember;
+
 export default Ember.Component.extend({
   myString: computed(function(){
     return Ember.String.htmlSafe(someString);
   });
 )};
 ```
+
+Detecting safe strings. Before:
+
+```js
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  actions: {
+    save() {
+      let myString = this.get('myString');
+      if (myString instanceof Ember.Handlebars.SafeString) {
+        // ...
+      }
+    }
+  }
+});
+```
+
+After:
+
+```js
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+  actions: {
+    save() {
+      let myString = this.get('myString');
+      if (Ember.String.isHtmlSafe(myString)) {
+        // ...
+      }
+    }
+  }
+});
+```
+
+If you're an addon maintainer, there is a polyfill for safe string detection ([ember-string-ishtmlsafe-polyfill](https://github.com/workmanw/ember-string-ishtmlsafe-polyfill))
+that will help maintain backwards compatibility. Additionally, it's worth noting that `Ember.String.htmlSafe`
+is supported back to pre-1.0, so there should be no concerns of backwards compatibility there.


### PR DESCRIPTION
This makes mention of `Ember.String.isHtmlSafe` and the related polyfill.

