### PR TITLE
Updated the deprecation for `ember-htmlbars.ember-handlebars-safestring`.

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -643,7 +643,7 @@ export default Ember.Component.extend({
   actions: {
     save() {
       let myString = this.get('myString');
-      if (Ember.String.isHtmlSafe(myString)) {
+      if (Ember.String.isHTMLSafe(myString)) {
         // ...
       }
     }


### PR DESCRIPTION
It's changing from `isHtmlSafe` to `isHTMLSafe`. See discussion here: https://github.com/emberjs/ember.js/pull/13666#issuecomment-233029252.