### PR TITLE
Added 'display: -webkit-flex' to support safari browsers < 9

### DIFF
--- a/source/stylesheets/_header.scss
+++ b/source/stylesheets/_header.scss
@@ -36,6 +36,7 @@
 
 .header .container {
   display: flex;
+  display: -webkit-flex;
 }
 
 @media screen and (max-width: 53.75rem) {


### PR DESCRIPTION
Browser version - Safari Version 8.0 (10600.1.25)

Before - 
<img width="1440" alt="screen shot 2016-08-22 at 12 40 58 pm" src="https://cloud.githubusercontent.com/assets/1799117/17887967/6d4821d2-6946-11e6-9250-0d35b2cb1b1f.png">


After - 
<img width="1440" alt="screen shot 2016-08-23 at 3 30 01 pm" src="https://cloud.githubusercontent.com/assets/1799117/17887985/8334ef0c-6946-11e6-816e-43ebaefd15c3.png">
