### PR TITLE
Remove loader.io addon

### DIFF
--- a/app.json
+++ b/app.json
@@ -13,7 +13,6 @@
   "formation": {
   },
   "addons": [
-    "loaderio"
   ],
   "buildpacks": [
     {


### PR DESCRIPTION
This creates a new loader.io addon every time a Review App is created on Heroku. We should probably not do that since we don't need it for review apps.