### PR TITLE
Remove over-eager sponsors styling

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -2023,16 +2023,6 @@ body.tomster_payment-sent #content {
   .thanks {
     margin-top: 50px;
   }
-
-  ul, ol {
-    margin-bottom: 28px;
-
-    list-style-type: disc;
-    li {
-      font-size: 15px;
-      margin: 10px 0 10px 0;
-    }
-  }
 }
 
 /**


### PR DESCRIPTION
Each page on the website results in a different class set on `<body>`. In a few cases, these class names were also used for content on the page. This resulted in some styles affecting more than they should. This PR aims to address one such issue on the Sponsors page.

Summary of this PR:
* Removal of`.sponsors li` -- this was affecting not just the list of sponsors but also the list items in the header nav. The list of sponsors is already styled as it should through the `.showcase` class.
* Removal of `.sponsors ul, .sponsors ol` -- similar to the above, though this actually had no effect on the page at all, as the header-nav overrode these settings for the top list, and `showcase` overrode it for the list of sponsors.