### PR TITLE
Remove `rvm` section from `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: ruby
 cache: bundler
-rvm:
-- 2.2
 script:
 - bundle exec middleman build
 before_install:


### PR DESCRIPTION
To use the same version as `.ruby-version` in Travis CI.

> If the ruby version is not specified by the rvm key as described above,
> Travis CI will consult `.ruby-version` in the root of the
> repository and use the indicated Ruby runtime.

Ref: https://docs.travis-ci.com/user/languages/ruby/#Using-.ruby-version