### PR TITLE
Add deprecation guide for ds-payload-type-hooks features

### DIFF
--- a/source/deprecations/ember-data/v2.x.html.md
+++ b/source/deprecations/ember-data/v2.x.html.md
@@ -517,3 +517,75 @@ let author = this.store.peekRecord('user', 456);
 
 post.set('author', author);
 ```
+
+#### JSONAPISerializer.modelNameFromPayloadKey for Resource
+
+###### until: 3.0.0
+###### id: ds.json-api-serializer.deprecated-model-name-for-resource
+###### feature: ds-payload-type-hooks
+
+Using `JSONAPISerializer.modelNameFromPayloadKey` to normalize the type of a
+resource has been deprecated in favor of
+`JSONAPISerializer.modelNameFromPayloadType`.
+
+In the context of a JSON API payload, it is the value of the `type` key that
+maps to the name of the corresponding `DS.Model` class rather than the key that
+the data is nested under.
+
+For example, if your API responds with a namespaced resource type in the payload
+when you fetch a `post`:
+
+```javascript
+// GET /post/1
+
+{
+  "data": {
+    "type": "api::v1::post",
+    "id": "1"
+  }
+}
+```
+
+Previously, you would want to override `modelNameFromPayloadKey` to remove the
+namespace:
+
+```javascript
+// app/serializers/post.js
+
+import DS from 'ember-data';
+
+export default DS.JSONAPISerializer.extend({
+  modelNameFromPayloadKey(key) {
+    return key.replace('api::v1::', '');
+  }
+});
+```
+
+You can remove this deprecation by refactoring your serializer to instead use
+`modelNameFromPayloadType`:
+
+```javascript
+// app/serializers/post.js
+
+import DS from 'ember-data';
+
+export default DS.JSONAPISerializer.extend({
+  modelNameFromPayloadType(type) {
+    return type.replace('api::v1::', '');
+  }
+});
+```
+
+#### JSONAPISerializer.modelNameFromPayloadKey for Relationship
+
+###### until: 3.0.0
+###### id: ds.json-api-serializer.deprecated-model-name-for-relationship
+###### feature: ds-payload-type-hooks
+
+Using `JSONAPISerializer.modelNameFromPayloadKey` to normalize the type of a
+relationship has been deprecated in favor of
+`JSONAPISerializer.modelNameFromPayloadType`.
+
+See [JSONAPISerializer.modelNameFromPayloadKey for
+Resource](#toc_jsonapiserializer-modelnamefrompayloadkey-for-resource) for more
+information.

--- a/source/deprecations/ember-data/v2.x.html.md
+++ b/source/deprecations/ember-data/v2.x.html.md
@@ -589,3 +589,85 @@ relationship has been deprecated in favor of
 See [JSONAPISerializer.modelNameFromPayloadKey for
 Resource](#toc_jsonapiserializer-modelnamefrompayloadkey-for-resource) for more
 information.
+
+#### JSONAPISerializer.payloadKeyFromModelName for Resource
+
+###### until: 3.0.0
+###### id: ds.json-api-serializer.deprecated-payload-type-for-model
+###### feature: ds-payload-type-hooks
+
+Using `JSONAPISerializer.payloadKeyFromModelName` to serialize the type of a
+model has been deprecated in favor of
+[`JSONAPISerializer.payloadTypeFromModelName`](http://emberjs.com/api/data/classes/DS.JSONAPISerializer.html#method_payloadTypeFromModelName).
+
+For example, if your API expects a namespaced resource type in the payload that
+is sent when you create a `post` model:
+
+```javascript
+// POST /api/posts/1
+
+{
+  "data": {
+    "id": 1,
+    "type": "api::v1::post"
+  }
+}
+```
+
+Previously, you would want to override `payloadKeyFromModelName` to add the
+namespace to the `modelName`:
+
+```javascript
+// app/serializers/post.js
+
+import DS from 'ember-data';
+
+export default DS.JSONAPISerializer.extend({
+  payloadKeyFromModelName(modelName) {
+    return `api::v1::${modelName}`;
+  }
+});
+```
+
+You can remove this deprecation by refactoring your serializer to instead use
+[`payloadTypeFromModelName`](http://emberjs.com/api/data/classes/DS.JSONAPISerializer.html#method_payloadTypeFromModelName):
+
+```javascript
+// app/serializers/post.js
+
+import DS from 'ember-data';
+
+export default DS.JSONAPISerializer.extend({
+  payloadTypeFromModelName(modelName) {
+    return `api::v1::${modelName}`;
+  }
+});
+```
+
+#### JSONAPISerializer.payloadKeyFromModelName for belongsTo Relationship
+
+###### until: 3.0.0
+###### id: ds.json-api-serializer.deprecated-payload-type-for-belongs-to
+###### feature: ds-payload-type-hooks
+
+Using `JSONAPISerializer.payloadKeyFromModelName` to serialize the type of a
+`belongsTo` relationship has been deprecated in favor of
+[`JSONAPISerializer.payloadTypeFromModelName`](http://emberjs.com/api/data/classes/DS.JSONAPISerializer.html#method_payloadTypeFromModelName).
+
+See [JSONAPISerializer.payloadKeyFromModelName for
+Resource](#toc_jsonapiserializer-payloadkeyfrommodelname-for-resource) for more
+information.
+
+#### JSONAPISerializer.payloadKeyFromModelName for hasMany Relationship
+
+###### until: 3.0.0
+###### id: ds.json-api-serializer.deprecated-payload-type-for-has-many
+###### feature: ds-payload-type-hooks
+
+Using `JSONAPISerializer.payloadKeyFromModelName` to serialize the type of a
+`hasMany` relationship has been deprecated in favor of
+[`JSONAPISerializer.payloadTypeFromModelName`](http://emberjs.com/api/data/classes/DS.JSONAPISerializer.html#method_payloadTypeFromModelName).
+
+See [JSONAPISerializer.payloadKeyFromModelName for
+Resource](#toc_jsonapiserializer-payloadkeyfrommodelname-for-resource) for more
+information.


### PR DESCRIPTION
For https://github.com/emberjs/data/issues/4695

Adds deprecation guides to the Ember Data Deprecation Guide for `JSONAPISerializer.payloadKeyFromModelName` and `JSONAPISerializer.modelNameFromPayloadKey`.

Deprecation ids included:

- `ds.json-api-serializer.deprecated-model-name-for-resource`
- `ds.json-api-serializer.deprecated-model-name-for-relationship`
- `ds.json-api-serializer.deprecated-payload-type-for-model`
- `ds.json-api-serializer.deprecated-payload-type-for-belongs-to`
- `ds.json-api-serializer.deprecated-payload-type-for-has-many`