### PR TITLE
Remove About from main navigation

### DIFF
--- a/source/_header.html.erb
+++ b/source/_header.html.erb
@@ -3,7 +3,6 @@
     <ul class="header-nav container">
       <li class="header-logo">
         <a href="http://emberjs.com/"><span class="visually-hidden">Ember homepage</span></a>
-      <%= link_to_page "About", "/about" %>
       <%= link_to_page "Guides", "http://guides.emberjs.com" %>
       <%= link_to_page "API", "/api" %>
       <%= link_to_page "Community", "/community" %>


### PR DESCRIPTION
- Twin issue: https://github.com/emberjs/guides/pull/1753

The logo already navigates the user to the home page.