### PR TITLE
Removing http -> https redirect

### DIFF
--- a/static.json
+++ b/static.json
@@ -1,5 +1,4 @@
 {
-  "https_only": true,
   "root": "build/",
   "proxies": {
     "/api-new/": {


### PR DESCRIPTION
Apparently the heroku buildpack will redirect to a raw proxy url instead of shifting to https and then proxying as we'd thought (i.e. when visiting http://www.emberjs.com/api-new folks end up getting redirected to the raw proxy url).