### PR TITLE
Cache Static Assets

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -13,6 +13,7 @@ set :markdown, :layout_engine => :erb,
          :lax_html_blocks => true,
          :renderer => Highlighter::HighlightedHTML.new
 
+activate :asset_hash
 activate :directory_indexes
 activate :toc
 activate :sponsors

--- a/static.json
+++ b/static.json
@@ -4,5 +4,10 @@
     "/api-new/": {
       "origin": "${EMBER_API_DOCS_URL}"
     }
+  },
+  "headers": {
+    "/images/**": {
+      "Cache-Control": "max-age=31536000"
+    }
   }
 }

--- a/static.json
+++ b/static.json
@@ -8,6 +8,12 @@
   "headers": {
     "/images/**": {
       "Cache-Control": "max-age=31536000"
+    },
+    "/javascripts/**": {
+      "Cache-Control": "max-age=31536000"
+    },
+    "/stylesheets/**": {
+      "Cache-Control": "max-age=31536000"
     }
   }
 }


### PR DESCRIPTION
This introduces adding a hash to all the static assets so we can aggressively cache them on the browser. This will also be beneficial for when we move over to a CDN like Fastly, so they should also pick up on it automatically based on the headers.

On the homepage in my test it shaved the transferred data from 1.1 mb (fresh page) to 890 Bytes.