### PR TITLE
Add link to Ember Community Slack

### DIFF
--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -33,7 +33,7 @@ responsive: true
   </p>
 
   <p>
-    You can also join the Ember Community Slack.
+    You can also join the <a href="https://embercommunity.slack.com">Ember Community Slack</a>.
     Use <a href="https://ember-community-slackin.herokuapp.com/">the Slackin app</a> to receive an invitation.
   </p>
   <p>


### PR DESCRIPTION
I was trying to sign in to the Slack team from a new machine recently, and it took me a while to find our actual domain name (`embercommunity.slack.com`). The first place I looked was on the Community page, but I only found a link to the invite app. 

I figured linking "Ember Community Slack" to the team page itself will help a lot of folks who are on a similar search in the future.