### PR TITLE
Fix wrong font-family on blog

### DIFF
--- a/source/stylesheets/blog.css.scss
+++ b/source/stylesheets/blog.css.scss
@@ -121,7 +121,6 @@ body.blog.responsive {
 }
 
 article.blog-post {
-  font-family: "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;  
   h1 {
     background-position: left 9px;
     text-transform: none;


### PR DESCRIPTION
Removes an extra font-family on the blog. With this change, it'll use Source Sans Pro, like the rest of emberjs.com. 