### PR TITLE
Correct link to PhantomJS maintenance announcement

### DIFF
--- a/source/blog/2017-09-01-ember-2-15-released.md
+++ b/source/blog/2017-09-01-ember-2-15-released.md
@@ -337,7 +337,7 @@ has, however, been a proxy for what we really want to test– the browsers that
 users are running.
 
 Now that we can easily test in headless Chrome the motivation for using
-PhantomJS has diminished, and as a result it is [no longer actively maintained](https://chromium.googlesource.com/chromium/src/+/lkgr/headless/README.md).
+PhantomJS has diminished, and as a result it is [no longer actively maintained](https://groups.google.com/d/msg/phantomjs/9aI5d-LDuNE/5Z3SMZrqAQAJ).
 
 #### app.import files within node_modules
 


### PR DESCRIPTION
Hey, I noticed this link was the same as the previous one, I think it probably was meant to be a link to the announcement. 😀 