### PR TITLE
Fix minor display bug for users page

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -1596,6 +1596,7 @@ ul.showcase {
     display: block;
     height: 103px;
     width: 210px;
+    text-align: center;
 
     img {
       height: auto;


### PR DESCRIPTION
It's only a little thing on the [users](http://emberjs.com/ember-users/) page, but smaller logos should be center aligned to match the layout of the rest of the page:

**Before:**
![image](https://cloud.githubusercontent.com/assets/120485/16584184/99016084-42ba-11e6-96e8-c41709bfe939.png)

**After:**
![image](https://cloud.githubusercontent.com/assets/120485/16584199/ac0e650a-42ba-11e6-9423-a2a8cdd3b3be.png)
