### PR TITLE
Add deprecation guide for renderToElement

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -729,3 +729,27 @@ export default Router.map(function() {
   });
 });
 ```
+
+### Deprecations Added in 2.10
+
+#### `renderToElement`
+
+##### until: 2.12.0
+##### id: ember-views.render-to-element
+
+Using the `renderToElement` is deprecated in favor of `appendTo`.
+Please refactor to use `appendTo`:
+
+For example, if you had:
+
+```js
+component.renderToElement('.my-component-wrapper');
+```
+
+Would be refactored to:
+
+```js
+component.appendTo('.my-component-wrapper');
+```
+
+Note that both APIs are private, so no public API is been deprecated here.


### PR DESCRIPTION
Deprecation for emberjs/ember.js#14482.
