### PR TITLE
Moved the `Enumerable#contains` deprecation to the Ember 2.8 section

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -606,57 +606,6 @@ If you're an addon maintainer, there is a polyfill for safe string detection ([e
 that will help maintain backwards compatibility. Additionally, it's worth noting that `Ember.String.htmlSafe`
 is supported back to pre-1.0, so there should be no concerns of backwards compatibility there.
 
-### Deprecations Added in Pending Features
-
-#### Route#serialize
-
-##### until: 3.0.0
-##### id: ember-routing.serialize-function
-
-The `Route#serialize` function was deprecated in favor of passing a `serialize` function into the route's definition in the router map. For more detailed information see the [Route Serializers RFC](https://github.com/emberjs/rfcs/blob/master/text/0120-route-serializers.md).
-
-As an example, given a route like:
-
-```js
-// app/routes/post.js
-import Ember from 'ember';
-export default Ember.Route.extend({
-  // ...
-  serialize(model) {
-    return { post_id: model.id };
-  }
-});
-
-// app/router.js
-export default Router.map(function() {
-  this.route('post', {
-    path: '/post/:post_id'
-  });
-});
-```
-
-You would refactor it like so:
-
-```js
-// app/routes/post.js
-import Ember from 'ember';
-export default Ember.Route.extend({
-  // ...
-});
-
-// app/router.js
-function serializePostRoute(model) {
-  return { post_id: model.id };
-}
-
-export default Router.map(function() {
-  this.route('post', {
-    path: '/post/:post_id',
-    serialize: serializePostRoute
-  });
-});
-```
-
 #### Enumerable#contains
 
 ##### until: 3.0.0
@@ -727,3 +676,54 @@ arr.without(NaN);         // ['a', 'b']
 
 
 Added in [PR #13553](https://github.com/emberjs/ember.js/pull/13553).
+
+### Deprecations Added in Pending Features
+
+#### Route#serialize
+
+##### until: 3.0.0
+##### id: ember-routing.serialize-function
+
+The `Route#serialize` function was deprecated in favor of passing a `serialize` function into the route's definition in the router map. For more detailed information see the [Route Serializers RFC](https://github.com/emberjs/rfcs/blob/master/text/0120-route-serializers.md).
+
+As an example, given a route like:
+
+```js
+// app/routes/post.js
+import Ember from 'ember';
+export default Ember.Route.extend({
+  // ...
+  serialize(model) {
+    return { post_id: model.id };
+  }
+});
+
+// app/router.js
+export default Router.map(function() {
+  this.route('post', {
+    path: '/post/:post_id'
+  });
+});
+```
+
+You would refactor it like so:
+
+```js
+// app/routes/post.js
+import Ember from 'ember';
+export default Ember.Route.extend({
+  // ...
+});
+
+// app/router.js
+function serializePostRoute(model) {
+  return { post_id: model.id };
+}
+
+export default Router.map(function() {
+  this.route('post', {
+    path: '/post/:post_id',
+    serialize: serializePostRoute
+  });
+});
+```


### PR DESCRIPTION
Per [blog post](http://emberjs.com/blog/2016/07/25/ember-2-7-and-2-8-beta-released.html#toc_code-enumerable-includes-code-and-code-array-includes-code) and this commit [84b16eb](https://github.com/emberjs/ember.js/commit/84b16eb36772b5292e392309d79ce66b0a70b1ab) (which is in beta), `Enumerable#contains` has been deprecated in Ember 2.8.

Figured I'd move the deprecation message into the appropriate section. 