### PR TITLE
ember-cli-update instructions

### DIFF
--- a/source/blog/2017-08-14-ember-2-15-released.md
+++ b/source/blog/2017-08-14-ember-2-15-released.md
@@ -103,8 +103,32 @@ applications.
 
 ### Upgrading Ember CLI
 
-You may upgrade Ember CLI separately from Ember.js and Ember Data! To upgrade
-your projects using `yarn` run:
+You may upgrade Ember CLI separately from Ember.js and Ember Data!
+There is a new experimental tool for Ember CLI upgrades called
+[ember-cli-update](https://github.com/kellyselden/ember-cli-update.git).
+To use it, run this command to install it globally:
+
+```
+npm install -g ember-cli-update
+```
+
+Then run:
+
+```
+ember-cli-update
+```
+
+It runs your system git merge tool if it finds a conflict. This can be pretty
+overwhelming for beginners, so you can run
+
+```
+ember-cli-update --ignore-conflicts
+```
+
+to handle the conflicts yourself.
+
+If this new tool is giving you problems, you can still upgrade your projects
+manually. To upgrade your projects using `yarn` run:
 
 ```
 yarn upgrade ember-cli


### PR DESCRIPTION
First pass at ember-cli-update instructions. I put it first because otherwise it seems like people would go through the old update instructions before seeing that there was a new way if I put it after.