### PR TITLE
Clean up code snippets, fix highlighting

### DIFF
--- a/source/blog/2012-12-22-this-week-in-ember-js-3.markdown
+++ b/source/blog/2012-12-22-this-week-in-ember-js-3.markdown
@@ -52,22 +52,24 @@ Ember.Handlebars just got a little bit smarter. `Ember.Handlebars.registerBoundH
 provides a way to easily create your own bound custom helpers.
 
 #### Example:
+
 ```javascript
-  Ember.Handlebars.registerBoundHelper('capitalize', function(value) {
-    return value.toUpperCase();
-  });
+Ember.Handlebars.registerBoundHelper('capitalize', function(value) {
+  return value.toUpperCase();
+});
 ```
+
 which can be used in your templates as follows:
 
 ```handlebars
-  {{capitalize name}}
+{{capitalize name}}
 ```
 
 ### Ember.Object.create behavior change
 
-The new behavior will call computed property setters instead of overwriting them.  
+The new behavior will call computed property setters instead of overwriting them.
 We suggest using `Ember.Object.extend()` to create classes and use `create` to initialize
-properties on your instance. The old behavior is available via `createWithMixins`.  
+properties on your instance. The old behavior is available via `createWithMixins`.
 This change should increase object creation performance by 2x.
 
 ### Other changes of note
@@ -85,6 +87,6 @@ The very first Ember Camp in SF is happening on the 15th February 2013.
 Looking to learn Ember? There's also an [Introduction to Ember](http://www.embertraining.com/)
 event in the week leading up to Ember Camp.
 
-Enjoy your holiday,  
-Bradley Priest  
+Enjoy your holiday,
+Bradley Priest
 [@bradleypriest](https://twitter.com/bradleypriest)

--- a/source/blog/2013-02-15-ember-1-0-rc.html.markdown
+++ b/source/blog/2013-02-15-ember-1-0-rc.html.markdown
@@ -36,7 +36,7 @@ to do the same thing.
 If you want every item in a `{{#each}}` to be wrapped in an `ObjectController`,
 you can do so easily:
 
-```js
+```handlebars
 {{#each posts itemController="post"}}
   {{!-- `this` in here is each post wrapped in an App.PostController --}}
 {{/each}}

--- a/source/blog/2013-03-30-ember-1-0-rc2.markdown
+++ b/source/blog/2013-03-30-ember-1-0-rc2.markdown
@@ -64,9 +64,7 @@ or router.
 
 If you have a template like this:
 
-```handlebars
-<!-- posts.handlebars -->
-
+```posts.hbs
 <ul>
 {{#each controller itemController='postItem'}}
   <li><button {{action 'selectPost' this}}>{{name}}</button></li>

--- a/source/blog/2013-05-28-ember-1-0-rc4.markdown
+++ b/source/blog/2013-05-28-ember-1-0-rc4.markdown
@@ -141,8 +141,9 @@ The `{{#linkTo}}` Handlebars helper now has a `disabledWhen` option that
 can be bound to conditionally disable a link:
 
 ```handlebars
-{{#linkTo 'upgradeAccount' disabledWhen=isPremiumUser}}Upgrade
-Account{{/linkTo}}
+{{#linkTo 'upgradeAccount' disabledWhen=isPremiumUser}}
+  Upgrade Account
+{{/linkTo}}
 ```
 
 Thanks to Trek Glowacki for this improvement.

--- a/source/blog/2013-12-17-whats-coming-in-ember-in-2014.md
+++ b/source/blog/2013-12-17-whats-coming-in-ember-in-2014.md
@@ -182,7 +182,7 @@ vendor/
 lib/
   ember-histogram/ // incubator for packages
     skylight/
-    bower.json 
+    bower.json
 modules/           // non-MVC stuff
   underscore.js
 ```

--- a/source/blog/2014-03-30-ember-1-5-0-and-ember-1-6-beta-released.md
+++ b/source/blog/2014-03-30-ember-1-5-0-and-ember-1-6-beta-released.md
@@ -15,7 +15,7 @@ process that began just after 1.0 was released.
 This feature allows you to log primitive values (strings, numbers, etc) from within your
 templates. Previously, the `{{log}}` helper only allowed usage of bound property lookup.
 
-```javascript
+```handlebars
 {{log "**LOOKEY HERE**"}}
 ```
 

--- a/source/blog/2014-12-08-ember-1-9-0-released.md
+++ b/source/blog/2014-12-08-ember-1-9-0-released.md
@@ -71,8 +71,7 @@ implementation then updated every Handlebars helper to the new API.
 Ember.js routes have long supported an `activate` and `deactivate` hook.
 For example:
 
-```js
-// app/routes/index.js
+```app/routes/index.js
 export default Ember.Route.extend({
   activate: function(){
     collectAnalytics();
@@ -82,8 +81,7 @@ export default Ember.Route.extend({
 
 Ember.js 1.9 introduces corresponding events for these hooks.
 
-```js
-// app/routes/index.js
+```app/routes/index.js
 export default Ember.Route.extend({
   collectAnalytics: function(){
     collectAnalytics();
@@ -153,9 +151,7 @@ is a step toward that goal.
 
 Two Ember helpers support context switching. The first is `{{each}}`:
 
-```handlebars
-{{! app/templates/people.hbs }}
-
+```app/templates/people.hbs
 {{! this context is the controller }}
 {{#each model}}
   {{name}} {{! this context is each person }}
@@ -164,9 +160,7 @@ Two Ember helpers support context switching. The first is `{{each}}`:
 
 The non-context switching version of this helper is now preferred:
 
-```handlebars
-{{! app/templates/people.hbs }}
-
+```app/templates/people.hbs
 {{! this context is the controller }}
 {{#each person in model}}
   {{person.name}} {{! this context is still the controller }}
@@ -175,9 +169,7 @@ The non-context switching version of this helper is now preferred:
 
 The second helper is `{{with}}`:
 
-```handlebars
-{{! app/templates/person.hbs }}
-
+```app/templates/person.hbs
 {{! this context is the controller }}
 {{#with model}}
   {{name}} {{! this context is the person }}
@@ -186,9 +178,7 @@ The second helper is `{{with}}`:
 
 The non-context switching version of this helper is now preferred:
 
-```handlebars
-{{! app/templates/person.hbs }}
-
+```app/templates/person.hbs
 {{! this context is the controller }}
 {{#with model as person}}
   {{person.name}} {{! this context is still the controller }}
@@ -266,8 +256,7 @@ Preserving template scope context results in easier to read templates.
 
 Any component in Ember 1.10 can use this feature. For example:
 
-```handlebars
-{{! app/templates/components/my-unordered-list.hbs }}
+```app/templates/components/my-unordered-list.hbs
 <ul>
   {{#each items as |item|}}
     <li>{{yield item}}</li>
@@ -275,8 +264,7 @@ Any component in Ember 1.10 can use this feature. For example:
 </ul>
 ```
 
-```handlebars
-{{! app/templates/index.hbs }}
+```app/templates/index.hbs
 {{#my-unordered-list items=cars as |car|}}
   Auto: {{car.name}}
 {{/my-unordered-list}}

--- a/source/blog/2014-12-23-ember-1-9-1-released.md
+++ b/source/blog/2014-12-23-ember-1-9-1-released.md
@@ -53,8 +53,7 @@ However, there is still another potential exploit vector: bound attributes.
 Let's say you display a profile for your users and allow them to supply
 an arbitrary homepage that your app links to:
 
-```handlebars
-{{!-- templates/user.hbs --}}
+```app/templates/user.hbs
 First Name: {{firstName}}
 Homepage: <a {{bind-attr href=homepageUrl}}>{{homepageUrl}}</a>
 ```

--- a/source/blog/2015-02-07-ember-1-10-0-released.md
+++ b/source/blog/2015-02-07-ember-1-10-0-released.md
@@ -137,8 +137,7 @@ variables into child scopes allows for new patterns of component composition.
 Block params are passed from a template via the `yield` helper. For example, this
 component yields the `fullName` and `age` values:
 
-```javascript
-// app/components/x-customer.js }}
+```app/components/x-customer.js
 export default Ember.Component.extend({
 
   fullName: function(){
@@ -153,15 +152,13 @@ export default Ember.Component.extend({
 });
 ```
 
-```handlebars
-{{! app/components/x-customer.hbs }}
+```app/components/x-customer.hbs
 <div class="customer">
   {{yield fullName age}}
 </div>
 ```
 
-```handlebars
-{{! app/templates/index.hbs }}
+```app/templates/index.hbs
 <div class="layout">
   {{#x-customer customer=model birthday=model.birthday as |fullName age|}}
     Hello, {{fullName}}. You are {{age}} years old.

--- a/source/blog/2015-05-10-run-up-to-two-oh.md
+++ b/source/blog/2015-05-10-run-up-to-two-oh.md
@@ -298,8 +298,7 @@ In Ember 1.13, you can write the same component this way:
 <my-counter count={{mut activatedCount}} />
 ```
 
-```js
-// my-counter.js
+```my-counter.js
 export default Component.extend({
   click: function() {
     this.attrs.count.update(this.attrs.count.value + 1);
@@ -338,9 +337,7 @@ function (i.e. "[currying][currying]").
 Starting in Ember 1.13, a new `action` helper provides you with a way to
 do both of these things:
 
-```handlebars
-{{!-- parent-component --}}
-
+```parent-component.hbs
 {{#each users as |user|}}
   <big-button on-active={{action 'selectedUser' user}} />
 
@@ -349,8 +346,7 @@ do both of these things:
 {{/each}}
 ```
 
-```js
-// parent-component.js
+```parent-component.js
 export default Component.extend({
   actions: {
     selectedUser(user) {
@@ -361,8 +357,7 @@ export default Component.extend({
 });
 ```
 
-```js
-// big-button.js
+```big-button.js
 export default Component.extend({
   click: function() {
     this.attrs['on-active']();
@@ -383,9 +378,7 @@ updates one of its values.
 <my-text on-enter={{action (mut currentText)}} />
 ```
 
-```js
-// my-text.js
-
+```my-text.js
 export default Component.extend({
   keyUp(event) {
     if (event.which === 13) {

--- a/source/blog/2015-05-21-ember-data-1-0-beta-18-released.md
+++ b/source/blog/2015-05-21-ember-data-1-0-beta-18-released.md
@@ -74,9 +74,7 @@ While `modelNameFromPayloadKey` returns a *model* for a JSON payload key,
 *to the server.* For instance, you may have a Post model, but your server
 expects a `message` as the root. You can override it like so:
 
-```javascript
-// app/serializers/application.js
-
+```app/serializers/application.js
 export default DS.RESTSerializer.extend({
   payloadKeyFromModelName: (modelName) {
     if (modelName === 'post') {

--- a/source/blog/2015-06-12-ember-1-13-0-released.md
+++ b/source/blog/2015-06-12-ember-1-13-0-released.md
@@ -138,8 +138,7 @@ enables return values, and introduces some powerful new currying capabilities.
 For example, action `submit` is passed to `my-component` where it is called upon
 click:
 
-```js
-// app/controllers/index.js
+```app/controllers/index.js
 import Ember from "ember";
 
 export default Ember.Controller.extend({
@@ -151,13 +150,11 @@ export default Ember.Controller.extend({
 });
 ```
 
-```hbs
-{{! app/templates/index.hbs }}
+```app/templates/index.hbs
 {{my-component submit=(action 'setName')}}
 ```
 
-```js
-// app/components/my-component.js
+```app/components/my-component.js
 import Ember from "ember";
 
 export default Ember.Component.extend({
@@ -205,8 +202,7 @@ Helpers come in two flavors. The first is a function-based API we call a
 shorthand helper. For example, this shorthand helper joins a first and
 last name:
 
-```js
-// app/helpers/full-name.js
+```app/helpers/full-name.js
 import Ember from "ember";
 
 export default Ember.Helper.helper(function(params, hash) {
@@ -216,7 +212,7 @@ export default Ember.Helper.helper(function(params, hash) {
 
 This helper can be used in a variety of contexts:
 
-```hbs
+```handlebars
 {{full-name "Daniel" model.lastName}}
 {{my-component name=(full-name model.firstName "Smith")}}
 {{! The following usage would set the model.name to the new full name
@@ -235,8 +231,7 @@ some control over their own invalidation and recomputation. In these cases, a he
 For example, this helper computes a name based on a `name-builder` service. It
 also recomputes whenever the `isAnonymized` state on that service changes:
 
-```js
-// app/helpers/full-name.js
+```app/helpers/full-name.js
 import Ember from "ember";
 
 export default Ember.Helper.extend({
@@ -265,8 +260,7 @@ how a component is called.
 `hasBlock` will be true when a component is invoked in block form. For example
 given this component:
 
-```hbs
-{{! app/components/show-full-name.hbs }}
+```app/components/show-full-name.hbs
 {{#if hasBlock}}
   {{yield fullName}}
 {{else}}

--- a/source/blog/2015-06-18-ember-data-1-13-released.md
+++ b/source/blog/2015-06-18-ember-data-1-13-released.md
@@ -267,15 +267,15 @@ Now, whenever you call `findRecord` or `findAll`, and the record is already cach
 
 For example, if you are building an events ticketing system, in which users can only reserve tickets for 20 minutes at a time, and want to ensure that in each route you have data that is no more than 20 minutes old you could write:
 
-```js 
+```js
 shouldReloadRecord: function(store, ticketSnapshot) {
   let timeDiff = moment().diff(ticketSnapshot.attr('lastAccessedAt')).minutes();
   if (timeDiff > 20) {
-    return true;    
+    return true;
   } else {
     return false;
   }
-}, 
+},
 ```
 
 This method would ensure that whenever you do `findRecord('ticket')` you will
@@ -284,10 +284,10 @@ version is more than 20 minutes old, `findRecord` will not resolve until you fet
 the latest version. By default this hook returns false, as most UIs should not block
 user interactions while waiting on data update.
 
-You can also customize whether you should try and do a background update. For example, if you do not want to fetch complex data over a mobile connection, or 
+You can also customize whether you should try and do a background update. For example, if you do not want to fetch complex data over a mobile connection, or
 if the network is down, you can implement `shouldBackgroundReloadRecord`
 
-```js 
+```js
 shouldBackgroundReloadRecord: function(store, snapshot) {
   if (window.navigator.connection === 'cellular' ||
   	window.navigator.connection === 'none') {

--- a/source/blog/2015-11-16-ember-2-2-released.md
+++ b/source/blog/2015-11-16-ember-2-2-released.md
@@ -91,13 +91,11 @@ This helper is introduced to make the new contextual components feature
 more convenient, and it will often be used with the `{{yield` helper. For
 example:
 
-```handlebars
-{{! app/templates/components/nice-person.hbs }}
+```app/templates/components/nice-person.hbs
 {{yield (hash name='Bob')}}
 ```
 
-```handlebars
-{{! app/templates/index.hbs }}
+```app/templates/index.hbs
 {{#nice-person as |person|}}
   Hello, my name is {{person.name}}
 {{/nice-person}}
@@ -120,8 +118,7 @@ privately share data, but be invoked in a flexible manner. For example,
 this `{{alert-box}}` component yields a contextual component composed
 of the `alert-box-button` component and the attribute `onclick`:
 
-```handlebars
-{{! app/templates/components/alert-box.hbs }}
+```app/templates/components/alert-box.hbs
 <div class="alert-box">
   {{yield (hash
     close-button=(component 'alert-box-button' onclick=(action 'close'))
@@ -129,8 +126,7 @@ of the `alert-box-button` component and the attribute `onclick`:
 </div>
 ```
 
-```handlebars
-{{! app/templates/index.hbs }}
+```app/templates/index.hbs
 {{#alert-box as |box|}}
   Danger, Will Robinson!
   <div style="float:right">

--- a/source/blog/2016-01-12-ember-data-2-3-released.md
+++ b/source/blog/2016-01-12-ember-data-2-3-released.md
@@ -194,8 +194,7 @@ relationships and belongs-to relationships:
 
 Consider the following `post` model:
 
-```js
-// app/models/post.js
+```app/models/post.js
 import Model from 'ember-data/model';
 import { belongsTo, hasMany } from 'ember-data/relationships';
 

--- a/source/blog/2016-01-15-ember-2-3-released.md
+++ b/source/blog/2016-01-15-ember-2-3-released.md
@@ -79,13 +79,11 @@ This helper is introduced to make the new contextual components feature
 more convenient, and it will often be used with the `{{yield` helper. For
 example:
 
-```handlebars
-{{! app/templates/components/nice-person.hbs }}
+```app/templates/components/nice-person.hbs
 {{yield (hash name='Bob')}}
 ```
 
-```handlebars
-{{! app/templates/index.hbs }}
+```app/templates/index.hbs
 {{#nice-person as |person|}}
   Hello, my name is {{person.name}}
 {{/nice-person}}
@@ -108,8 +106,7 @@ privately share data, but be invoked in a flexible manner. For example,
 this `{{alert-box}}` component yields a contextual component composed
 of the `alert-box-button` component and the attribute `onclick`:
 
-```handlebars
-{{! app/templates/components/alert-box.hbs }}
+```app/templates/components/alert-box.hbs
 <div class="alert-box">
   {{yield (hash
     close-button=(component 'alert-box-button' onclick=(action 'close'))
@@ -117,8 +114,7 @@ of the `alert-box-button` component and the attribute `onclick`:
 </div>
 ```
 
-```handlebars
-{{! app/templates/index.hbs }}
+```app/templates/index.hbs
 {{#alert-box as |box|}}
   Danger, Will Robinson!
   <div style="float:right">

--- a/source/blog/2016-03-13-ember-data-2-4-released.md
+++ b/source/blog/2016-03-13-ember-data-2-4-released.md
@@ -80,8 +80,7 @@ relationships and belongs-to relationships:
 
 Consider the following `post` model:
 
-```js
-// app/models/post.js
+```app/models/post.js
 import Model from 'ember-data/model';
 import { belongsTo, hasMany } from 'ember-data/relationships';
 

--- a/source/blog/2016-04-28-baseURL.md
+++ b/source/blog/2016-04-28-baseURL.md
@@ -62,8 +62,7 @@ The primary migration effort is that you should expect to adjust any relative pa
 
 As an example, given this configuration where you have configured a different `rootURL` and `baseURL`:
 
-```javascript
- // Snipped from /config/environment.js
+```config/environment.js
 var ENV = {
   /* ... */
   rootURL: '/path/to/application/',
@@ -74,7 +73,7 @@ var ENV = {
 
 You would remove the `baseURL` option and modify your templates like so:
 
-```hbs
+```handlebars
 {{!-- Old: --}}
 <img src="images/logo.png" />
 
@@ -86,7 +85,7 @@ You would remove the `baseURL` option and modify your templates like so:
 
 One of the most common use cases for `baseURL` was pointing to assets on a CDN. After this change to remove `baseURL` you should use the `prepend` option for [`broccoli-asset-rev`](https://github.com/rickharrison/broccoli-asset-rev) which is included with Ember CLI apps by default. For example, in `ember-cli-build.js`:
 
-```javascript
+```ember-cli-build.js
 var app = new EmberApp(defaults, {
   // Add options here
   fingerprint: {
@@ -97,8 +96,7 @@ var app = new EmberApp(defaults, {
 
 Note that the `prepend` option only applies when doing *production* builds via something like `ember build --prod`. Given the above example, and this input:
 
-```javascript
-// Snipped from /config/environment.js
+```config/environment.js
 var ENV = {
   /* ... */
   rootURL: '/path/to/application/'
@@ -125,8 +123,7 @@ Note that `rootURL` *is present* as part of the path for the CDN-hosted assets i
 
 We also use the setting for `rootURL` at runtime in the application's router:
 
-```javascript
-// Snipped from /app/router.js
+```app/router.js
 import Ember from 'ember';
 import config from './config/environment';
 
@@ -137,8 +134,7 @@ const Router = Ember.Router.extend({
 
 In most cases this does exactly what you want it to do. However, if you wish to mount the application at a different place than the Ember CLI `rootURL` specifies for its `ember serve` location, you may add an additional property in your config, `routerRootURL`, to specify the path that your application will live at runtime.
 
-```javascript
-// Snipped from /config/environment.js
+```config/environment.js
 var ENV = {
   /* ... */
   rootURL: '/',

--- a/source/blog/2016-05-03-ember-data-2-5-released.md
+++ b/source/blog/2016-05-03-ember-data-2-5-released.md
@@ -49,8 +49,7 @@ relationships and belongs-to relationships:
 
 Consider the following `post` model:
 
-```js
-// app/models/post.js
+```app/models/post.js
 import Model from 'ember-data/model';
 import { belongsTo, hasMany } from 'ember-data/relationships';
 

--- a/source/blog/2016-07-25-ember-data-2-7-released.md
+++ b/source/blog/2016-07-25-ember-data-2-7-released.md
@@ -77,8 +77,7 @@ Data 2.7.
 
 Allow `null`/`undefined` values for boolean attributes via `attr('boolean', { allowNull: true })`
 
-```js
-// app/models/user.js
+```app/models/user.js
 import DS from 'ember-data';
 
 export default DS.Model.extend({
@@ -148,8 +147,7 @@ request using `jQuery.ajax` and attaches success and failure handlers.
 Say your API handles creation of resources via PUT, this can now be
 customized as follows:
 
-``` js
-// adapters/application.js
+```adapters/application.js
 import DS from 'ember-data';
 
 export default DS.RESTAdapter.extend({

--- a/source/blog/2017-04-05-emberconf-2017-state-of-the-union.md
+++ b/source/blog/2017-04-05-emberconf-2017-state-of-the-union.md
@@ -46,7 +46,7 @@ Ember was still finding its sea legs, too. There was no Ember App Kit yet, let a
 </html>
 ```
 
-As antiquated as this feels today, this was more or less how most JavaScript apps were written. 
+As antiquated as this feels today, this was more or less how most JavaScript apps were written.
 
 Some parts of Ember are truly embarrassing to look back on. Because IE was so dominant, our rendering engine was optimized for its performance quirks. DOM APIs were extremely slow, so our templates were string-based: render everything as a string of HTML, and then insert it with a single `innerHTML` operation. (Modern rendering engines like React, Angular, and Glimmer all create their own DOM instead of asking the browser to parse HTML.)
 

--- a/source/deprecations/ember-data/v2.x.html.md
+++ b/source/deprecations/ember-data/v2.x.html.md
@@ -51,9 +51,7 @@ key separately from the key used for the relationship.
 
 For example, given the following model:
 
-```javascript
-// app/models/comment.js
-
+```app/models/comment.js
 import DS from 'ember-data';
 
 export default DS.Model.extend({
@@ -203,9 +201,7 @@ extension.
 
 With Ember >= v2.7.0, disable the prototype extension for `Date`:
 
-```javascript
-// config/environment.js
-
+```config/environment.js
 ENV = {
   EmberENV: {
     EXTEND_PROTOTYPES: {
@@ -217,9 +213,7 @@ ENV = {
 
 With Ember < v2.7.0, values must be provided for all prototype extensions:
 
-```javascript
-// config/environment.js
-
+```config/environment.js
 var ENV = {
   EmberENV: {
     EXTEND_PROTOTYPES: {
@@ -296,9 +290,7 @@ Another option is to override
 [`normalizeQueryRecordResponse`](http://emberjs.com/api/data/classes/DS.RESTSerializer.html#method_normalizeQueryRecordResponse)
 in your serializer, manipulating the payload so it matches the expected format:
 
-```javascript
-// app/serializers/user.js
-
+```app/serializers/user.js
 import DS from 'ember-data';
 
 export default DS.RESTSerializer.extend({
@@ -320,9 +312,7 @@ object as its primary data. This can be done by overriding
 [`urlForQueryRecord`](http://emberjs.com/api/data/classes/DS.RESTAdapter.html#method_urlForQueryRecord)
 in your adapter:
 
-```javascript
-// app/adapters/user.js
-
+```app/adapters/user.js
 import DS from 'ember-data';
 
 export default DS.RESTAdapter.extend({
@@ -554,9 +544,7 @@ when you fetch a `post`:
 Previously, you would want to override `modelNameFromPayloadKey` to remove the
 namespace:
 
-```javascript
-// app/serializers/post.js
-
+```app/serializers/post.js
 import DS from 'ember-data';
 
 export default DS.JSONAPISerializer.extend({
@@ -569,9 +557,7 @@ export default DS.JSONAPISerializer.extend({
 You can remove this deprecation by refactoring your serializer to instead use
 `modelNameFromPayloadType`:
 
-```javascript
-// app/serializers/post.js
-
+```app/serializers/post.js
 import DS from 'ember-data';
 
 export default DS.JSONAPISerializer.extend({
@@ -622,9 +608,7 @@ is sent when you create a `post` model:
 Previously, you would want to override `payloadKeyFromModelName` to add the
 namespace to the `modelName`:
 
-```javascript
-// app/serializers/post.js
-
+```app/serializers/post.js
 import DS from 'ember-data';
 
 export default DS.JSONAPISerializer.extend({
@@ -637,9 +621,7 @@ export default DS.JSONAPISerializer.extend({
 You can remove this deprecation by refactoring your serializer to instead use
 [`payloadTypeFromModelName`](http://emberjs.com/api/data/classes/DS.JSONAPISerializer.html#method_payloadTypeFromModelName):
 
-```javascript
-// app/serializers/post.js
-
+```app/serializers/post.js
 import DS from 'ember-data';
 
 export default DS.JSONAPISerializer.extend({

--- a/source/deprecations/v1.x.html.md
+++ b/source/deprecations/v1.x.html.md
@@ -97,7 +97,7 @@ library may need to update its suggested usage.
 
 One solution for such a library is to provide mixins instead of classes:
 
-```JavaScript
+```js
 // usage is {{view "list"}}
 var App.ListView = Ember.View.extend(ListView);
 ```
@@ -105,7 +105,7 @@ var App.ListView = Ember.View.extend(ListView);
 A more advanced solution is to use an initializer to register the plugin's
 views on the application:
 
-```JavaScript
+```js
 // usage is {{view "list"}}
 Ember.Application.initializer({
   name: 'list-view',
@@ -243,7 +243,7 @@ listed object controllers as a concept to be removed from the framework.
 To migrate from an explicitly defined object controller, first convert
 the class definition to inherit from `Ember.Controller`. For example:
 
-```
+```js
 import Ember from "ember";
 
 // Change:
@@ -536,13 +536,11 @@ deprecated. If you were using this class, please migrate to `Ember.Component`.
 In most cases Ember views can be replaced with a component. For example
 this view and usage:
 
-```handlebars
-{{! app/templates/show-menu.hbs }}
+```app/templates/show-menu.hbs
 {{view.title}}
 ```
 
-```js
-// app/views/show-menu.js
+```app/views/show-menu.js
 import Ember from "ember";
 
 // Usage: {{view "show-menu"}}
@@ -554,13 +552,11 @@ export default Ember.View.extend({
 
 Can be replaced with this component:
 
-```handlebars
-{{! app/templates/components/show-menu.hbs }}
+```app/templates/components/show-menu.hbs
 {{title}}
 ```
 
-```js
-// app/components/show-menu.js
+```app/components/show-menu.js
 import Ember from "ember";
 
 // Usage: {{show-menu}}
@@ -583,8 +579,7 @@ if data is needed it should be passed upon invocation. For example:
 Some notable differences exist between yielded view blocks and yielded component
 blocks. A view could be used this way:
 
-```js
-// app/views/reverse-name.js
+```app/views/reverse-name.js
 import Ember from "ember";
 
 export default Ember.View.extend({
@@ -603,8 +598,7 @@ export default Ember.View.extend({
 Components introduced block params. This concept achieves data passing
 without the confusion over what `{{view}}` refers to. For example:
 
-```js
-// app/components/reverse-name.js
+```app/components/reverse-name.js
 import Ember from "ember";
 
 export default Ember.Component.extend({
@@ -614,8 +608,7 @@ export default Ember.Component.extend({
 });
 ```
 
-```handlebars
-// app/templates/components/reverse-name.hbs
+```app/templates/components/reverse-name.hbs
 {{yield reversedName}}
 ```
 
@@ -635,8 +628,7 @@ When a template for a given route is rendered, if there is a view with the
 same name that view will also be used. For example this view is attached
 to the rendered route template:
 
-```js
-// app/router.js
+```app/router.js
 import Ember from "ember";
 
 export default Ember.Router.map(function() {
@@ -644,8 +636,7 @@ export default Ember.Router.map(function() {
 });
 ```
 
-```js
-// app/views/about.js
+```app/views/about.js
 import Ember from "ember";
 
 export default Ember.View.extend({
@@ -661,8 +652,7 @@ There are only two reasons a view may be used for a route.
 You should migrate away from routed views. For example to attach
 bindings an element in the template is sufficient:
 
-```js
-// app/router.js
+```app/router.js
 import Ember from "ember";
 
 export default Ember.Router.map(function() {
@@ -670,8 +660,7 @@ export default Ember.Router.map(function() {
 });
 ```
 
-```handlebars
-{{! app/templates/about.hbs }}
+```app/templates/about.hbs
 <div class="{{if isActive 'active'}}">
   <!-- something something -->
 </div>
@@ -679,8 +668,7 @@ export default Ember.Router.map(function() {
 
 If attaching events or sharing DOM is necessary, consider a component:
 
-```js
-// app/router.js
+```app/router.js
 import Ember from "ember";
 
 export default Ember.Router.map(function() {
@@ -688,15 +676,13 @@ export default Ember.Router.map(function() {
 });
 ```
 
-```handlebars
-{{! app/templates/about.hbs }}
+```app/templates/about.hbs
 {{#active-layout isActive=isActive}}
   <!-- something something -->
 {{/active-layout}}
 ```
 
-```js
-// app/components/active-layout.js
+```app/components/active-layout.js
 import Ember from "ember";
 
 export default Ember.Component.extend({
@@ -750,8 +736,7 @@ data-down, actions-up paradigm in one's codebase.
 For example, to create a component that displays a prompt and a list of
 dropdown options, the following code could be used:
 
-```handlebars
-{{! app/templates/components/my-select.hbs}}
+```app/templates/components/my-select.hbs
 <select {{action 'change' on='change'}}>
   {{#each content key="@index" as |item|}}
     <option value="{{item}}" selected={{is-equal item selectedValue}}>
@@ -761,8 +746,7 @@ dropdown options, the following code could be used:
 </select>
 ```
 
-```javascript
-// app/components/my-select.js
+```app/components/my-select.js
 import Ember from "ember";
 
 export default Ember.Component.extend({
@@ -793,9 +777,8 @@ export default Ember.Component.extend({
 });
 ```
 
-```javascript
+```app/helpers/is-equal.js
 // is-equal helper is necessary to determine which option is currently selected.
-// app/helpers/is-equal.js
 import Ember from "ember";
 
 export default Ember.Helper.helper(function([leftSide, rightSide]) {
@@ -806,9 +789,7 @@ export default Ember.Helper.helper(function([leftSide, rightSide]) {
 This component could be used in a template by supplying it an array of strings
 as `content` and an action to call when the user makes a selection as `change`:
 
-```handlebars
-{{! app/templates/application.hbs}}
-
+```app/templates/application.hbs
 The currently selected item: {{mySelectedItem}}.
 
 {{! myItems is an array of strings: ['first', 'second', 'third',...] }}
@@ -840,8 +821,7 @@ Legacy support of `Ember.ContainerView` will be provided via the [ember-legacy-v
 
 In most cases container view can be replaced using the `{{each}}` helper in combination with the `{{component}}` helper.
 
-```javascript
-// app/components/component-container.js
+```app/components/component-container.js
 import Ember from 'ember';
 
 export default Ember.Component.extend({
@@ -850,8 +830,7 @@ export default Ember.Component.extend({
 })
 ```
 
-```handlebars
-{{! app/templates/components/component-container.hbs }}
+```app/templates/components/component-container.hbs
 {{#each childComponents as |childComponent|}}
   {{component childComponent}}
 {{/each}}
@@ -869,8 +848,7 @@ In most cases collection view can be replaced using the `{{each}}` helper in com
 
 To be able to programmatically decide which component to use for an item, you can use a `Ember.Helper`
 
-```javascript
-// app/helpers/animal-component.js
+```app/helpers/animal-component.js
 import Ember from 'ember';
 
 export default Ember.Helper.extend({
@@ -883,20 +861,17 @@ export default Ember.Helper.extend({
 
 Then if you have these two components:
 
-```handlebars
-{{! app/templates/components/dog-component.hbs }}
+```app/templates/components/dog-component.hbs
 {{animal.name}} is a dog!
 ```
 
-```handlebars
-{{! app/templates/components/cat-component.hbs }}
+```app/templates/components/cat-component.hbs
 {{animal.name}} is a cat!
 ```
 
 Then you can render your different animals like this:
 
-```javascript
-// app/controllers/animals.js
+```app/controllers/animals.js
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
@@ -907,8 +882,7 @@ export default Ember.Controller.extend({
 });
 ```
 
-```handlebars
-{{! app/templates/animals.hbs}}
+```app/templates/animals.hbs
 <ul>
 {{#each animals as |animal|}}
   <li>
@@ -1116,7 +1090,7 @@ Along with `Ember.ArrayController`, `Ember.SortableMixin` will be removed in Emb
 
 You can migrate away from using `Ember.SortableMixin` by using `Ember.computed.sort`. Using this example:
 
-```
+```js
 const SongsController = Ember.ArrayController.extend(Ember.SortableMixin, {
   model: null,
   sortProperties: ['trackNumber'],
@@ -1128,7 +1102,7 @@ let songsController = SongsController.create({ songs: songList });
 
 You can transition to using `Ember.computed.sort` like this:
 
-```
+```js
 const SongsController = Ember.Controller.extend({
   model: null,
   sortedSongs: Ember.computed.sort('model', 'songSorting'),
@@ -1159,19 +1133,24 @@ where the key now implicitly defaults to `@identity`, which will pick either a g
 of each array entry. Therefore, providing the key attribute is no longer required for re-render optimizations.
 
 Applications should replace instances of:
-```hbs
+
+```handlebars
 {{#each people key='@guid' as |person|}}
 ...
 {{/each}}
 ```
+
 and
-```hbs
+
+```handlebars
 {{#each people key='@item' as |person|}}
 ...
 {{/each}}
 ```
+
 with
-```hbs
+
+```handlebars
 {{#each people as |person|}}
 ...
 {{/each}}
@@ -1431,23 +1410,20 @@ This makes it possible to express a number of concepts directly in the template 
 
 Ember 1.11's attribute binding syntax no longer supports dasherizing for boolean values. For example:
 
-```component
-// app/components/user-profile.js
+```app/components/user-profile.js
 export default Ember.Component.extend({
   isActiveUser: true
 });
 ```
 
-```handlebars
-{{! app/templates/components/user-profile.hbs }}
+```app/templates/components/user-profile.hbs
 <div {{bind-attr class="isActiveUser"}}>
 </div>
 ```
 
 Should be replaced with:
 
-```handlebars
-{{! app/templates/components/user-profile.hbs }}
+```app/templates/components/user-profile.hbs
 <div class="{{if isActiveUser 'is-active-user'}}">
 </div>
 ```
@@ -1588,8 +1564,7 @@ a component with the same name as the view helper you registered.
 
 If you have for example:
 
-```javascript
-// app/helpers/foo-bar.js
+```app/helpers/foo-bar.js
 export default Ember.HTMLBars.makeBoundHelper(function(firstArg, secondArg, options) {
   let { hash } = options;
   // helper code

--- a/source/deprecations/v2.x.html.md
+++ b/source/deprecations/v2.x.html.md
@@ -107,9 +107,7 @@ Please refactor from using `appInstance.container.lookup` to `appInstance.lookup
 
 Before:
 
-```javascript
-// app/initializers/preload-store.js
-
+```app/initializers/preload-store.js
 export function initialize(appInstance) {
   let store = appInstance.container.lookup('service:store');
 
@@ -124,9 +122,7 @@ export default {
 
 After:
 
-```javascript
-// app/instance-initializers/preload-store.js
-
+```app/instance-initializers/preload-store.js
 export function initialize(appInstance) {
   let store = appInstance.lookup('service:store');
 
@@ -343,13 +339,13 @@ anything inside the block are incorrect) that prevent continued support.
 
 Support the following forms will be removed after 2.4:
 
-```hbs
+```handlebars
 {{#render 'foo'}}
   <p>Stuff Here</p>
 {{/render}}
 ```
 
-```hbs
+```handlebars
 {{#render 'foo' someModel}}
   <p>Stuff Here</p>
 {{/render}}
@@ -367,7 +363,7 @@ available after calling `this._super(...arguments)`
 
 Given a htmlbars template like this:
 
-```hbs
+```handlebars
 {{my-component handle="@tomdale"}}
 ```
 
@@ -403,17 +399,15 @@ components. Please refactor to a component and invoke thusly:
 
 For example, if you had:
 
-```hbs
+```handlebars
 {{render 'foo-bar' someModel}}
 ```
 
-```hbs
-{{! app/templates/foo-bar.hbs }}
+```app/templates/foo-bar.hbs }}
 <p>{{someProp}} template stuff here</p>
 ```
 
-```js
-// app/controllers/foo-bar.js
+```app/controllers/foo-bar.js
 export default Controller.extend({
   someProp: Ember.computed('model.yolo', function() {
     return this.get('model.yolo');
@@ -423,17 +417,15 @@ export default Controller.extend({
 
 Would be refactored to:
 
-```hbs
+```handlebars
 {{foo-bar model=someModel}}
 ```
 
-```hbs
-{{! app/templates/components/foo-bar.hbs }}
+```app/templates/components/foo-bar.hbs
 <p>{{someProp}} template stuff here</p>
 ```
 
-```js
-// app/components/foo-bar.js
+```app/components/foo-bar.js
 export default Component.extend({
   someProp: Ember.computed('model.yolo', function() {
     return this.get('model.yolo');
@@ -707,34 +699,30 @@ Please refactor uses of this helper to components:
 
 For example, if you had:
 
-```hbs
+```handlebars
 {{render 'my-sidebar'}}
 ```
 
-```hbs
-{{! app/templates/my-sidebar.hbs }}
+```app/templates/my-sidebar.hbs
 <p>template stuff here</p>
 ```
 
-```js
-// app/controllers/my-sidebar.js
+```app/controllers/my-sidebar.js
 export default Ember.Controller.extend({
 });
 ```
 
 You would refactor to a component like so:
 
-```hbs
+```handlebars
 {{my-sidebar}}
 ```
 
-```hbs
-{{! app/templates/components/my-sidebar.hbs }}
+```app/templates/components/my-sidebar.hbs
 <p>template stuff here</p>
 ```
 
-```js
-// app/components/my-sidebar.js
+```app/components/my-sidebar.js
 export default Ember.Component.extend({
 });
 ```
@@ -754,19 +742,16 @@ Before named outlets were introduced to Ember the render helper was used to decl
 
 For example this code uses the render helper as a target for a special sidebar present on the index route. The special sidebar is in a template named `index-sidebar`:
 
-```hbs
-{{! app/templates/application.hbs }}
+```app/templates/application.hbs
 <div class="sidebar">{{render 'sidebar'}}</div>
 <div class="main">{{outlet}}</div>
 ```
 
-```hbs
-{{! app/templates/index.hbs }}
+```app/templates/index.hbs
 Index Content
 ```
 
-```js
-// app/routes/index.js
+```app/routes/index.js
 App.IndexRoute = Ember.Route.extend({
   renderTemplate() {
     this._super(...arguments);
@@ -785,14 +770,12 @@ App.IndexRoute = Ember.Route.extend({
 
 It should be refactored to use [ember-elsewhere](https://github.com/ef4/ember-elsewhere). The sidebar content must be implemented as a component, in this case named `index-sidebar`. The logic previously used in the route file can be removed. The refactored example:
 
-```hbs
-{{! app/templates/application.hbs }}
+```app/templates/application.hbs
 <div class="sidebar">{{from-elsewhere name='sidebar'}}</div>
 <div class="main">{{outlet}}</div>
 ```
 
-```hbs
-{{! app/templates/index.hbs }}
+```app/templates/index.hbs
 {{to-elsewhere named='sidebar' send=(component 'index-sidebar')}}
 Index Content
 ```
@@ -846,7 +829,7 @@ Addon creators and maintainers can use [ember-factory-for-polyfill](https://gith
 
 Before:
 
-```
+```js
 export default Component.extend(
   init() {
     this._super(...arguments);
@@ -858,7 +841,7 @@ export default Component.extend(
 
 After:
 
-```
+```js
 export default Component.extend(
   init() {
     this._super(...arguments);
@@ -870,7 +853,7 @@ export default Component.extend(
 
 Any methods or properties of the factory can be accessed through the `class` property when using `factoryFor`.
 
-```
+```js
 let factory = owner.factoryFor('widget:slow');
 let klass = factory.class;
 klass.hasSpeed('slow'); // true
@@ -891,7 +874,7 @@ Imagine you have a component that stores a timestamp when it is initialized.
 
 Before:
 
-``` javascript
+```javascript
 Ember.Component.extend({
   didInitAttrs({ attrs }) {
     this.set('initialTimestamp', attrs.timestamp);
@@ -901,7 +884,7 @@ Ember.Component.extend({
 
 After:
 
-``` javascript
+```javascript
 Ember.Component.extend({
   init() {
     this._super(...arguments);
@@ -916,7 +899,7 @@ This example for `didReceiveAttrs` below also applies to `didUpdateAttrs`, a sim
 
 Before:
 
-``` javascript
+```javascript
 Ember.Component.extend({
   didReceiveAttrs({ oldAttrs, newAttrs }) {
     if (oldAttrs.temp !== newAttrs.temp) {
@@ -928,7 +911,7 @@ Ember.Component.extend({
 
 After:
 
-``` javascript
+```javascript
 Ember.Component.extend({
   didReceiveAttrs() {
     let oldTemp = this.get('_oldTemp');

--- a/source/stylesheets/highlight.css.scss
+++ b/source/stylesheets/highlight.css.scss
@@ -146,6 +146,16 @@ body.guides .highlight {
     background-color: #eaffea;
     color: #55a532;
   }
+
+  thead {
+    background-color: #f9e7e4;
+  }
+
+  th,
+  td {
+    padding: 5px 10px;
+  }
+
 }
 
 .handlebars {


### PR DESCRIPTION
* Fix code syntax highlighting on non-blog pages. They now properly render code blocks with a file name.
* Clean up many code block languages, either use a file name or use a language where proper.
* Use `handlebars` instead of `hbs`.