### PR TITLE
updating slider css to be contained on mobile devices

### DIFF
--- a/source/stylesheets/pages/about.css.scss
+++ b/source/stylesheets/pages/about.css.scss
@@ -55,15 +55,15 @@
 
 #content .users.section {
   .surround {
-    width: 940px;
-    margin: 0 auto;
-    padding-top: 19px;
-
-    border-radius: 3px;
-    box-shadow: inset 0 1px 2px rgba(0,0,0,0.1), 0 1px 0 #fff;
     @include clearfix;
     background-color: #FFF;
+    border-radius: 3px;
     border: 1px solid #d1d1d1;
+    box-shadow: inset 0 1px 2px rgba(0,0,0,0.1), 0 1px 0 #fff;
+    margin: 0 auto;
+    max-width: 100%;
+    padding-top: 19px;
+    width: 940px;
 
     a:hover {
       border: 0;
@@ -76,6 +76,7 @@
     .bx-wrapper,
     .bx-window {
       width: 940px;
+      max-width: 100%;
     }
 
     .bx-wrapper {
@@ -160,7 +161,12 @@
   .user {
     position: relative;
     float: left;
-    width: 230px;
+    @media screen and (min-width: 0px) and (max-width:767px) {
+      width: 50%;
+    }
+    @media screen and (min-width:768px) {
+      width: 230px;
+    }
 
     &.empty {
       display: block;


### PR DESCRIPTION
- alpha-sorted the CSS properties
- added a max-width to contain the slider on smaller screens
- added media queries for the user images but this probably won't work, we should really just update the slider (newer versions are responsive) if we can't replace it immediately. 