### PR TITLE
Add deprecation guide for ds-overhaul-references

### DIFF
--- a/source/deprecations/ember-data/v2.x.html.md
+++ b/source/deprecations/ember-data/v2.x.html.md
@@ -203,3 +203,113 @@ store.findRecord('post', 1).then(function() {
 ###### id: ds.store.lookupSerializer
 
 `lookupSerializer` has been deprecated in favor of using `serializerFor`.
+
+### Deprecations Added in Pending Features
+
+#### HasManyReference.push(array)
+
+###### until: 3.0.0
+###### id: ds.references.has-many.push-array
+
+Passing an array to a `HasManyReference#push` has been deprecated. You should
+refactor your code to instead pass a [JSON API Relationship
+Object](http://jsonapi.org/format/#document-resource-object-relationships).
+
+For example, if you previously had something like:
+
+```javascript
+let commentsData = [
+  { data: { type: 'comment', id: 1 } },
+  { data: { type: 'comment', id: 2 } }
+];
+
+let post = this.store.peekRecord('post', 123);
+
+post.hasMany('comments').push(commentsData);
+```
+
+You could remove this deprecation by refactoring your code to:
+
+```javascript
+let commentsData = {
+  data: [
+    { type: 'comment', id: 1 },
+    { type: 'comment', id: 2 }
+  ]
+};
+
+let post = this.store.peekRecord('post', 123);
+
+post.hasMany('comments').push(commentsData);
+```
+
+#### HasManyReference.push Invalid Data
+
+###### until: 3.0.0
+###### id: ds.references.has-many.push-invalid-json-api
+
+In previous versions of Ember Data, `HasManyReference#push` supported pushing
+data that was almost formatted as a [JSON API Relationship
+Object](http://jsonapi.org/format/#document-resource-object-relationships), but
+wasn't quite correct. Pushing data that is formatted this way has been
+deprecated. You should refactor your code to instead push a properly formatted
+JSON API Relationship Object.
+
+For example, if you previously had something like:
+
+```javascript
+let commentsData = {
+  data: [
+    { data: { type: 'comment', id: 1 } },
+    { data: { type: 'comment', id: 2 } }
+  ]
+};
+
+let post = this.store.peekRecord('post', 123);
+
+post.hasMany('comments').push(commentsData);
+```
+
+You could remove this deprecation by refactoring your code to:
+
+```javascript
+let commentsData = {
+  data: [
+    { type: 'comment', id: 1 },
+    { type: 'comment', id: 2 }
+  ]
+};
+
+let post = this.store.peekRecord('post', 123);
+
+post.hasMany('comments').push(commentsData);
+```
+
+#### BelongsToReference.push(DS.Model)
+
+###### until: 3.0.0
+###### id: ds.references.belongs-to.push-record
+
+Passing an instance of
+[`DS.Model`](http://emberjs.com/api/data/classes/DS.Model.html) to
+`BelongsToReference#push` has been deprecated. You should instead follow the
+pattern of `model.set('relationship', value)` to update a `belongsTo`
+relationship with an instance of `DS.Model`.
+
+For example, if you have something like:
+
+```javascript
+let post = this.store.peekRecord('post', 123);
+let author = this.store.peekRecord('user', 456);
+
+post.belongsTo('author').push(author);
+```
+
+You can remove this deprecation by refactoring your code to:
+
+```javascript
+let post = this.store.peekRecord('post', 123);
+let author = this.store.peekRecord('user', 456);
+
+post.set('author', author);
+```


### PR DESCRIPTION
For https://github.com/emberjs/data/issues/4695

Adds guides for the deprecations introduced by the [`ds-overhaul-references` feature](https://github.com/emberjs/data/pull/4398/files).