### PR TITLE
Added notation about `ember-diff-attrs` to deprecation page

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -987,4 +987,4 @@ Ember.Component.extend({
 });
 ```
 
-Additionally, [ember-diff-atts](https://github.com/workmanw/ember-diff-attrs) is an addon that spun out of the discussions on the RFC. It provides a dry way to track attribute changes for this lifecycle hook.
+Additionally, [ember-diff-attrs](https://github.com/workmanw/ember-diff-attrs) is an addon that spun out of the discussions on the RFC. It provides a dry way to track attribute changes for this lifecycle hook.

--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -987,4 +987,4 @@ Ember.Component.extend({
 });
 ```
 
-Additionally, [ember-diff-atts](https://github.com/workmanw/ember-diff-attrs) is an addon that spun out of the discussions on the RFC. It provides dry way to track attribute changes for this lifecycle hook.
+Additionally, [ember-diff-atts](https://github.com/workmanw/ember-diff-attrs) is an addon that spun out of the discussions on the RFC. It provides a dry way to track attribute changes for this lifecycle hook.

--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -986,3 +986,5 @@ Ember.Component.extend({
   }
 });
 ```
+
+Additionally, [ember-diff-atts](https://github.com/workmanw/ember-diff-attrs) is an addon that spun out of the discussions on the RFC. It provides dry way to track attribute changes for this lifecycle hook.


### PR DESCRIPTION
I wasn't sure if it would be appropriate or not to mention an addon that provides an alternate means of gaining back deprecated functionality. I wasn't trying to plug my addon. The only reason I opened this PR was because the addon was inspired by RFC discussions.

My feelings won't be hurt if this isn't merged 😄 