### PR TITLE
 Blog typography update

### DIFF
--- a/source/stylesheets/blog.css.scss
+++ b/source/stylesheets/blog.css.scss
@@ -121,16 +121,23 @@ body.blog.responsive {
 }
 
 article.blog-post {
+  font-family: "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;  
   h1 {
     background-position: left 9px;
     text-transform: none;
     font-size: 34px;
     min-height: 34px;
     padding-left: 25px;
+    color: #E04E39;
   }
 
   h2 {
-    margin: 35px 0;
+    text-transform: capitalize;
+    &.anchorable-toc {
+      margin-top: 1.8em !important;
+      font-size: 1.66667em; //to match elsewhere
+
+    }
   }
 
   h3.blog-post-author,
@@ -163,10 +170,16 @@ article.blog-post {
   }
 
   .chapter {
+    font-family: "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
+    font-size: 16px;
+    line-height: 1.5;
+
     h1 {
       padding-bottom: 0.5em;
     }
-
+    h2 {
+      text-transform: capitalize;
+    }
     ul,
     ol {
       margin-left: $list-indent;

--- a/source/stylesheets/blog.css.scss
+++ b/source/stylesheets/blog.css.scss
@@ -170,13 +170,10 @@ article.blog-post {
   }
 
   .chapter {
-    font-family: "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
-    font-size: 16px;
-    line-height: 1.5;
-
     h1 {
       padding-bottom: 0.5em;
     }
+
     h2 {
       text-transform: capitalize;
     }


### PR DESCRIPTION
Intended to resolve issue #3004 

**Updated css for blog to normalize with the guides section:**
- switched typography back to Helvetica
- normalized font-sizes and line-height
- normalized h2 margin-top (should help resolve some vertical rhythm issues)

Attached is a screenshot of what the changes should look like when rendered in the browser (compared to the Guides section):
![ember-website-3004](https://user-images.githubusercontent.com/4587451/31201235-94a76044-a923-11e7-9cf2-32c2d110ee03.JPG)

Other work to-do: 
- normalize headers across the site to use uniform colors and margins; remove use of !important

