### PR TITLE
deprecate Ember.K

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -858,3 +858,38 @@ Index Content
 
 For more informations of how to use `ember-elsewhere`, please visit the official
 documentation [here](https://github.com/ef4/ember-elsewhere#ember-elsewhere).
+
+### Deprecations Added in 2.12
+
+#### `Ember.K`
+
+##### until: 3.0.0
+##### id: ember-metal.ember-k
+
+Using `Ember.K` is deprecated in favor of defining a function inline. See [RFC 0178](https://github.com/emberjs/rfcs/blob/master/text/0178-deprecate-ember-k.md).
+
+You can use the addon [ember-watson](https://github.com/abuiles/ember-watson#remove-usages-of-emberk) to automate the removal of `Ember.K` from your application.
+
+Example object:
+
+```js
+Ember.Object.extend({
+  someFun: Ember.K
+});
+``` 
+
+Command:
+
+```sh
+ember watson:remove-ember-k --empty
+```
+
+The result will be:
+
+```js
+Ember.Object.extend({
+  someFun() {}
+});
+```
+
+If for some reason your app depends on the ability to chain `Ember.K` invocations, you can use the flag `--return-this`. It will replace `Ember.K` with a function that returns `this`. 


### PR DESCRIPTION
deprecate Ember.K according to https://github.com/emberjs/ember.js/issues/14746

[rendered view](https://github.com/givanse/website/blob/0053f6e7f5d4556937e0b20dd5ca491c306f90cb/source/deprecations/v2.x.html.md#deprecations-added-in-212)