### PR TITLE
Fix linking to incorrect version of quick start guide

### DIFF
--- a/lib/versions.rb
+++ b/lib/versions.rb
@@ -9,7 +9,9 @@ module Versions
   module Helpers
 
     def current_version
-      @current_version = JSON.parse(open('https://raw.githubusercontent.com/emberjs/guides.emberjs.com/master/snapshots/versions.json').read).last
+      versions = JSON.parse(open('https://raw.githubusercontent.com/emberjs/guides.emberjs.com/master/snapshots/versions.json').read)
+      versions.sort_by! { |version| Gem::Version.new(version[1..-1]) }
+      @current_version = versions.last
     end
   end
 end


### PR DESCRIPTION
Hey there :wave: 

In its current state the versions helper gives v2.9.0 as the current version, causing the quick start link on the homepage to link to the quick start guide for that version instead of v2.10.0.

This is because [this list](https://raw.githubusercontent.com/emberjs/guides.emberjs.com/master/snapshots/versions.json) that the versions are read from is not in order. I fixed this by sorting the list of versions using the Gem class.