### PR TITLE
Changed example for "Arguments in Component Lifecycle Hooks" deprecation

### DIFF
--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -931,12 +931,13 @@ After:
 ``` javascript
 Ember.Component.extend({
   didReceiveAttrs() {
-    let highTemp = this.get('_highTemp');
-    let lowTemp = this.get('_lowTemp');
+    let oldTemp = this.get('_oldTemp');
+    let newTemp = this.get('temp');
 
-    if (highTemp !== lowTemp) {
-      this.thermometer.move({ from: highTemp, to: lowTemp });
+    if (oldTemp && oldTemp !== newTemp) {
+      this.thermometer.move({ from: oldTemp, to: newTemp });
     }
+    this.set('_oldTemp', newTemp);
   }
 });
 ```


### PR DESCRIPTION
In the "Arguments in Component Lifecycle Hooks" section, changed the After example for `didReceiveAttrs` to better match the Before example, and more importantly, to show the manual saving of any properties one might want to compare old values and new values of during `didReceiveAttrs`. More details and link to inspiration for change in #2862