### PR TITLE
Fix deprecation example of renderToElement

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -743,13 +743,14 @@ Please refactor to use `appendTo`:
 For example, if you had:
 
 ```js
-component.renderToElement('.my-component-wrapper');
+component.renderToElement('div');
 ```
 
 Would be refactored to:
 
 ```js
-component.appendTo('.my-component-wrapper');
+let element = document.createElement('div');
+component.appendTo(element);
 ```
 
 Note that both APIs are private, so no public API is been deprecated here.


### PR DESCRIPTION
It seems that the deprecation example was wrong. This updates it as per @chancancode's comment on https://github.com/emberjs/website/pull/2702#issuecomment-263493004.

Let me know if the change does make sense. Also should we mention that the `appendTo` can also receive an string with the selector?