### PR TITLE
Add deprecation guide for Ember.Date.parse

### DIFF
--- a/source/deprecations/ember-data/v2.x.html.md
+++ b/source/deprecations/ember-data/v2.x.html.md
@@ -54,3 +54,59 @@ It would be refactored to:
 ```javascript
 import DS from 'ember-data';
 ```
+
+#### Ember.Date.parse
+
+###### until: 3.0.0
+###### id: ds.ember.date.parse-deprecate
+
+`Ember.Date.parse` was created as a [progressive enhancement for ISO
+8601](https://github.com/csnover/js-iso8601) support in browsers that do not
+support it (Safari 5-, IE 8-, Firefox 3.6-).
+
+When `Ember.EXTEND_PROTOTYPES === true` or `Ember.EXTEND_PROTOTYPES.Date ===
+true`, Ember Data overrides the native `Date.parse` with `Ember.Date.parse`.
+This overriding behavior is now deprecated.
+
+To clear this deprecation you should refactor your application's code to use
+`Date.parse` and disable Ember Data's `Date` prototype extension.
+
+With Ember >= v2.7.0, disable the prototype extension for `Date`:
+
+```javascript
+// config/environment.js
+
+ENV = {
+  EmberENV: {
+    EXTEND_PROTOTYPES: {
+      Date: false
+    }
+  }
+}
+```
+
+With Ember < v2.7.0, values must be provided for all prototype extensions:
+
+```javascript
+// config/environment.js
+
+var ENV = {
+  EmberENV: {
+    EXTEND_PROTOTYPES: {
+      Array: true,
+      Date: false,
+      Function: true,
+      String: true
+    }
+  }
+};
+```
+
+If you're not sure which prototype extensions your app already has enabled, you
+can check `EmberENV.EXTEND_PROTOTYPES` in your browser's JavaScript console
+while your app is running.
+
+Note: The existing behavior of
+[`DS.DateTransform`](http://emberjs.com/api/data/classes/DS.DateTransform.html)
+was preserved. It is the direct usage of `Ember.Date.parse` and overriding of
+`Date.parse` that has been deprecated.


### PR DESCRIPTION
Adds `Ember.Date.parse` to the Ember Data deprecation guide.

Related to https://github.com/emberjs/data/issues/4695