### PR TITLE
slide-widget-head required for sliding TOC

### DIFF
--- a/source/blog/_sidebar.html.erb
+++ b/source/blog/_sidebar.html.erb
@@ -1,7 +1,7 @@
 <ol id='toc-list'>
   <% if blog.tags['Recent Posts'] %>
   <li class='level-1'>
-    <a href="<%= tag_path 'Recent posts'%>" class="slide-widget-head">Recent Posts</a>
+    <a href="<%= tag_path 'Recent posts'%>">Recent Posts</a>
     <ol style="display:block">
       <% blog.tags['Recent Posts'].sort_by(&:date).reverse.take(5).each_with_index do |article, i| %>
       <li class='level-3'><%= link_to article.title, article %></li>
@@ -10,7 +10,7 @@
   </li>
   <% end %>
   <li class='level-1'>
-    <a href="<%= tag_path 'Releases'%>" class="slide-widget-head">Releases</a>
+    <a href="<%= tag_path 'Releases'%>">Releases</a>
     <ol style="display:block">
       <% blog.tags['Releases'].sort_by(&:date).reverse.take(7).each_with_index do |article, i| %>
       <li class='level-3'><%= link_to article.title, article %></li>
@@ -18,7 +18,7 @@
     </ol>
   </li>
   <li class='level-1'>
-    <a href="<%= tag_path 'Ember Data' %>" class="slide-widget-head">Ember Data</a>
+    <a href="<%= tag_path 'Ember Data' %>">Ember Data</a>
     <ol style="display:block">
       <% blog.tags['Ember Data'].sort_by(&:date).reverse.take(7).each_with_index do |article, i| %>
       <li class='level-3'><%= link_to article.title, article %></li>

--- a/source/javascripts/app/api/toc.js
+++ b/source/javascripts/app/api/toc.js
@@ -1,5 +1,5 @@
 $(function(){
-  $("#toc-list .level-1 > a").not('[target=_blank]').click(function() {
+  $("#toc-list .level-1 > a.slide-widget-head").not('[target=_blank]').click(function() {
     $(this).parent().find('> ol').slideToggle(function() {
       positionBackToTop(true);
     });

--- a/source/javascripts/app/internal_api/toc.js
+++ b/source/javascripts/app/internal_api/toc.js
@@ -1,5 +1,5 @@
 $(function(){
-  $("#toc-list .level-1 > a").not('[target=_blank]').click(function() {
+  $("#toc-list .level-1 > a.slide-widget-head").not('[target=_blank]').click(function() {
     $(this).parent().find('> ol').slideToggle(function() {
       positionBackToTop(true);
     });

--- a/source/javascripts/deprecations.js
+++ b/source/javascripts/deprecations.js
@@ -9,7 +9,7 @@
 
     if ($this.prop('tagName') === 'H3') {
       var li = $("<li class='level-1'>" +
-                    "<a href='#" + $this.attr('id') + "'>" + $this.text() + "</a>" +
+                    "<a class='slide-widget-head' href='#" + $this.attr('id') + "'>" + $this.text() + "</a>" +
                     "<ol></ol>" +
                   "</li>");
 

--- a/source/javascripts/toc.js
+++ b/source/javascripts/toc.js
@@ -1,5 +1,5 @@
 $(function(){
-  $("#toc-list .level-1 > a").click(function() {
+  $("#toc-list .level-1 > a.slide-widget-head").click(function() {
     $(this).parent().find('> ol').slideToggle(function() {
       positionBackToTop(true);
     });

--- a/source/layouts/api.erb
+++ b/source/layouts/api.erb
@@ -6,7 +6,7 @@
   <% content_for :sidebar do %>
     <ol id='toc-list'>
       <li class='level-1'>
-        <a href="#">Projects</a>
+        <a class="slide-widget-head" href="#">Projects</a>
         <ol>
           <% @apis.each do |key, opts| %>
           <li class='level-3 <%= api_li_class(key) %>'>
@@ -19,7 +19,7 @@
       <li class='level-1'><a href="<%= sha_url %>" target="_blank"> Tag: <%= sha %></a></li>
 
       <% li_for(:modules) do %>
-        <a href='#'>Modules</a>
+        <a class="slide-widget-head" href='#'>Modules</a>
         <% ol_for(:modules) do %>
           <% api_modules.each do |id, data| %>
             <% li_for(:modules, name: data['name'], class: 'sub-selected') do %>
@@ -30,7 +30,7 @@
       <% end %>
 
       <% li_for(:namespaces) do %>
-        <a href='#'>Namespaces</a>
+        <a class="slide-widget-head" href='#'>Namespaces</a>
         <% ol_for(:namespaces) do %>
           <% api_namespaces.each do |id, data| %>
             <% li_for(:namespaces, name: data['name'], class: 'sub-selected') do %>
@@ -41,7 +41,7 @@
       <% end %>
 
       <% li_for(:classes) do %>
-        <a href='#'>Classes</a>
+        <a class="slide-widget-head" href='#'>Classes</a>
         <% ol_for(:classes) do %>
           <% api_classes.each do |id, data| %>
             <% li_for(:classes, name:data['name'], class: 'sub-selected') do %>

--- a/source/layouts/internal_api.erb
+++ b/source/layouts/internal_api.erb
@@ -6,7 +6,7 @@
   <% content_for :sidebar do %>
     <ol id='toc-list'>
       <li class='level-1'>
-        <a href="#">Projects</a>
+        <a class="slide-widget-head" href="#">Projects</a>
         <ol>
           <% @internal_apis.each do |key, opts| %>
           <li class='level-3 <%= internal_api_li_class(key) %>'>
@@ -19,7 +19,7 @@
       <li class='level-1'><a href="<%= internal_sha_url %>" target="_blank"> Tag: <%= internal_sha %></a></li>
 
       <% internal_li_for(:modules) do %>
-        <a href='#'>Modules</a>
+        <a class="slide-widget-head" href='#'>Modules</a>
         <% internal_ol_for(:modules) do %>
           <% internal_api_modules.each do |id, data| %>
             <% internal_li_for(:modules, name: data['name'], class: 'sub-selected') do %>
@@ -30,7 +30,7 @@
       <% end %>
 
       <% internal_li_for(:namespaces) do %>
-        <a href='#'>Namespaces</a>
+        <a class="slide-widget-head" href='#'>Namespaces</a>
         <% internal_ol_for(:namespaces) do %>
           <% internal_api_namespaces.each do |id, data| %>
             <% internal_li_for(:namespaces, name: data['name'], class: 'sub-selected') do %>
@@ -41,7 +41,7 @@
       <% end %>
 
       <% internal_li_for(:classes) do %>
-        <a href='#'>Classes</a>
+        <a class="slide-widget-head" href='#'>Classes</a>
         <% internal_ol_for(:classes) do %>
           <% internal_api_classes.each do |id, data| %>
             <% internal_li_for(:classes, name:data['name'], class: 'sub-selected') do %>


### PR DESCRIPTION
should fix https://github.com/emberjs/website/issues/2829

Now we require the `slide-widget-head` on any links that are sliding widgets. The blog sidebar then does not use this class.