### PR TITLE
Updates consistent container sizes

### DIFF
--- a/source/stylesheets/components/legal.css.scss
+++ b/source/stylesheets/components/legal.css.scss
@@ -1,7 +1,7 @@
 .legal-wrapper {
-  padding: 3em;
+  padding: 3em 1rem;
   padding-bottom: 1em;
-  max-width: 60em;
+  max-width: 960px;
   margin: 0 auto;
 }
 

--- a/source/stylesheets/components/logos.css.scss
+++ b/source/stylesheets/components/logos.css.scss
@@ -1,8 +1,7 @@
 body.logos_index.responsive > #content-wrapper {
-  padding: 3em;
-  padding-bottom: 1em;
+  padding: 3em 1rem 1em;
   width: 100%;
-  max-width: 60em;
+  max-width: 960px;
   margin: 0 auto;
 }
 

--- a/source/stylesheets/components/security.css.scss
+++ b/source/stylesheets/components/security.css.scss
@@ -1,8 +1,7 @@
 body.security.responsive > #content-wrapper {
-  padding: 3em;
-  padding-bottom: 1em;
+  padding: 3em 1rem 1em;
   width: auto;
-  max-width: 60em;
+  max-width: 960px;
   margin: 0 auto;
 }
 

--- a/source/stylesheets/components/sponsors.css.scss
+++ b/source/stylesheets/components/sponsors.css.scss
@@ -1,8 +1,7 @@
 body.sponsors_index.responsive > #content-wrapper {
-  padding: 3em;
-  padding-bottom: 1em;
+  padding: 3em 1rem 1em;
   width: auto;
-  max-width: 60em;
+  max-width: 960px;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
In the midst of the redesign it seems that the container sizes for the page content and header/footer has become inconsistent.

The header footer (and most of the site) uses a 960px container with `1rem` of horizontal padding.
However there are a few text containers (most noticeably the `.legal-wrapper`) which are MUCH smaller.

This is because the `.legal-wrapper` relied on `em` units.
Since the base `font-size` of these areas were reduced to `14px` then `60em` is no longer the loved `960px` but instead comes out to `840px`.

On top of this, the padding of the `.legal-wrapper` container also used `3rem` left and right.
This meant that the container was even smaller than the `840px`.
The content width of the navbar vs `.legal-wrapper` is `928px` to `756px` after padding and everything is done.

This PR brings back consistency in container sizes.