### PR TITLE
change api docs link in blog post to one that works

### DIFF
--- a/source/blog/2017-10-11-ember-2-16-released.md
+++ b/source/blog/2017-10-11-ember-2-16-released.md
@@ -70,7 +70,7 @@ code, documentation, generators/blueprints, and more. We've made the following
 changes to prepare for the shift in usage:
 
 * The [Ember.js
-API documentation](https://emberjs.com/api/ember) and
+API documentation](https://emberjs.com/api/) and
 [Ember guides](https://guides.emberjs.com/v2.16.0/) have been updated to reflect the new API.
 * The [application
 blueprints](https://github.com/ember-cli/ember-cli/tree/master/blueprints/app)


### PR DESCRIPTION
currently https://emberjs.com/api/ works but https://emberjs.com/api/ember does not, so lets use the former in the blog post so people can navigate over to see the docs updates