### PR TITLE
Adding deprecation information for the rename of Ember.Router.router

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -876,6 +876,49 @@ let klass = factory.class;
 klass.hasSpeed('slow'); // true
 ```
 
+### Deprecations Added in 2.13
+
+#### EmberRouter.router renamed to EmberRouter.routerMicrolib
+
+##### until: 2.16.0
+##### id: ember-router.router
+
+The `router` property of `EmberRouter` has been renamed to `routerMicrolib` to disambiguate it from `router.js`, the microlib used within `EmberRouter`.
+
+Addon and application developers that are using the internal `router` property of `EmberRouter` should replace those usages with `EmberRouter.routerMicrolib`.
+
+This example demonstrates a common use case for `EmberRouter.router`. 
+
+Before:
+
+``` javascript
+Ember.Service.extend({
+  getRouteNameFromUrl (url) {
+    const router = getContainer(this).lookup('router:main');
+    const routes = router.router.recognizer.recognize(url);
+
+    if (routes && routes.length) {
+      return routes[routes.length-1].handler;
+    }
+  }
+});
+``` 
+
+After:
+
+``` javascript
+Ember.Service.extend({
+  getRouteNameFromUrl (url) {
+    const router = getContainer(this).lookup('router:main');
+    const routes = router.routerMicrolib.recognizer.recognize(url);
+    
+    if (routes && routes.length) {
+      return routes[routes.length-1].handler;
+    }
+  }
+});
+``` 
+
 ### Deprecations Added in Pending Features
 
 #### Arguments in Component Lifecycle Hooks

--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -878,7 +878,7 @@ klass.hasSpeed('slow'); // true
 
 ### Deprecations Added in 2.13
 
-#### EmberRouter.router renamed to EmberRouter.routerMicrolib
+#### Ember.Router.router renamed to Ember.Router.routerMicrolib
 
 ##### until: 2.16.0
 ##### id: ember-router.router

--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -883,16 +883,17 @@ klass.hasSpeed('slow'); // true
 ##### until: 2.16.0
 ##### id: ember-router.router
 
-The `router` property of `EmberRouter` has been renamed to `routerMicrolib` to disambiguate it from `router.js`, the microlib used within `EmberRouter`.
+The private `router` property of the `Ember.Router` instance (commonly found as this.router in Ember.Route instances or via router:main in the container) 
+has been renamed to `routerMicrolib` to disambiguate it from `router.js`, the microlib used within `Ember.Router`.
 
-Addon and application developers that are using the internal `router` property of `EmberRouter` should replace those usages with `EmberRouter.routerMicrolib`.
+Addon and application developers that are using the internal `router` property of `Ember.Router` should replace those usages with `Ember.Router.routerMicrolib`.
 
-This example demonstrates a common use case for `EmberRouter.router`. 
+This example demonstrates a common use case for `.router`. 
 
 Before:
 
-``` javascript
-Ember.Service.extend({
+```javascript
+export default Ember.Service.extend({
   getRouteNameFromUrl (url) {
     const router = getContainer(this).lookup('router:main');
     const routes = router.router.recognizer.recognize(url);
@@ -906,8 +907,8 @@ Ember.Service.extend({
 
 After:
 
-``` javascript
-Ember.Service.extend({
+```javascript
+export default Ember.Service.extend({
   getRouteNameFromUrl (url) {
     const router = getContainer(this).lookup('router:main');
     const routes = router.routerMicrolib.recognizer.recognize(url);


### PR DESCRIPTION
This PR adds information related to the rename of `EmberRouter.router` to `EmberRouter.routerMicrolib` and the associated deprecation.

**Related PRs**: 
https://github.com/emberjs/ember.js/pull/14919

**Reviewers**
@rwjblue @locks 

**Changes**:
- Added information and examples for guidance on the rename


