### PR TITLE
Replace EmberWatch with Ember Weekly

### DIFF
--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -40,7 +40,7 @@ responsive: true
     Please note that neither the IRC channel nor the Slack room are managed or moderated by the Ember Core Team. They are public forums.
   </p>
   <p>
-    For a curated list of Ember learning resources (podcasts, videos, blog posts, books, etc) check out <a href="http://emberwatch.com/">EmberWatch</a>.
+    For a curated list of Ember learning resources (podcasts, videos, blog posts, books, etc) check out <a href="http://emberweekly.com/">Ember Weekly</a>.
   </p>
 </div>
 


### PR DESCRIPTION
EmberWatch hasn't been updated in a long time. Ember Weekly is a better community resource.