### PR TITLE
Add deprecation guide for JSONSerializer._shouldSerializeHasMany

### DIFF
--- a/source/deprecations/ember-data/v2.x.html.md
+++ b/source/deprecations/ember-data/v2.x.html.md
@@ -203,3 +203,15 @@ store.findRecord('post', 1).then(function() {
 ###### id: ds.store.lookupSerializer
 
 `lookupSerializer` has been deprecated in favor of using `serializerFor`.
+
+### Deprecations Added in Pending Features
+
+#### JSONSerializer.shouldSerializeHasMany
+
+###### until: 3.0.0
+###### id: ds.serializer.private-should-serialize-has-many
+
+The private method `_shouldSerializeHasMany` has been promoted to the public
+API. To remove this deprecation, please remove the underscore to use the public
+[`shouldSerializeHasMany`](http://emberjs.com/api/data/classes/DS.JSONSerializer.html#method_shouldSerializeHasMany)
+method.


### PR DESCRIPTION
For https://github.com/emberjs/data/issues/4695

Adds guide for removing `ds.serializer.private-should-serialize-has-many` deprecation to the Ember Data Deprecation guide