### PR TITLE
Changes to #2828 for Heroku work

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -237,3 +237,7 @@ desc "Find organizers for meetup user group_urlname"
 task :findorganizers do |t, args|
   find_meetup_organizers(ENV['force'])
 end
+
+task "assets:precompile" do
+  build
+end

--- a/static.json
+++ b/static.json
@@ -2,7 +2,7 @@
   "root": "build/",
   "proxies": {
     "/api-new/": {
-      "origin": "https://ember-versioned-api-docs.herokuapp.com/"
+      "origin": "${EMBER_API_DOCS_URL}"
     }
   }
 }


### PR DESCRIPTION
Changes to #2828 

1. The middleman buildpack is redundant. Any ruby app can hook into an asset compilation step by just defining the task `assets:precompile` like Rails does. This just executes the `build` method for building the middleman app.
2. The static buildpack allows variable substitution using env vars using the syntax `${}`. This change lets us set the env var `EMBER_API_DOCS_URL` to any instance we want to proxy to.

I deployed version of ember-api-docs to Heroku where I changed the `rootURL` to be `/api-new/` to match the proxy. Fastboot works, but I ran into issues with pouchdb/couchdb when the JavaScript loads. I've been working with @sivakumar-kailasam to deploy a working version without a dependency on pouchdb: ember-learn/ember-api-docs#146.

Currently, you can see the progress here: https://ember-website-hone.herokuapp.com/api-new

As part of this work, I fixed a proxy redirect issue in the static buildpack wrt schemes, heroku/heroku-buildpack-static#61