### PR TITLE
adding contribute link to bottom of pages

### DIFF
--- a/source/about.html.erb
+++ b/source/about.html.erb
@@ -112,3 +112,4 @@ $(function() {
     Donate
   </a>
 </div>
+<div class="cta-contribute"><a href="https://github.com/emberjs/website" title="Use Github to suggest an edit to this page">Contribute to this page.</a></div>

--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -93,3 +93,4 @@ responsive: true
 
   <a class="ember-button ember-button--centered ember-button--community" href="../tomster">Meet the Mascots</a>
 </div>
+<div class="cta-contribute"><a href="https://github.com/emberjs/website" title="Use Github to suggest an edit to this page">Contribute to this page.</a></div>

--- a/source/ember-users.html.erb
+++ b/source/ember-users.html.erb
@@ -40,3 +40,4 @@ responsive: true
 </p>
 
 </div>
+<div class="cta-contribute"><a href="https://github.com/emberjs/website" title="Use Github to suggest an edit to this page">Contribute to this page.</a></div>

--- a/source/guidelines.html.erb
+++ b/source/guidelines.html.erb
@@ -86,7 +86,7 @@ title: "Community"
 <p>
 	As always, for issues, bug reports, pull requests, docs, etc., <a href="https://github.com/emberjs/">GitHub</a> is still the right place to go.
 </p>
-
+<div class="cta-contribute"><a href="https://github.com/emberjs/website" title="Use Github to suggest an edit to this page">Contribute to this page.</a></div>
 
 
 

--- a/source/learn/examples.html.erb
+++ b/source/learn/examples.html.erb
@@ -35,4 +35,5 @@ responsive: true
         <% end %>
     </div>
 </div>
+<div class="cta-contribute"><a href="https://github.com/emberjs/website" title="Use Github to suggest an edit to this page">Contribute to this page.</a></div>
 <% end %>

--- a/source/sponsors.html.erb
+++ b/source/sponsors.html.erb
@@ -43,3 +43,4 @@ responsive: true
   <p class="thanks">A special thanks to <a href="https://dribbble.com/mg">Matt Grantham</a> for design of the original Ember website.</p>
 
 </div>
+<div class="cta-contribute"><a href="https://github.com/emberjs/website" title="Use Github to suggest an edit to this page">Contribute to this page.</a></div>

--- a/source/stylesheets/base/_typography.scss
+++ b/source/stylesheets/base/_typography.scss
@@ -1,3 +1,5 @@
+@import "variables";
+
 html {
 	font-size: 16px;
 }
@@ -97,4 +99,20 @@ ol {
 
 p {
   margin: 1em 0;
+}
+.cta-contribute {
+  display: block;
+  margin: 0 auto;
+  max-width: 100%;
+  padding: 0.2em 0;
+  text-align: center;
+  a {
+    color: $orange-darker;
+    padding: 1em;
+    text-decoration: underline;
+    &:hover, :focus {
+      color: $orange-darkest;
+      cursor: pointer;
+    }
+  }
 }

--- a/source/team.html.erb
+++ b/source/team.html.erb
@@ -111,3 +111,4 @@ subteams.sort_by! {|u| [u.type, u.name] }
 </ul>
 
 </div>
+<div class="cta-contribute"><a href="https://github.com/emberjs/website" title="Use Github to suggest an edit to this page">Contribute to this page.</a></div>


### PR DESCRIPTION
Resolves #3007 

- added cta to bottom of page templates
-- is there a better way to abstract this/ 
-- how can this be added to guides/api/builds etc. 
- added styles for cta

Should look like this: 
![image](https://user-images.githubusercontent.com/4587451/33528536-a9d02e14-d827-11e7-93ec-ccc31d544d38.png)
