### PR TITLE
Drop unused gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,11 +19,6 @@ gem "faraday"
 gem "bourbon"
 gem "neat"
 
-source 'https://rails-assets.org' do
-  gem "rails-assets-js-md5"
-  gem "rails-assets-moment"
-end
-
 group :development, :test do
   gem 'pry'
   gem 'pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,7 +15,6 @@ GIT
 
 GEM
   remote: https://rubygems.org/
-  remote: https://rails-assets.org/
   specs:
     activesupport (4.2.5)
       i18n (~> 0.7)
@@ -143,8 +142,6 @@ GEM
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
-    rails-assets-js-md5 (1.1.1)
-    rails-assets-moment (2.10.6)
     rake (10.4.2)
     rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
@@ -217,8 +214,6 @@ DEPENDENCIES
   pry
   pry-byebug
   rack
-  rails-assets-js-md5!
-  rails-assets-moment!
   rake
   redcarpet
   rspec
@@ -228,4 +223,4 @@ DEPENDENCIES
   wdm (>= 0.1.0)
 
 BUNDLED WITH
-   1.14.3
+   1.15.1


### PR DESCRIPTION
They are unnecessary since https://github.com/emberjs/website/commit/2b192878e77816d8274a2179e00aa4c9e7ca4c98