### PR TITLE
Bug fix for quick start guide link on builds page

### DIFF
--- a/source/javascripts/app/builds/app.js
+++ b/source/javascripts/app/builds/app.js
@@ -372,6 +372,14 @@ App.IndexRoute = Ember.Route.extend({
   }
 });
 
+App.IndexController = Ember.Controller.extend({
+  latestVersionOfDocs: Ember.computed('model.release.lastRelease', function() {
+    const release = this.get('model.release.lastRelease');
+    const versionArray = release.split('.');
+    return `${versionArray[0]}.${versionArray[1]}.0`;
+  })
+});
+
 App.ProjectsMixin = Ember.Mixin.create({
   projects: Ember.computed('channel', 'model', function(){
     var projects = App.Project.find(this.get('channel')),

--- a/source/javascripts/app/builds/templates/index.js.hbs
+++ b/source/javascripts/app/builds/templates/index.js.hbs
@@ -2,7 +2,7 @@
   <i class="icon-attention-circled"></i>
   <strong>Getting Started?</strong> Ember-CLI is the
   modern, supported way to run an Ember application.
-  <a class="btn" href={{concat 'https://guides.emberjs.com/v' model.release.lastRelease '/getting-started/quick-start/'}}>Getting Started Guide</a>
+  <a class="btn" href={{concat 'https://guides.emberjs.com/v' latestVersionOfDocs '/getting-started/quick-start/'}}>Getting Started Guide</a>
 </div>
 
 <p>


### PR DESCRIPTION
Quick start guide was linking to versions that do not exist such as 2.6.1.  Now will only create links for latest MINOR versions such as 2.6.0.