### PR TITLE
Fix ember data Date.parse deprecation guides

### DIFF
--- a/source/deprecations/ember-data/v2.x.html.md
+++ b/source/deprecations/ember-data/v2.x.html.md
@@ -62,14 +62,26 @@ import DS from 'ember-data';
 
 `Ember.Date.parse` was created as a [progressive enhancement for ISO
 8601](https://github.com/csnover/js-iso8601) support in browsers that do not
-support it (Safari 5-, IE 8-, Firefox 3.6-).
-
-When `Ember.EXTEND_PROTOTYPES === true` or `Ember.EXTEND_PROTOTYPES.Date ===
-true`, Ember Data overrides the native `Date.parse` with `Ember.Date.parse`.
-This overriding behavior is now deprecated.
+support it (Safari 5-, IE 8-, Firefox 3.6-). These browsers versions are no
+longer supported by Ember or Ember Data so `Ember.Date.parse` has been
+deprecated.
 
 To clear this deprecation you should refactor your application's code to use
-`Date.parse` and disable Ember Data's `Date` prototype extension.
+`Date.parse` instead of `Ember.Date.parse`.
+
+#### Date Prototype Extension
+
+###### until: 3.0.0
+###### id: ds.date.parse-deprecate
+
+In previous versions of Ember Data, the native `Date.parse` function was
+replaced with `Ember.Date.parse`, a [progressive enhancement for ISO
+8601](https://github.com/csnover/js-iso8601) support in browsers that do not
+support it (Safari 5-, IE 8-, Firefox 3.6-). Since these browser versions are no
+longer supported by Ember or Ember data, this behavior has been deprecated.
+
+To clear this deprecation, you should disable Ember Data's `Date` prototype
+extension.
 
 With Ember >= v2.7.0, disable the prototype extension for `Date`:
 
@@ -106,7 +118,6 @@ If you're not sure which prototype extensions your app already has enabled, you
 can check `EmberENV.EXTEND_PROTOTYPES` in your browser's JavaScript console
 while your app is running.
 
-Note: The existing behavior of
-[`DS.DateTransform`](http://emberjs.com/api/data/classes/DS.DateTransform.html)
-was preserved. It is the direct usage of `Ember.Date.parse` and overriding of
-`Date.parse` that has been deprecated.
+See [Disabling Prototype
+Extensions](https://guides.emberjs.com/v2.10.0/configuring-ember/disabling-prototype-extensions/#toc_strings)
+for more information about how Ember uses prototype extensions.


### PR DESCRIPTION
Related to https://github.com/emberjs/website/pull/2745

This breaks up the single deprecation into one for `Ember.Date.parse`
and another for the `Date.parse` prototype extension.

Previously these deprecations were both part of the same guide but I
realized that they were actually two separate deprecations with their
own deprecation ids.