### PR TITLE
Redirect all http traffic to https

### DIFF
--- a/static.json
+++ b/static.json
@@ -1,4 +1,5 @@
 {
+  "https_only": true,
   "root": "build/",
   "proxies": {
     "/api-new/": {


### PR DESCRIPTION
Now that we handle things on Heroku's end and have LetsEncrypt certs doing this automatically for us ...