### PR TITLE
Disables robot access to our /api-beta folder

### DIFF
--- a/source/robots.txt
+++ b/source/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /api-beta/


### PR DESCRIPTION
Doing this so we can keep the api-beta files out of search engine indices until we're ready to launch 