### PR TITLE
Add guide to ember-data deprecations for version 2.11

### DIFF
--- a/source/deprecations/ember-data/v2.x.html.md
+++ b/source/deprecations/ember-data/v2.x.html.md
@@ -121,3 +121,44 @@ while your app is running.
 See [Disabling Prototype
 Extensions](https://guides.emberjs.com/v2.10.0/configuring-ember/disabling-prototype-extensions/#toc_strings)
 for more information about how Ember uses prototype extensions.
+
+### Deprecations Added in Ember Data 2.11
+
+#### recordIsLoaded
+
+###### until: 3.0.0
+###### id: ds.store.recordIsLoaded
+
+`recordIsLoaded` has been deprecated and is an alias for `hasRecordForId`, which should be used instead.
+
+If you have this:
+
+```javascript
+store.recordIsLoaded('post', 1); // false
+store.findRecord('post', 1).then(function() {
+  store.recordIsLoaded('post', 1); // true
+});
+```
+
+You can change it to this:
+
+```javascript
+store.hasRecordForId('post', 1); // false
+store.findRecord('post', 1).then(function() {
+  store.hasRecordForId('post', 1); // true
+});
+```
+
+#### lookupAdapter
+
+###### until: 3.0.0
+###### id: ds.store.lookupAdapter
+
+`lookupAdapter` has been deprecated in favor of using `adapterFor`.
+
+#### lookupSerializer
+
+###### until: 3.0.0
+###### id: ds.store.lookupSerializer
+
+`lookupSerializer` has been deprecated in favor of using `serializerFor`.


### PR DESCRIPTION
As part of https://github.com/emberjs/data/issues/4695.