### PR TITLE
Put Helvetica Neue back in for better iOS

### DIFF
--- a/source/stylesheets/base/_variables.scss
+++ b/source/stylesheets/base/_variables.scss
@@ -1,5 +1,5 @@
 // Typography
-$base-font-family: 'Source Sans Pro', sans-serif;
+$base-font-family: 'Helvetica Neue','Source Sans Pro', sans-serif;
 $heading-font-family: $base-font-family;
 $monospace-font-family: Menlo, Courier, monospace;
 $footer-font-family: proxima-nova, sans-serif;


### PR DESCRIPTION
Since iOS doesn't render Google Fonts very well at all, putting Helvetica Neue first should help resolve some issues where Source Sans Pro looks great on any other device but iOS.