### PR TITLE
Clarify escapeCSS use.

### DIFF
--- a/source/deprecations/v1.x.html.md
+++ b/source/deprecations/v1.x.html.md
@@ -344,6 +344,7 @@ making the content a `SafeString`. For example:
 
 ```js
   myStyle: Ember.computed('color', function() {
+    /* Note: You must implement #escapeCSS. */
     var color = escapeCSS(this.get('color'));
     return Ember.String.htmlSafe("color: " + color);
   })


### PR DESCRIPTION
#escapeCSS is not natively implemented by Ember. Closes #14518.