### PR TITLE
Update v2.x.html.md

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -335,7 +335,7 @@ After it installs, use as follows:-
 // Ember < 2.3
 import Ember from 'ember';
 
-const {getOwner} = Ember;
+const { getOwner } = Ember;
 
 export default Ember.Helper.extend({
   init() {

--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -329,6 +329,7 @@ export default Ember.Helper.extend({
     this.customThing = getOwner(this).lookup('custom:thing');
   }
 });
+```
 
 ### Deprecations Added in 2.4
 

--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -323,10 +323,19 @@ was created for this exact reason.
 
 Using the above before example, the following demonstrates how to use the polyfill:
 
+do an ember install of the polyfill.
+
+```sh
+ember install ember-getowner-polyfill
+```
+
+After it installs, use as follows:- 
+
 ```js
 // Ember < 2.3
 import Ember from 'ember';
-import getOwner from 'ember-getowner-polyfill';
+
+const {getOwner} = Ember;
 
 export default Ember.Helper.extend({
   init() {

--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -289,7 +289,7 @@ This refactor is relatively straight forward for applications, but still leaves 
 without deprecation on all versions while still using the newer paradigms. [ember-getowner-polyfill](https://github.com/rwjblue/ember-getowner-polyfill)
 was created for this exact reason.
 
-NOTE:- `getOwner` API is natively available in Ember versions 2.3 and up, you don't need to install a polyfill for the newer versions, use it like you would use any other API, For eg:- `Ember.getOwner(...)` or The `After:` example.
+Note that the `getOwner` API is natively available in Ember versions 2.3 and up, so you don't need to install a polyfill. Use it like you would use any other API, as in the `After:` example.
 
 Before:
 
@@ -320,13 +320,11 @@ After it installs, use as follows:-
 // Ember < 2.3 needs the polyfill installed, Ember >= 2.3 available natively.
 import Ember from 'ember';
 
-const { getOwner } = Ember;
-
 export default Ember.Helper.extend({
   init() {
     this._super(...arguments);
 
-    this.customThing = getOwner(this).lookup('custom:thing');
+    this.customThing = Ember.getOwner(this).lookup('custom:thing');
   }
 });
 ```

--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -285,6 +285,12 @@ API surface was not added to individual instances that were using `this.containe
 
 Ember 2.3 now provides a public API for usage from within any instances that were instantiated from the container.
 
+This refactor is relatively straight forward for applications, but still leaves a few gaps for addons that want to function
+without deprecation on all versions while still using the newer paradigms. [ember-getowner-polyfill](https://github.com/rwjblue/ember-getowner-polyfill)
+was created for this exact reason.
+
+NOTE:- `getOwner` API is natively available in Ember versions 2.3 and up, you don't need to install a polyfill for the newer versions, use it like you would use any other API, For eg:- `Ember.getOwner(...)` or The `After:` example.
+
 Before:
 
 ```js
@@ -302,27 +308,6 @@ export default Ember.Helper.extend({
 
 After:
 
-```js
-// Ember 2.3 and later
-import Ember from 'ember';
-
-const { getOwner } = Ember;
-
-export default Ember.Helper.extend({
-  init() {
-    this._super(...arguments);
-
-    this.customThing = getOwner(this).lookup('custom:thing');
-  }
-});
-```
-
-This refactor is relatively straight forward for applications, but still leaves a few gaps for addons that want to function
-without deprecation on all versions while still using the newer paradigms. [ember-getowner-polyfill](https://github.com/rwjblue/ember-getowner-polyfill)
-was created for this exact reason.
-
-Using the above before example, the following demonstrates how to use the polyfill:
-
 do an ember install of the polyfill.
 
 ```sh
@@ -332,7 +317,7 @@ ember install ember-getowner-polyfill
 After it installs, use as follows:- 
 
 ```js
-// Ember < 2.3
+// Ember < 2.3 needs the polyfill installed, Ember >= 2.3 available natively.
 import Ember from 'ember';
 
 const { getOwner } = Ember;
@@ -344,7 +329,6 @@ export default Ember.Helper.extend({
     this.customThing = getOwner(this).lookup('custom:thing');
   }
 });
-```
 
 ### Deprecations Added in 2.4
 


### PR DESCRIPTION
move to new syntax, Importing the module from ember-getowner-polyfill is deprecated.

cc:- @rwjblue 