### PR TITLE
Extract common styles for Showcase link backgrounds

### DIFF
--- a/source/stylesheets/pages/ember-users.css.scss
+++ b/source/stylesheets/pages/ember-users.css.scss
@@ -3,7 +3,4 @@
     height: 103px;
 
     text-align: center;
-    background-color: white;
-    border-radius: 5px;
-    box-shadow: 0px 1px 4px -1px rgba(0,0,0,0.8)
 }

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -1674,6 +1674,10 @@ ul.showcase {
   }
 
   > a {
+    background-color: white;
+    border-radius: 5px;
+    box-shadow: 0px 1px 4px -1px rgba(0,0,0,0.8);
+
     img {
       height: auto;
       width: auto;


### PR DESCRIPTION
This moves the styles used to create the rounded shadowed white pill backgrounds from being specific to the Ember Users page to be used for all showcase list links (currently just `/ember-users/` and `/sponsors/` as far as I can tell).

This fixes [the issue reported by @wifelette](https://github.com/emberjs/website/pull/2876#issuecomment-291246130).