### PR TITLE
Updating docs based on rename of routerMicrolib to _routerMicrolib

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -878,15 +878,15 @@ klass.hasSpeed('slow'); // true
 
 ### Deprecations Added in 2.13
 
-#### Ember.Router.router renamed to Ember.Router.routerMicrolib
+#### Ember.Router.router renamed to Ember.Router._routerMicrolib
 
 ##### until: 2.16.0
 ##### id: ember-router.router
 
-The private `router` property of the `Ember.Router` instance (commonly found as this.router in Ember.Route instances or via router:main in the container) 
-has been renamed to `routerMicrolib` to disambiguate it from `router.js`, the microlib used within `Ember.Router`.
+The private `router` property of the `Ember.Router` instance (commonly found as `this.router` in `Ember.Route` instances or via router:main in the container) 
+has been renamed to `_routerMicrolib` to identify it as `router.js`, the microlib used within `Ember.Router`.
 
-Addon and application developers that are using the internal `router` property of `Ember.Router` should replace those usages with `Ember.Router.routerMicrolib`.
+Addon and application developers that are using the internal `router` property of `Ember.Router` should replace those usages with `Ember.Router._routerMicrolib`.
 
 This example demonstrates a common use case for `.router`. 
 
@@ -911,7 +911,7 @@ After:
 export default Ember.Service.extend({
   getRouteNameFromUrl (url) {
     const router = getContainer(this).lookup('router:main');
-    const routes = router.routerMicrolib.recognizer.recognize(url);
+    const routes = router._routerMicrolib.recognizer.recognize(url);
     
     if (routes && routes.length) {
       return routes[routes.length-1].handler;


### PR DESCRIPTION
This PR quickly follows the already merged https://github.com/emberjs/website/pull/2806. 

**Reviewers**:
@rwjblue @krisselden 

**Changes**:
- Renaming references to `routerMicrolib` to `_routerMicrolib` to imply a private member.