### PR TITLE
Add ember-data deprecation guide

### DIFF
--- a/source/deprecations/ember-data/v2.x.html.md
+++ b/source/deprecations/ember-data/v2.x.html.md
@@ -1,0 +1,35 @@
+---
+title: Deprecations for Ember Data v2.x
+alias: guides/deprecations/
+layout: deprecations
+---
+
+## Deprecations Added in Ember Data 2.x
+
+### Deprecations Added in Ember Data 2.3
+
+#### Non-primitive defaultValue for Model Attributes
+
+###### until: 3.0.0
+###### id: ds.defaultValue.complex-object
+
+Providing a non-primitive value as a `defaultValue` has been deprecated because
+the provided value is shared between all instances of the model. Using a
+non-primitive value, such as `defaultValue: []`, can lead to unexpected bugs when
+that value is mutated.
+
+If you wish to continue using a non-primitive value as the `defaultValue` for an
+attribute, you should provide a function that returns the value:
+
+```javascript
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  username: DS.attr('string'),
+  createdAt: DS.attr('date', {
+    defaultValue() {
+      return new Date();
+    }
+  })
+});
+```

--- a/source/deprecations/index.html.md
+++ b/source/deprecations/index.html.md
@@ -11,7 +11,11 @@ code firing such deprecations is still supported by the Ember community. After
 the next major revision lands, the supporting code may be removed. This style
 of change management is commonly referred to as [Semantic Versioning](http://semver.org/).
 
-### By Version
+### Ember
 
 * [Version 1.x](/deprecations/v1.x)
 * [Version 2.x](/deprecations/v2.x)
+
+### Ember Data
+
+* [Version 2.x](/deprecations/ember-data/v2.x)


### PR DESCRIPTION
This adds a new page to start building the ember-data 2.x deprecation guide along with the first deprecation guide.

I'm planning to put up an issue to track all of the deprecations in ember-data 2.x so we can hopefully get help covering the rest of the deprecations from the community. Having this first example up will make it easier for people to start helping out.