### PR TITLE
Add deprecation guide to RESTSerializer.normalizeHash

### DIFF
--- a/source/deprecations/ember-data/v2.x.html.md
+++ b/source/deprecations/ember-data/v2.x.html.md
@@ -34,6 +34,47 @@ export default DS.Model.extend({
 });
 ```
 
+### Deprecations Added in Ember Data 2.6
+
+#### RESTSerializer.normalizeHash
+
+###### until: 3.0.0
+###### id: ds.serializer.normalize-hash-deprecated
+
+`RESTSerializer.normalizeHash` has been deprecated in favor of using `normalize`.
+
+If you had this:
+
+```javascript
+import DS from 'ember-data';
+
+export default DS.RESTSerializer.extend({
+  normalizeHash: {
+    _id: function(hash) {
+      hash.id = hash._id;
+      delete hash._id;
+      return hash;
+    }
+  }
+});
+```
+
+You could change it to this:
+
+```javascript
+import DS from 'ember-data';
+
+export default DS.RESTSerializer.extend({
+  normalize(model, hash, prop) {
+    if (prop === 'comments') {
+      hash.id = hash._id;
+      delete hash._id;
+    }
+    return this._super(...arguments);
+  }
+});
+```
+
 ### Deprecations Added in Ember Data 2.7
 
 #### Global version of DS


### PR DESCRIPTION
As part of https://github.com/emberjs/data/issues/4695