### PR TITLE
Add link to Enumerable.includes polyfill.

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -674,6 +674,8 @@ arr.addObject(NaN);       // ['a', 'b', NaN]
 arr.without(NaN);         // ['a', 'b']
 ```
 
+Addon authors should use [ember-runtime-enumerable-includes-polyfill](https://github.com/rwjblue/ember-runtime-enumerable-includes-polyfill)
+to fix the deprecation in a backwards-compatible way.
 
 Added in [PR #13553](https://github.com/emberjs/ember.js/pull/13553).
 


### PR DESCRIPTION
It is helpful to have this information in the deprecation guide.