### PR TITLE
[BUGFIX] temporary disabling of highlight classes brought over to the…

### DIFF
--- a/source/stylesheets/base/_variables.scss
+++ b/source/stylesheets/base/_variables.scss
@@ -34,28 +34,28 @@ $base-background-color: $creme;
 $sidebar-background-color: #FFFDF9;
 
 // Code Highlighting
-$highlight-yellow: #F5E090;
-$highlight-green: #C3F590;
-$highlight-red: #EC605E;
-$highlight-blue: #90D7F5;
-$highlight-cyan: #78CEC8;
+/* $highlight-yellow: #F5E090; */
+/* $highlight-green: #C3F590; */
+/* $highlight-red: #EC605E; */
+/* $highlight-blue: #90D7F5; */
+/* $highlight-cyan: #78CEC8; */
 $highlight-added: #5D7D5D;
 $highlight-removed: #905454;
 $code-background: $dark-gray;
 $code-header-background: shade($code-background, 40%);
 $code-line-number-background: mix($code-background, $code-header-background);
 
-$highlight-colors: (
-        attribute-name: $highlight-red,
-        comment: $medium-gray,
-        content: $highlight-cyan,
-        function: $highlight-red,
-        key: $highlight-red,
-        keyword: $highlight-yellow,
-        local-variable: $highlight-red,
-        string: $highlight-cyan,
-        tag: $highlight-red,
-);
+/* $highlight-colors: ( */
+/*         attribute-name: $highlight-red, */
+/*         comment: $medium-gray, */
+/*         content: $highlight-cyan, */
+/*         function: $highlight-red, */
+/*         key: $highlight-red, */
+/*         keyword: $highlight-yellow, */
+/*         local-variable: $highlight-red, */
+/*         string: $highlight-cyan, */
+/*         tag: $highlight-red, */
+/* ); */
 
 // Font Colors
 $base-font-color: $brown;


### PR DESCRIPTION
After merging/deploying the search PR (https://github.com/emberjs/website/commit/8d509c72a393670cb12e1bf2666d0aae4df53c0f ), the website API doc code samples color highlighting became unreadable.  I'm commenting out the changes below until we figure out why they came in with search in the first place and how to get them to coexist the api doc highlights.

![image](https://cloud.githubusercontent.com/assets/3609063/16921181/6eb7072e-4cde-11e6-94c8-753e2f6719b5.png)

After commenting out the styles below we are back to this: 

![image](https://cloud.githubusercontent.com/assets/3609063/16921155/5856cdde-4cde-11e6-86c4-68f82ce64947.png)
