### PR TITLE
Update Ember-Data Deprecations

### DIFF
--- a/source/deprecations/ember-data/v2.x.html.md
+++ b/source/deprecations/ember-data/v2.x.html.md
@@ -364,13 +364,10 @@ store.findRecord('post', 1).then(function() {
 
 `lookupSerializer` has been deprecated in favor of using `serializerFor`.
 
-### Deprecations Added in Pending Features
-
 #### Store.serialize
 
 ###### until: 3.0.0
 ###### id: ds.store.serialize
-###### feature: ds-deprecate-store-serialize
 
 `Store.serialize` has been deprecated in favor of
 [`Model.serialize`](http://emberjs.com/api/data/classes/DS.Model.html#method_serialize)
@@ -391,20 +388,61 @@ let post = this.store.peekRecord('post', 123);
 post.serialize();
 ```
 
+### Deprecations Added in Ember Data 2.12
+
 #### JSONSerializer.shouldSerializeHasMany
 
 ###### until: 3.0.0
 ###### id: ds.serializer.private-should-serialize-has-many
-###### feature: ds-check-should-serialize-relationships
 
 The private method `_shouldSerializeHasMany` has been promoted to the public
 API. To remove this deprecation, please remove the underscore to use the public
 [`shouldSerializeHasMany`](http://emberjs.com/api/data/classes/DS.JSONSerializer.html#method_shouldSerializeHasMany)
 method.
 
-#### HasManyReference.push(array)
+### Deprecations Added in Ember Data 2.13
+
+#### Unused Initializers
 
 ###### until: 3.0.0
+###### id: ds.deprecated-initializers
+
+The Ember Data initializers `data-adapter`, `injectStore`, `transforms`, and `store` are no longer used, so they are being removed.
+Applications that depend on these for the ordering of their own custom initializers can substitute `ember-data` instead, without any change in functionality.
+
+Before:
+
+```javascript
+export function initialize(application) {
+  // ... your code ...
+};
+
+export default {
+  name: 'websocketInit',
+  after: 'store',
+  initialize: initialize
+};
+```
+
+After:
+
+```javascript
+export function initialize(application) {
+  // ... your code ...
+};
+
+export default {
+  name: 'websocketInit',
+  after: 'ember-data',
+  initialize: initialize
+};
+```
+
+### Deprecations Added in Pending Features
+
+#### HasManyReference.push(array)
+
+###### until: 4.0.0
 ###### id: ds.references.has-many.push-array
 ###### feature: ds-overhaul-references
 
@@ -442,7 +480,7 @@ post.hasMany('comments').push(commentsData);
 
 #### HasManyReference.push Invalid Data
 
-###### until: 3.0.0
+###### until: 4.0.0
 ###### id: ds.references.has-many.push-invalid-json-api
 ###### feature: ds-overhaul-references
 
@@ -485,7 +523,7 @@ post.hasMany('comments').push(commentsData);
 
 #### BelongsToReference.push(DS.Model)
 
-###### until: 3.0.0
+###### until: 4.0.0
 ###### id: ds.references.belongs-to.push-record
 ###### feature: ds-overhaul-references
 
@@ -515,7 +553,7 @@ post.set('author', author);
 
 #### JSONAPISerializer.modelNameFromPayloadKey for Resource
 
-###### until: 3.0.0
+###### until: 4.0.0
 ###### id: ds.json-api-serializer.deprecated-model-name-for-resource
 ###### feature: ds-payload-type-hooks
 
@@ -569,7 +607,7 @@ export default DS.JSONAPISerializer.extend({
 
 #### JSONAPISerializer.modelNameFromPayloadKey for Relationship
 
-###### until: 3.0.0
+###### until: 4.0.0
 ###### id: ds.json-api-serializer.deprecated-model-name-for-relationship
 ###### feature: ds-payload-type-hooks
 
@@ -583,7 +621,7 @@ information.
 
 #### JSONAPISerializer.payloadKeyFromModelName for Resource
 
-###### until: 3.0.0
+###### until: 4.0.0
 ###### id: ds.json-api-serializer.deprecated-payload-type-for-model
 ###### feature: ds-payload-type-hooks
 
@@ -633,7 +671,7 @@ export default DS.JSONAPISerializer.extend({
 
 #### JSONAPISerializer.payloadKeyFromModelName for belongsTo Relationship
 
-###### until: 3.0.0
+###### until: 4.0.0
 ###### id: ds.json-api-serializer.deprecated-payload-type-for-belongs-to
 ###### feature: ds-payload-type-hooks
 
@@ -647,7 +685,7 @@ information.
 
 #### JSONAPISerializer.payloadKeyFromModelName for hasMany Relationship
 
-###### until: 3.0.0
+###### until: 4.0.0
 ###### id: ds.json-api-serializer.deprecated-payload-type-for-has-many
 ###### feature: ds-payload-type-hooks
 
@@ -658,39 +696,3 @@ Using `JSONAPISerializer.payloadKeyFromModelName` to serialize the type of a
 See [JSONAPISerializer.payloadKeyFromModelName for
 Resource](#toc_jsonapiserializer-payloadkeyfrommodelname-for-resource) for more
 information.
-
-#### Unused Initializers
-
-###### until: 3.0.0
-###### id: ds.deprecated-initializers
-
-The Ember Data initializers `data-adapter`, `injectStore`, `transforms`, and `store` are no longer used, so they are being removed.
-Applications that depend on these for the ordering of their own custom initializers can substitute `ember-data` instead, without any change in functionality.
-
-Before:
-
-```javascript
-export function initialize(application) {
-  // ... your code ...
-};
-
-export default {
-  name: 'websocketInit',
-  after: 'store',
-  initialize: initialize
-};
-```
-
-After:
-
-```javascript
-export function initialize(application) {
-  // ... your code ...
-};
-
-export default {
-  name: 'websocketInit',
-  after: 'ember-data',
-  initialize: initialize
-};
-```


### PR DESCRIPTION
* Store.serialize deprecation was in 2.11 (https://www.emberjs.com/blog/2017/01/23/ember-2-11-released.html#toc_deprecations-in-ember-data-2-11)
* JSONSerializes.shouldSerializeHasMany was in 2.12  (https://github.com/emberjs/data/commit/388c475c776860b15be05dc49ad8a883bc834bce) although the blog post and changelog don't seem to reflect this https://www.emberjs.com/blog/2017/03/19/ember-2-12-released.html#toc_deprecations-in-ember-data-2-12
* Unused initializers was in 2.13 (https://www.emberjs.com/blog/2017/04/29/ember-2-13-released.html#toc_deprecations-in-ember-data-2-13 https://github.com/emberjs/data/commit/223767fa0011cb0e6e84e15997e8470b3dfa6d2f)
* Change all deprecations in "pending features" to 4.0. This will also need to be done in the Ember-Data codebase.