### PR TITLE
Dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM dockerizedember/website-dev:latest
+FROM emberjs/website-dev:latest
 
 # Customizations for this project here.
 # e.g.: if you have dependencies in addition to what the base image provides:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM dockerizedember/website-dev:latest
+
+# Customizations for this project here.
+# e.g.: if you have dependencies in addition to what the base image provides:
+ADD Gemfile /src/Gemfile
+ADD Gemfile.lock /src/Gemfile.lock
+RUN bundle install
+
+ADD . /src

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ The website for the Ember.js project.
 
 To get started:
 
+## Running locally with Docker (recommended)
+
+## Running locally with Ruby and Middleman
+
 ``` sh
 git clone https://github.com/emberjs/website.git
 cd website

--- a/README.md
+++ b/README.md
@@ -9,6 +9,28 @@ To get started:
 
 ## Running locally with Docker (recommended)
 
+This is the recommended method for new contributors.
+Although the website is built with Ruby, most work is done in Markdown files.
+You don't need to know Ruby or install its dependencies to help out. Simply follow
+the Docker container instructions below to install and run locally.
+
+First, install [Docker and Compose](https://store.docker.com/search?offering=community&type=edition) and leave it running.
+
+Next, the commands below will install all necessary dependencies for the website
+app and start a server. This will take a little while to run,
+possibly a few minutes. The dependencies will be installed inside a Docker
+container, and do not affect your normal developer environment. 
+
+```sh
+git clone git://github.com/emberjs/website.git
+cd website
+docker-compose build
+docker-compose up
+```
+Subsequent runs will be much faster once all the dependencies are installed. 
+
+You can view the site locally at [http://localhost:4567](http://localhost:4567)
+
 ## Running locally with Ruby and Middleman
 
 ``` sh

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To get started:
 
 This is the recommended method for new contributors.
 Although the website is built with Ruby, most work is done in Markdown files.
-You don't need to know Ruby or install its dependencies to help out. Simply follow
+You don't need to know Ruby or install its dependencies to help out. Follow
 the Docker container instructions below to install and run locally.
 
 First, install [Docker and Compose](https://store.docker.com/search?offering=community&type=edition) and leave it running.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2'
+services:
+  guides:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    command: bundle exec middleman
+    ports:
+      - "4567:4567"
+    volumes:
+      - .:/src


### PR DESCRIPTION
Just copys from the guides repo.

Since all the setup stuff is going to be the exact same, instead of  copying all the readme pieces everywhere, should we have a central location where all the middleman/website docs are?