### PR TITLE
Changing our api beta url

### DIFF
--- a/static.json
+++ b/static.json
@@ -2,7 +2,7 @@
   "https_only": true,
   "root": "build/",
   "proxies": {
-    "/api-new/": {
+    "/api-beta/": {
       "origin": "${EMBER_API_DOCS_URL}"
     }
   },
@@ -18,8 +18,8 @@
     }
   },
   "redirects": {
-    "/api-new": {
-      "url": "/api-new/"
+    "/api-beta": {
+      "url": "/api-beta/"
     }
   }
 }


### PR DESCRIPTION
Per a recommendation from @rwjblue we'll shift to `/api-beta` for the api viewer, makes things clearer