### PR TITLE
Cleanup ahead of 2.12

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -876,52 +876,6 @@ let klass = factory.class;
 klass.hasSpeed('slow'); // true
 ```
 
-### Deprecations Added in 2.13
-
-#### Ember.Router.router renamed to Ember.Router._routerMicrolib
-
-##### until: 2.16.0
-##### id: ember-router.router
-
-The private `router` property of the `Ember.Router` instance (commonly found as `this.router` in `Ember.Route` instances or via router:main in the container) 
-has been renamed to `_routerMicrolib` to identify it as `router.js`, the microlib used within `Ember.Router`.
-
-Addon and application developers that are using the internal `router` property of `Ember.Router` should replace those usages with `Ember.Router._routerMicrolib`.
-
-This example demonstrates a common use case for `.router`. 
-
-Before:
-
-```javascript
-export default Ember.Service.extend({
-  getRouteNameFromUrl (url) {
-    const router = getContainer(this).lookup('router:main');
-    const routes = router.router.recognizer.recognize(url);
-
-    if (routes && routes.length) {
-      return routes[routes.length-1].handler;
-    }
-  }
-});
-``` 
-
-After:
-
-```javascript
-export default Ember.Service.extend({
-  getRouteNameFromUrl (url) {
-    const router = getContainer(this).lookup('router:main');
-    const routes = router._routerMicrolib.recognizer.recognize(url);
-    
-    if (routes && routes.length) {
-      return routes[routes.length-1].handler;
-    }
-  }
-});
-``` 
-
-### Deprecations Added in Pending Features
-
 #### Arguments in Component Lifecycle Hooks
 
 ##### until: 2.13.0
@@ -988,3 +942,47 @@ Ember.Component.extend({
 ```
 
 Additionally, [ember-diff-attrs](https://github.com/workmanw/ember-diff-attrs) is an addon that spun out of the discussions on the RFC. It provides a dry way to track attribute changes for this lifecycle hook.
+
+### Deprecations Added in 2.13
+
+#### Ember.Router.router renamed to Ember.Router._routerMicrolib
+
+##### until: 2.16.0
+##### id: ember-router.router
+
+The private `router` property of the `Ember.Router` instance (commonly found as `this.router` in `Ember.Route` instances or via router:main in the container)
+has been renamed to `_routerMicrolib` to identify it as `router.js`, the microlib used within `Ember.Router`.
+
+Addon and application developers that are using the internal `router` property of `Ember.Router` should replace those usages with `Ember.Router._routerMicrolib`.
+
+This example demonstrates a common use case for `.router`.
+
+Before:
+
+```javascript
+export default Ember.Service.extend({
+  getRouteNameFromUrl (url) {
+    const router = getContainer(this).lookup('router:main');
+    const routes = router.router.recognizer.recognize(url);
+
+    if (routes && routes.length) {
+      return routes[routes.length-1].handler;
+    }
+  }
+});
+```
+
+After:
+
+```javascript
+export default Ember.Service.extend({
+  getRouteNameFromUrl (url) {
+    const router = getContainer(this).lookup('router:main');
+    const routes = router._routerMicrolib.recognizer.recognize(url);
+
+    if (routes && routes.length) {
+      return routes[routes.length-1].handler;
+    }
+  }
+});
+```

--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -807,7 +807,7 @@ documentation [here](https://github.com/ef4/ember-elsewhere#ember-elsewhere).
 ##### until: 3.0.0
 ##### id: ember-metal.ember-k
 
-Using `Ember.K` is deprecated in favor of defining a function inline. See [RFC 0178](https://github.com/emberjs/rfcs/blob/master/text/0178-deprecate-ember-k.md).
+Using `Ember.K` is deprecated in favor of defining a function inline. See [RFC #178](https://github.com/emberjs/rfcs/blob/master/text/0178-deprecate-ember-k.md).
 
 You can use the addon [ember-watson](https://github.com/abuiles/ember-watson#remove-usages-of-emberk) to automate the removal of `Ember.K` from your application.
 


### PR DESCRIPTION
Per items in https://github.com/emberjs/website/pull/2824

* Change `0178` into `#178`
* Move the component lifecycle hook arguments deprecation guide into the 2.12 section (diff shows it as moving an unrelated section in 2.13 :-p)