### PR TITLE
responsive team page

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -1982,6 +1982,11 @@ body.tomster_payment-sent #content {
 **/
 
 body.team {
+  #content {
+      margin: 3em auto 0 auto;
+      max-width: 54em;
+      width: 90%;
+  }
   h1, .lead {
     text-align: center;
   }
@@ -1991,18 +1996,27 @@ body.team {
     margin: 4em 0;
     background-color: #dfd7d4;
   }
-  .headshots {
-    width: 760px;
+  #content .headshots { /* #content is needed for specifity override */
+    max-width: 760px;
+    width: 100%;
     margin: 0 auto;
 
     a:hover {
       border-bottom: none;
     }
 
-    td {
-      width: 190px;
+    > li {
+      display: inline-block;
+      width: 24%;
       text-align: center;
       padding: 40px 0 0;
+
+      @media screen and (max-width: 860px) {
+        width: 32%;
+      }
+      @media screen and (max-width: 560px) {
+        width: 49%;
+      }
 
       p {
         margin: 0px 0px 10px 0px;
@@ -2023,7 +2037,7 @@ body.team {
       }
       .social {
         margin-bottom: 0;
-        li {
+        > li {
           display: inline-block;
           padding: 0;
         }

--- a/source/team.html.erb
+++ b/source/team.html.erb
@@ -1,5 +1,6 @@
 ---
 title: "Team"
+responsive: true
 ---
 
 <h1>
@@ -15,41 +16,37 @@ title: "Team"
 
 <% core = data.team.select { |m| m.teams.include?('core') } %>
 
-<table class="headshots">
-  <% core.each_slice(4) do |slice| %>
-    <tr>
-      <% slice.each do |user| %>
-        <td>
-          <a href="<%= user.github %>" rel="nofollow" class="avatar">
-            <img src="/images/team/<%= user.image %>">
+<ul class="headshots">
+  <% core.each do |user| %>
+    <li>
+      <a href="<%= user.github %>" rel="nofollow" class="avatar">
+        <img src="/images/team/<%= user.image %>">
+      </a>
+
+      <p class="name">
+        <%= user.name %>
+      </p>
+
+      <ul class="social">
+        <li>
+          <a class="twitter" href="<%= user.twitter %>">
+            <i class="icon-twitter"></i>
           </a>
+        </li>
 
-          <p class="name">
-            <%= user.name %>
-          </p>
+        <li>
+          <a class="github" href="<%= user.github %>">
+            <i class="icon-github"></i>
+          </a>
+        </li>
+      </ul>
 
-          <ul class="social">
-            <li>
-              <a class="twitter" href="<%= user.twitter %>">
-                <i class="icon-twitter"></i>
-              </a>
-            </li>
-
-            <li>
-              <a class="github" href="<%= user.github %>">
-                <i class="icon-github"></i>
-              </a>
-            </li>
-          </ul>
-
-          <p class="bio">
-            <%= user.bio %>
-          </p>
-        </td>
-      <% end %>
-    </tr>
+      <p class="bio">
+        <%= user.bio %>
+      </p>
+  </li>
   <% end %>
-</table>
+</ul>
 
 <hr>
 
@@ -71,25 +68,21 @@ subteams = subteams.map { |team|
 subteams.sort_by! {|u| [u.type, u.name] }
 %>
 
-<table class="contributors headshots">
-  <% subteams.each_slice(4) do |slice| %>
-    <tr>
-      <% slice.each do |user| %>
-        <td>
-          <a href="<%= user.github %>" rel="nofollow" class="avatar">
-            <img src="/images/team/<%= user.image %>">
+<ul class="contributors headshots">
+  <% subteams.each do |user| %>
+    <li>
+      <a href="<%= user.github %>" rel="nofollow" class="avatar">
+        <img src="/images/team/<%= user.image %>">
 
-            <span class="type"><%= user.type %></span>
-          </a>
+        <span class="type"><%= user.type %></span>
+      </a>
 
-          <p class="name">
-            <%= user.name %>
-          </p>
-        </td>
-      <% end %>
-    </tr>
+      <p class="name">
+        <%= user.name %>
+      </p>
+  </li>
   <% end %>
-</table>
+</ul>
 
 <hr>
 
@@ -104,21 +97,17 @@ subteams.sort_by! {|u| [u.type, u.name] }
 
 <% alumni = data.team.select { |m| m.teams.include?('corealumni') } %>
 
-<table class="headshots">
-  <% alumni.each_slice(4) do |slice| %>
-    <tr>
-      <% slice.each do |user| %>
-        <td>
-          <a href="<%= user.github %>" rel="nofollow">
-            <img src="/images/team/<%= user.image %>" width="150" height="150">
-          </a>
-          <p>
-            <%= user.name %>
-          </p>
-        </td>
-      <% end %>
-    </tr>
+<ul class="headshots">
+  <% alumni.each do |user| %>
+    <li>
+      <a href="<%= user.github %>" rel="nofollow">
+        <img src="/images/team/<%= user.image %>" width="150" height="150">
+      </a>
+      <p>
+        <%= user.name %>
+      </p>
+    </li>
   <% end %>
-</table>
+</ul>
 
 </div>


### PR DESCRIPTION
This PR updates the Team page to a responsive layout. HTML was updated from `table`-based layout to `ul > li` structure. 

The team grid goes from 2-up to 3-up to 4-up.

![team-small](https://cloud.githubusercontent.com/assets/6877934/18735913/e3d87f40-803e-11e6-9d63-00ee46149085.png)
![team-medium](https://cloud.githubusercontent.com/assets/6877934/18735915/e55c088c-803e-11e6-8d80-b9311bd3375b.png)
