### PR TITLE
add deprecation guide for migrating from _lookupFactory to factoryFor

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -314,7 +314,7 @@ do an ember install of the polyfill.
 ember install ember-getowner-polyfill
 ```
 
-After it installs, use as follows:- 
+After it installs, use as follows:-
 
 ```js
 // Ember < 2.3 needs the polyfill installed, Ember >= 2.3 available natively.
@@ -834,6 +834,47 @@ Ember.Object.extend({
 ```
 
 If for some reason your app depends on the ability to chain `Ember.K` invocations, you can use the flag `--return-this`. It will replace `Ember.K` with a function that returns `this`.
+
+#### Migrating from _lookupFactory to factoryFor
+
+##### until: 2.13.0
+##### id: container-lookupFactory
+
+The private API method `_lookupFactory` is deprecated and replaced by `factoryFor` in public API. This API will return the original base class registered into or resolved by the container and a `create` function to generate a dependency-injected instance.
+
+Addon creators and maintainers can use [ember-factory-for-polyfill](https://github.com/rwjblue/ember-factory-for-polyfill) for addons supporting versions 2.3+, or [ember-getowner-polyfill](https://github.com/rwjblue/ember-getowner-polyfill) for 1.10+.
+
+Before:
+
+```
+export default Component.extend(
+  init() {
+    this._super(...arguments);
+    let Factory = getOwner(this)._lookupFactory('logger:main');
+    this.logger = Factory.create({ level: 'low' });
+  }
+});
+```
+
+After:
+
+```
+export default Component.extend(
+  init() {
+    this._super(...arguments);
+    let factory = getOwner(this).factoryFor('logger:main');
+    this.logger = factory.create({ level: 'low' });
+  }
+});
+```
+
+Any methods or properties of the factory can be accessed through the `class` property when using `factoryFor`.
+
+```
+let factory = owner.factoryFor('widget:slow');
+let klass = factory.class;
+klass.hasSpeed('slow'); // true
+```
 
 ### Deprecations Added in Pending Features
 


### PR DESCRIPTION
Please double check that this deprecation is under the right heading (added in 2.12).

Comments welcome!

[RFC](https://github.com/emberjs/rfcs/blob/master/text/0150-factory-for.md#example-deprecation-guide-migrating-from-_lookupfactory-to-factoryfor)
[Issue](https://github.com/emberjs/website/issues/2796)