### PR TITLE
WIP: Shift main site to run on Heroku

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,6 @@ GEM
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
-    ffi (1.9.10-x86-mingw32)
     geocoder (1.2.12)
     gmaps4rails (2.1.2)
     haml (4.0.7)
@@ -140,8 +139,6 @@ GEM
       thor (~> 0.19)
     nokogiri (1.6.6.3)
       mini_portile (~> 0.6.0)
-    nokogiri (1.6.6.3-x86-mingw32)
-      mini_portile (~> 0.6.0)
     padrino-helpers (0.12.5)
       i18n (~> 0.6, >= 0.6.7)
       padrino-support (= 0.12.5)
@@ -157,11 +154,6 @@ GEM
       coderay (~> 1.0)
       method_source (~> 0.8)
       slop (~> 3.4)
-    pry (0.9.12.6-x86-mingw32)
-      coderay (~> 1.0)
-      method_source (~> 0.8)
-      slop (~> 3.4)
-      win32console (~> 1.3)
     pry-byebug (1.3.2)
       byebug (~> 2.7)
       pry (~> 0.9.12)
@@ -220,13 +212,11 @@ GEM
     websocket-driver (0.6.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
-    win32console (1.3.2-x86-mingw32)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
-  x86-mingw32
 
 DEPENDENCIES
   activesupport

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: thin start -p $PORT

--- a/Rakefile
+++ b/Rakefile
@@ -237,3 +237,7 @@ desc "Find organizers for meetup user group_urlname"
 task :findorganizers do |t, args|
   find_meetup_organizers(ENV['force'])
 end
+
+task "assets:precompile" do
+  build
+end

--- a/lib/sponsors.rb
+++ b/lib/sponsors.rb
@@ -8,7 +8,6 @@ module Sponsors
 
   module Helpers
 
-    ::Middleman::Extensions.register(:api_docs, APIDocs)
     def sponsors
       @sponsors ||= data.sponsors.map do |sponsor|
         Sponsor.new(sponsor)

--- a/lib/toc.rb
+++ b/lib/toc.rb
@@ -1,5 +1,4 @@
 require 'redcarpet'
-require 'pry'
 
 module TOC
   class << self

--- a/static.json
+++ b/static.json
@@ -1,0 +1,8 @@
+{
+  "root": "build/",
+  "proxies": {
+    "/api-new/": {
+      "origin": "https://ember-versioned-api-docs.herokuapp.com/"
+    }
+  }
+}

--- a/static.json
+++ b/static.json
@@ -2,7 +2,7 @@
   "root": "build/",
   "proxies": {
     "/api-new/": {
-      "origin": "https://ember-versioned-api-docs.herokuapp.com/"
+      "origin": "${EMBER_API_DOCS_URL}"
     }
   }
 }


### PR DESCRIPTION
This begins the migration of the main EmberJS website over to Heroku (https://emberjs-website.herokuapp.com/).  Our Fastboot API viewer is currently being proxied in at (https://emberjs-website.herokuapp.com/api-new/) but `rootUrl` needs to be changed in the api viewer for it to work.

Uses three build packs:

- heroku/ruby
- https://github.com/hashicorp/heroku-buildpack-middleman.git (handles Middleman building)
- https://github.com/heroku/heroku-buildpack-static.git (handles serving built files and proxying)

Things remaining to be done:

- [x] get dyno infrastructure setup as desired with Heroku (SSL endpoints as well)
- [x] setup www.emberjs.com (and emberjs.com too?) to point to our Heroku instance