### PR TITLE
Extract footer to glimmer-styleguide

### DIFF
--- a/source/layout.erb
+++ b/source/layout.erb
@@ -23,6 +23,7 @@
     <% if current_page.data.no_index.eql? true %>
       <meta name="robots" content="noindex">
     <% end %>
+    <link rel="stylesheet" href="https://glimmer-styleguide.global.ssl.fastly.net/glimmer-styleguide/master/app.css" />
     <%= yield_content :head %>
   </head>
 
@@ -52,7 +53,7 @@
       </div>
     </div>
 
-    <%= partial "footer" %>
+    <main-footer></main-footer>
 
     <%= yield_content :foot %>
     <script type="text/javascript">
@@ -68,5 +69,6 @@
         var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
       })();
     </script>
+    <script src="https://glimmer-styleguide.global.ssl.fastly.net/glimmer-styleguide/master/app.js"></script>
   </body>
 </html>

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -7,7 +7,6 @@
 @import 'mixins/hidpi';
 @import 'fonts';
 @import 'header';
-@import 'footer';
 @import 'examples';
 @import 'about';
 @import 'guides';


### PR DESCRIPTION
Although they are components to be used in Emberjs family of web resources, the package is prefixed "glimmer" because the components are implemented in Glimmerjs.
We are using the web component shim for easy integration.