### PR TITLE
Add indentation to fix line numbers on homepage example

### DIFF
--- a/source/javascripts/app/examples/binding/templates/application.hbs
+++ b/source/javascripts/app/examples/binding/templates/application.hbs
@@ -3,5 +3,5 @@
  {{input type="text" value=name placeholder="Enter your name"}}
 </div>
 <div class="text">
-<h3>My name is {{name}} and I want to learn Ember!</h3>
+ <h3>My name is {{name}} and I want to learn Ember!</h3>
 </div>


### PR DESCRIPTION
Current website looks like (6 != 7) 👎 :
![screen shot 2016-11-03 at 12 37 30 pm](https://cloud.githubusercontent.com/assets/748245/19975476/7e5b7d70-a1c2-11e6-9ee3-7d08c49a53d8.png)

But if we fix the indentation, it looks like (7 == 7) :+1: :

![screen shot 2016-11-03 at 12 37 35 pm](https://cloud.githubusercontent.com/assets/748245/19975473/7c865b64-a1c2-11e6-966e-3ac4f5c4f5b9.png)
