### PR TITLE
Add deprecation guide for DS.Store.serialize

### DIFF
--- a/source/deprecations/ember-data/v2.x.html.md
+++ b/source/deprecations/ember-data/v2.x.html.md
@@ -203,3 +203,28 @@ store.findRecord('post', 1).then(function() {
 ###### id: ds.store.lookupSerializer
 
 `lookupSerializer` has been deprecated in favor of using `serializerFor`.
+
+### Deprecations Added in Pending Features
+
+#### Store.serialize
+
+###### until: 3.0.0
+###### id: ds.store.serialize
+
+`Store.serialize` has been deprecated in favor of
+[`Model.serialize`](http://emberjs.com/api/data/classes/DS.Model.html#method_serialize)
+as part of an effort to reduce duplication and API surface area.
+
+Before:
+
+```javascript
+let post = this.store.peekRecord('post', 123);
+this.store.serialize(post);
+```
+
+After:
+
+```javascript
+let post = this.store.peekRecord('post', 123);
+post.serialize();
+```


### PR DESCRIPTION
For https://github.com/emberjs/data/issues/4695

Adds guide for `ds.store.serialize` deprecation to the Ember Data Deprecation Guide.