### PR TITLE
Fix borders on users

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -1607,6 +1607,7 @@ ul.showcase {
 
 #content ul.showcase {
   margin: 0;
+  padding: 0 1px;
 }
 
 #content .showcase li {


### PR DESCRIPTION
On the users page (`/ember-users`), the users in the leftmost column are missing their left border and the users in the rightmost column are missing their right border. You might have to resize the window width to see it.

![screen shot 2017-06-12 at 10 47 27 am](https://user-images.githubusercontent.com/118005/27047378-be30432a-4f5c-11e7-8e1e-d924fa351c63.png)

This fix just adds a 1px padding to the container so that the borders always show.

![screen shot 2017-06-12 at 10 50 40 am](https://user-images.githubusercontent.com/118005/27047453-05c876da-4f5d-11e7-8edd-790d2a722364.png)

