### PR TITLE
remove the two tomster images from the asset_hash for social use.

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -14,7 +14,12 @@ set :markdown,
   :lax_html_blocks => true,
   :renderer => Highlighter::HighlightedHTML.new
 
-activate :asset_hash, :ignore => [/^sw/]
+activate :asset_hash, :ignore => [
+  /^sw/,
+  'tomster-sm.png',
+  'tomster-twitter-card.png'
+]
+
 activate :directory_indexes
 activate :toc
 activate :sponsors


### PR DESCRIPTION
addresses: https://github.com/emberjs/website/issues/3018

looks like middleman just doesn't want to deal with urls in meta tags.
though based off this: https://docs.datocms.com/middleman/seo.html there may be a gem or something to more properly handle fingerprinted full-url assets ref'd in meta.