### PR TITLE
Update ember source to 2.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
       middleman (~> 3.0)
       middleman-sprockets (~> 3.0)
       sass
-    ember-source (2.4.1)
+    ember-source (2.9.0)
     erubis (2.7.0)
     eventmachine (1.0.8)
     execjs (2.6.0)
@@ -246,4 +246,4 @@ DEPENDENCIES
   wdm (>= 0.1.0)
 
 BUNDLED WITH
-   1.13.6
+   1.14.3

--- a/source/javascripts/app/about/inline-examples.js
+++ b/source/javascripts/app/about/inline-examples.js
@@ -66,7 +66,7 @@ function generateViewerApp($elem, files) {
     output += '</td><td class="code"><pre>' + highlighted + '</pre></td></tr></table>';
 
     output = "<div class='example-highlight'>" + output + "</div>";
-    return new Ember.Handlebars.SafeString(output);
+    return new Ember.String.htmlSafe(output);
   });
 }
 


### PR DESCRIPTION
Remove deprecated Handlebars SafeString in favor of String htmlSafe

There are issues moving to glimmer2. 

In talk with @acorncom there are plans to move the home page of the ember website to an ember-cli fastboot app in the near future.  

