### PR TITLE
Ember 2.18 Release Blog Post

### DIFF
--- a/source/blog/2018-01-01-ember-2-18-released.md
+++ b/source/blog/2018-01-01-ember-2-18-released.md
@@ -37,21 +37,7 @@ bugfixes, performance improvements, and minor deprecations.
 
 #### Deprecations in Ember 2.18
 
-Deprecations are added to Ember.js when an API will be removed at a later date.
-
-Each deprecation has an entry in the deprecation guide describing the migration
-path to more stable API. Deprecated public APIs are not removed until a major
-release of the framework.
-
-Consider using the
-[ember-cli-deprecation-workflow](https://github.com/mixonic/ember-cli-deprecation-workflow)
-addon if you would like to upgrade your application without immediately addressing
-deprecations.
-
-Two new deprecations are introduces in Ember.js 2.18:
-
-* TODO
-* TODO
+Ember 2.18 does not introduce new deprecations.
 
 For more details on changes in Ember.js 2.18, please review the
 [Ember.js 2.18.0 release page](https://github.com/emberjs/ember.js/releases/tag/v2.18.0).
@@ -67,13 +53,12 @@ To enable these developers to upgrade piecemeal, we have created the [ember=2=le
 The `ember-2-legacy` addon will enable developers to selectively opt into continuing to use removed APIs until a time when they can migrate away from them.
 
 The list of removed APIs is as follows:
+* TODO
+* TODO
 
 #### Deprecations in Ember.js 3.0
 
-Two new deprecations are introduces in Ember.js 3.0:
-
-* TODO
-* TODO
+No new deprecations are introduced in Ember.js 3.0.
 
 For more details on the upcoming changes in Ember.js 3.0, please review the
 [Ember.js 3.0.0-beta.1 release page](https://github.com/emberjs/ember.js/releases/tag/v3.0.0-beta.1).

--- a/source/blog/2018-01-01-ember-2-18-released.md
+++ b/source/blog/2018-01-01-ember-2-18-released.md
@@ -51,9 +51,18 @@ rendering, and dependency injection features.
 
 ### Changes in Ember.js 2.18
 
-Ember.js 2.18 is an incremental and backwards compatible release of Ember which
-includes minor bugfixes. No new features or public API deprecations are
+Ember.js 2.18 is an incremental and backwards compatible release which
+includes minor bug fixes. No new features or public API deprecations are
 introduced.
+
+2.18 is light on changes because we want the final release of the 2.x cycle to
+be as stable and battle-tested as possible. 2.8 is an LTS candidate, which means
+after six weeks it will be promoted to an LTS release. As an LTS release it
+will receive bug fixes until Ember 3.5 is released and security patches until
+Ember 3.9 is released.
+
+2.18 is the final release of Ember.js to support IE9, IE10, and PhantomJS. It is
+also the final release published for Bower.
 
 "Intimate API" refers to API surface that maintainers never intended to become
 public, but which still has some small use in the wild. 2.18.0 adds an intimate
@@ -67,7 +76,7 @@ For more details on changes in Ember.js 2.18, please review the
 ### Upcoming Changes in Ember.js 3.0
 
 Ember.js 3.0 is the first release in the 3.x series. It introduces no new
-public API or deprecations. Included are bugfixes and most importantly the removal of
+public API or deprecations. Instead, it is comprised of bug fixes and the removal of
 previously deprecated public API from the 2.x cycle. This release drops support
 for IE9, IE10, and PhantomJS.
 
@@ -75,21 +84,20 @@ for IE9, IE10, and PhantomJS.
 
 The public APIs removed in 3.0-beta.1 do not yet represent the complete list
 of removals planned for 3.0 stable.
-You can keep track of the effort on
-[emberjs/ember.js#15876](https://github.com/emberjs/ember.js/issues/15876).
-For an exhaustive list planned 3.0 removals and migration guidance see the
+For an exhaustive list of planned 3.0 removals and migration guidance see the
 [Ember.js 2.x deprecation guide](https://www.emberjs.com/deprecations/v2.x/)
-(any entry "until: 3.0").
+(any entry "until: 3.0") and the quest issue
+[emberjs/ember.js#15876](https://github.com/emberjs/ember.js/issues/15876).
 
-The list of public API removals included in 3.0-beta.1 is below.
+The list of public API removals included in 3.0-beta.1 are:
 
 * The `{{render}}` helper has been removed. Any remaining usage should be
   [migrated to components](https://emberjs.com/deprecations/v2.x/#toc_code-render-code-helper).
 * `didInitAttrs` is removed and can be [replaced with `init`](https://www.emberjs.com/deprecations/v2.x/#toc_ember-component-didinitattrs)
-* A form of declaring an observer where dependent keys are stated after the callback is removed. Dependent keys should be passed before the callback as described in the [API docs](https://emberjs.com/api/ember/2.17/classes/@ember%2Fobject/methods/observer?anchor=observer).
+* Declaring an observer with dependent keys after the callback is removed. Dependent keys should be passed before the callback as described in the [API docs](https://emberjs.com/api/ember/2.17/classes/@ember%2Fobject/methods/observer?anchor=observer).
 * `Enumerable#contains` and `Array#contains` methods are removed. Instead usage should be [replaced with `includes`](https://www.emberjs.com/deprecations/v2.x/#toc_enumerable-contains).
-* A behavior of `{{link-to}}` where `model` properties would be unwrapped from
-  a passed controller has been removed.
+* `{{link-to}}` unwrapped the `model` property from passed controllers. This
+  behavior has been removed.
 * Specifying `defaultLayout` on a component rather than [`layout`](https://www.emberjs.com/deprecations/v2.x/#toc_ember-component-defaultlayout) has been removed.
 * `Ember.Handlebars.SafeString` has been removed. Instead, use [`Ember.String.htmlSafe`](https://www.emberjs.com/deprecations/v2.x/#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring) or the `import { htmlSafe } from '@ember/string'`.
 * `Ember.K` has been removed. Usage should be replaced with [inline functions](https://www.emberjs.com/deprecations/v2.x/#toc_deprecations-added-in-2-12).
@@ -100,7 +108,7 @@ The list of public API removals included in 3.0-beta.1 is below.
 Further planned public API removals for 3.0 include:
 
 * Ember's legacy binding system, including `Ember.Binding` and the `fooBinding`
-  microsyntax. See the [migration guide](https://emberjs.com/deprecations/v2.x/#toc_ember-binding) for details.
+  micro-syntax. See the [migration guide](https://emberjs.com/deprecations/v2.x/#toc_ember-binding) for details.
 * Ember's `Map`, `MapWithDefault`, and `OrderedSet` classes. These should be
   replaced with native features or with implementations from other libraries.
 
@@ -108,19 +116,27 @@ Please see [emberjs/ember.js#15876](https://github.com/emberjs/ember.js/issues/1
 for more details (including about previously deprecated private or intimate
 API removals) and updates during the beta cycle.
 
-#### Transitioning to 3.x with `ember-2-legacy`
+#### Transitioning to 3.x with ember-2-legacy
 
-Some developers might still be relying on some of these removed APIs.
-To enable these developers to upgrade piecemeal, we have created the [ember-2-legacy](https://github.com/emberjs/ember-2-legacy) addon.
+Public APIs removed in Ember.js 3.0 have each been ported to the
+[ember-2-legacy](https://github.com/emberjs/ember-2-legacy) addon. This addon
+makes it possible for applications to adopt 3.0 even if they still
+require features unsupported by the core of the framework.
 
-The `ember-2-legacy` addon will enable developers to selectively opt into continuing to use removed APIs until a time when they can migrate away from them.
+This addon will not include support for removed intimate or private APIs, nor
+will it enable support for IE9, IE10, PhantomJS, or Bower. In [The Road to Ember
+3.0](https://www.emberjs.com/blog/2017/10/03/the-road-to-ember-3-0.html#toc_transitioning-to-3-0)
+we committed to support this addon through Ember.js 3.4, the first LTS
+candidate of the 3.x cycle.
 
-#### Browser Support in Ember.js 3.0
+#### Other Ember.js 3.0 Changes
 
-The Ember 3.x series will also drop support for Internet Explorer 9 and 10. Earlier this year, Microsoft [announced end of life](https://www.microsoft.com/en-us/WindowsForBusiness/End-of-IE-support) for these browser versions, ending their own technical and security updates.
+Ember.js 3.0 removes support for IE9,
+IE 10, and PhantomJS. For more details about this decision see
+[RFC 252](https://github.com/emberjs/rfcs/blob/master/text/0252-browser-support-changes.md)
+and the discussion on [RFC PR #252](https://github.com/emberjs/rfcs/pull/252).
 
-Finally, Ember 3.0 will not be published on Bower. 2.18 will be the last release
-of Ember published to Bower.
+Finally, Ember.js 3.0 will not be published for Bower.
 
 For more details on the upcoming changes in Ember.js 3.0, please review the
 [Ember.js 3.0.0-beta.1 release page](https://github.com/emberjs/ember.js/releases/tag/v3.0.0-beta.1).
@@ -136,9 +152,7 @@ Ember Data is the official data persistence library for Ember.js applications.
 Ember Data 2.18 contains no new features. The changes introduced in
 Ember Data 2.18 mostly focus on bug fixes and improved documentation.
 
-#### Deprecations in Ember Data 2.18
-
-One new deprecation is introduced in Ember Data 2.18:
+One public API deprecation targeting **Ember Data 4.0** is introduced in Ember Data 2.18:
 
 * Support for "production-like" values of `EMBER_ENV` [will be removed](https://github.com/emberjs/data/pull/5239).
 For example, custom production names like `production-qa` should be replaced with `production`
@@ -155,9 +169,7 @@ that are shipped with Ember Data and used by Ember CLI when you use
 work on the [QUnit Blueprints Quest
 Issue](https://github.com/emberjs/data/issues/5292).
 
-#### Deprecations in Ember Data 3.0
-
-There are no new deprecations in Ember Data 3.0.
+There are no deprecations introduced in Ember Data 3.0.
 
 For more details on the upcoming changes in Ember Data 3.0, please review the
 [Ember Data 3.0.0-beta.1 release page](https://github.com/emberjs/data/releases/tag/v3.0.0-beta.1).
@@ -169,29 +181,21 @@ For more details on the upcoming changes in Ember Data 3.0, please review the
 Ember CLI is the command line interface for managing and packaging Ember.js
 applications.
 
-### Upgrading Ember CLI
-
-You may upgrade Ember CLI separately from Ember.js and Ember Data! To upgrade
-your projects using `yarn` run:
-
-```
-yarn upgrade ember-cli
-```
-
-To upgrade your projects using `npm` run:
-
-```
-npm install --save-dev ember-cli
-```
-
-After running the
-upgrade command run `ember init` inside of the project directory to apply the
-blueprint changes. You can preview those changes for [applications](https://github.com/ember-cli/ember-new-output/compare/v2.17.0...v2.18.0)
-and [addons](https://github.com/ember-cli/ember-addon-output/compare/v2.17.0...v2.18.0).
-
 ### Changes in Ember CLI 2.18
 
-Ember CLI 2.18 is an incremental release, featuring bugfixes and improvements.
+Ember CLI 2.18 is an incremental release featuring bug fixes and improvements.
+This release does not introduce any new deprecations.
+
+#### ESLint configuration changes
+
+Newly generate Ember applications will now have only a single `.eslintrc.js`
+file. This file uses the "overrides" feature of ESLint to customize rules
+appropriately for test or Node.js files.
+
+For more details see:
+
+* [ember-cli/ember-cli#7443](https://github.com/ember-cli/ember-cli/pull/7443) Use overrides for a single `.eslintrc.js`.
+* [ember-cli/ember-cli#7455](https://github.com/ember-cli/ember-cli/pull/7455) Add eslint-plugin-ember to default linting config.
 
 #### Node 7 removed from CI testing matrix
 
@@ -203,23 +207,14 @@ If you are developing an application using Ember CLI, it is recommended that you
 
 Previously, if you were npm-linking an addon that had itself npm-linked a dependency, Ember CLI would fail to find it. This is now fixed.
 
-#### `crossdomain.xml` from blueprints
+#### `crossdomain.xml` removed for new applications
 
-`crossdomain.xml` was originally introduced to limit vulnerabilities with using the Flash Player,
-by declaring which servers it could connect to outside the one currently hosting it.
+`crossdomain.xml` was originally introduced to limit vulnerabilities when
+using the Flash Player.
+It did this by declaring which hosts the Flash Player could connect to outside
+the one hosting the file.
 Browsers have since disabled Flash for security reasons, rendering the file moot.
-Ember CLI 2.18 will no longer generate the file when generating new applications.
-
-#### ESLint default configuration and overriding
-
-* #7443 Use overrides for a single .eslintrc.js. @rwjblue
-* #7455 Add eslint-plugin-ember to default linting config. @rwjblue
-
-I guess the biggest user-facing change is the ESLint thing. We now only have a single .eslintrc.js file and that includes eslint-plugin-ember by default.
-
-#### Deprecations in Ember CLI 2.18
-
-Ember CLI 2.18 does not introduce new deprecations
+Ember CLI 2.18 will no longer generate the file for new applications.
 
 For more details on the changes in Ember CLI 2.18 and detailed upgrade
 instructions, please review the [Ember CLI 2.18.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/v2.18.0).
@@ -234,9 +229,7 @@ The improvements include:
 * A "License" section
 * [Setext headings](http://spec.commonmark.org/0.28/#setext-heading) to emphasize sections when in raw text mode.
 
-#### Deprecations in Ember CLI 3.0
-
-Ember CLI 3.0 does not introduce new deprecations.
+Ember CLI 3.0 does not introduce any new deprecations.
 
 For more details on the changes in Ember CLI 3.0.0-beta.1 and detailed upgrade
 instructions, please review the [Ember CLI 3.0.0-beta.1 release page](https://github.com/ember-cli/ember-cli/releases/tag/v3.0.0-beta.1).

--- a/source/blog/2018-01-01-ember-2-18-released.md
+++ b/source/blog/2018-01-01-ember-2-18-released.md
@@ -132,19 +132,52 @@ and [addons](https://github.com/ember-cli/ember-addon-output/compare/v2.17.0...v
 
 ### Changes in Ember CLI 2.18
 
+Ember CLI 2.18 is an incremental release, featuring bugfixes and improvements.
+
+#### Node 7 removed from CI testing matrix
+
+According to the [Node.js support policy]() of the Ember CLI project,
+Node 7 is removed from the testing matrix.
+If you are developing an application using Ember CLI, it is recommended that you upgrade your Node to one of the [active LTS]() versions to guarantee security updates.
+
+#### Addon dependencies when using npm link
+
+Previously, if you were npm-linking an addon that had itself npm-linked a dependency, Ember CLI would fail to find it. This is now fixed.
+
+#### `crossdomain.xml` from blueprints
+
+`crossdomain.xml` was originally introduced to limit vulnerabilities with using the Flash Player,
+by declaring which servers it could connect to outside the one currently hosting it.
+Browsers have since disabled Flash for security reasons, rendering the file moot.
+Ember CLI 2.18 will no longer generate the file when generating new applications.
+
+#### ESLint default configuration and overriding
+
+* #7443 Use overrides for a single .eslintrc.js. @rwjblue
+* #7455 Add eslint-plugin-ember to default linting config. @rwjblue
+
+I guess the biggest user-facing change is the ESLint thing. We now only have a single .eslintrc.js file and that includes eslint-plugin-ember by default.
+
 #### Deprecations in Ember CLI 2.18
 
-Two new deprecations are introduces in Ember CLI 2.18:
-
-* TODO
-* TODO
+Ember CLI 2.18 does not introduce new deprecations
 
 For more details on the changes in Ember CLI 2.18 and detailed upgrade
 instructions, please review the [Ember CLI 2.18.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/v2.18.0).
 
 ### Upcoming Changes in Ember CLI 3.0
 
+Ember CLI 3.0 will feature a much improved README for the addon blueprint.
+The improvements include:
+
+* An automatically generated "Installation" section
+* An empty "Usage" section
+* A "License" section
+* [Setext headings](http://spec.commonmark.org/0.28/#setext-heading) to emphasize sections when in raw text mode.
+
 #### Deprecations in Ember CLI 3.0
+
+Ember CLI 3.0 does not introduce new deprecations.
 
 For more details on the changes in Ember CLI 3.0.0-beta.1 and detailed upgrade
 instructions, please review the [Ember CLI 3.0.0-beta.1 release page](https://github.com/ember-cli/ember-cli/releases/tag/v3.0.0-beta.1).

--- a/source/blog/2018-01-01-ember-2-18-released.md
+++ b/source/blog/2018-01-01-ember-2-18-released.md
@@ -190,7 +190,7 @@ This release does not introduce any new deprecations.
 
 Newly generate Ember applications will now have only a single `.eslintrc.js`
 file. This file uses the "overrides" feature of ESLint to customize rules
-appropriately for test or Node.js files.
+appropriately for test or Node files.
 
 For more details see:
 
@@ -199,7 +199,7 @@ For more details see:
 
 #### Node 7 removed from CI testing matrix
 
-According to the [Node.js support policy](https://github.com/ember-cli/ember-cli/blob/master/docs/node-support.md) of the Ember CLI project,
+According to the [Node support policy](https://github.com/ember-cli/ember-cli/blob/master/docs/node-support.md) of the Ember CLI project,
 Node 7 is removed from the testing matrix.
 If you are developing an application using Ember CLI, it is recommended that you upgrade your Node to one of the [active LTS](https://github.com/nodejs/Release) versions to guarantee security updates.
 

--- a/source/blog/2018-01-01-ember-2-18-released.md
+++ b/source/blog/2018-01-01-ember-2-18-released.md
@@ -10,7 +10,7 @@ and Ember CLI.
 **After 2.5 years and 18 minor releases, Ember 2.18 marks the end of the project's 2.x series**.
 To ensure a smooth upgrade path going into the 3.x series, 2.18 has been
 declared an LTS candidate. In six weeks the latest 2.18 build will succeed
-Ember 2.16.2 as the latest LTS release. As an LTS it will
+Ember 2.16.2 as the latest LTS release. As an LTS, it will
 receive bug fixes until Ember 3.5 is released.
 
 **Today we also kick off the 3.0 beta cycle for all sub-projects.** Ember 3.0
@@ -56,8 +56,8 @@ includes minor bug fixes. No new features or public API deprecations are
 introduced.
 
 2.18 is light on changes because we want the final release of the 2.x cycle to
-be as stable and battle-tested as possible. 2.8 is an LTS candidate, which means
-after six weeks it will be promoted to an LTS release. As an LTS release it
+be as stable and battle-tested as possible. 2.18 is an LTS candidate, which means
+that after six weeks it will be promoted to an LTS release. As an LTS release it
 will receive bug fixes until Ember 3.5 is released and security patches until
 Ember 3.9 is released.
 

--- a/source/blog/2018-01-01-ember-2-18-released.md
+++ b/source/blog/2018-01-01-ember-2-18-released.md
@@ -48,13 +48,22 @@ Ember.js 3.0 represents the first release in the 3,0 series.
 Repeating what happened in the previous cycle, Ember 3.0 will remove a number of public APIs.
 
 Some developers might still be relying on some of these removed APIs.
-To enable these developers to upgrade piecemeal, we have created the [ember=2=legacy]() addon.
+To enable these developers to upgrade piecemeal, we have created the [ember=2=legacy](https://github.com/emberjs/ember-2-legacy) addon.
 
 The `ember-2-legacy` addon will enable developers to selectively opt into continuing to use removed APIs until a time when they can migrate away from them.
 
-The list of removed APIs is as follows:
-* TODO
-* TODO
+Developers should reference the [2.x series deprecation guide](https://www.emberjs.com/deprecations/v2.x/) to see which pieces of public API will be removed in 3.x and how to migrate.
+
+Public APIs to be removed in 3.0 are as follows:
+* `didInitAttrs` is removed and can be [replaced with `init`](https://www.emberjs.com/deprecations/v2.x/#toc_ember-component-didinitattrs)
+* One form of declaring an `observer` where dependent keys are stated after the callback (they should go before the callback as described in the [API docs](https://emberjs.com/api/ember/2.17/classes/@ember%2Fobject/methods/observer?anchor=observer))
+* Enumerable and Array `contains` should be [replaced with `includes`](https://www.emberjs.com/deprecations/v2.x/#toc_enumerable-contains)
+* Providing `{{link-to}}` with a param wrapped in a controller
+* Specifying `defaultLayout` to a component, rather than [layout](https://www.emberjs.com/deprecations/v2.x/#toc_ember-component-defaultlayout)
+* Using `Ember.Handlebars.SafeString` [instead of `Ember.String.htmlSafe`](https://www.emberjs.com/deprecations/v2.x/#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring)
+* `Ember.K` should be replaced with [inline functions](https://www.emberjs.com/deprecations/v2.x/#toc_deprecations-added-in-2-12)
+
+The Ember 3.x series will also drop support for Internet Explorer 9 and 10. Earlier this year, Microsoft [announced end of life](https://www.microsoft.com/en-us/WindowsForBusiness/End-of-IE-support) for these browser versions, ending their own technical and security updates.
 
 #### Deprecations in Ember.js 3.0
 
@@ -121,9 +130,9 @@ Ember CLI 2.18 is an incremental release, featuring bugfixes and improvements.
 
 #### Node 7 removed from CI testing matrix
 
-According to the [Node.js support policy]() of the Ember CLI project,
+According to the [Node.js support policy](https://github.com/ember-cli/ember-cli/blob/master/docs/node-support.md) of the Ember CLI project,
 Node 7 is removed from the testing matrix.
-If you are developing an application using Ember CLI, it is recommended that you upgrade your Node to one of the [active LTS]() versions to guarantee security updates.
+If you are developing an application using Ember CLI, it is recommended that you upgrade your Node to one of the [active LTS](https://github.com/nodejs/Release) versions to guarantee security updates.
 
 #### Addon dependencies when using npm link
 

--- a/source/blog/2018-01-01-ember-2-18-released.md
+++ b/source/blog/2018-01-01-ember-2-18-released.md
@@ -12,6 +12,11 @@ any bugs before they are published as a final release in six weeks' time. The
 [ember-try](https://github.com/ember-cli/ember-try) addon is a great way to
 continuously test your projects against the latest Ember releases.
 
+After 2.5 years and 18 minor releases, Ember 2.18 marks the end of the 2.x series.
+As the last release in the series, 2.18 is an LTS candidate to ensure a smooth upgrade path going into the 3.x series.
+
+You can see the full release schedule up to 3.5 in [“The Road to Ember 3.0”](https://www.emberjs.com/blog/2017/10/03/the-road-to-ember-3-0.html).
+
 You can read more about our general release process here:
 
 * [Release Dashboard](http://emberjs.com/builds/)
@@ -53,10 +58,15 @@ For more details on changes in Ember.js 2.18, please review the
 
 ### Upcoming Changes in Ember.js 3.0
 
-Ember.js 3.0 will introduce two new features:
+Ember.js 3.0 represents the first release in the 3,0 series.
+Repeating what happened in the previous cycle, Ember 3.0 will remove a number of public APIs.
 
-* TODO
-* TODO
+Some developers might still be relying on some of these removed APIs.
+To enable these developers to upgrade piecemeal, we have created the [ember=2=legacy]() addon.
+
+The `ember-2-legacy` addon will enable developers to selectively opt into continuing to use removed APIs until a time when they can migrate away from them.
+
+The list of removed APIs is as follows:
 
 #### Deprecations in Ember.js 3.0
 

--- a/source/blog/2018-01-01-ember-2-18-released.md
+++ b/source/blog/2018-01-01-ember-2-18-released.md
@@ -1,12 +1,12 @@
 ---
-title: Ember 2.18 and 2.19 Beta Released
+title: Ember 2.18 and 3.0 Beta Released
 author: Ricardo Mendes
 tags: Releases
 ---
 
 Today the Ember project is releasing version 2.18.0 of Ember.js, Ember Data, and Ember CLI.
 
-This release kicks off the 2.19 beta cycle for all sub-projects. We encourage our
+This release kicks off the 3.0 beta cycle for all sub-projects. We encourage our
 community (especially addon authors) to help test these beta builds and report
 any bugs before they are published as a final release in six weeks' time. The
 [ember-try](https://github.com/ember-cli/ember-try) addon is a great way to
@@ -14,10 +14,10 @@ continuously test your projects against the latest Ember releases.
 
 You can read more about our general release process here:
 
-- [Release Dashboard](http://emberjs.com/builds/)
-- [The Ember Release Cycle](http://emberjs.com/blog/2013/09/06/new-ember-release-process.html)
-- [The Ember Project](http://emberjs.com/blog/2015/06/16/ember-project-at-2-0.html)
-- [Ember LTS Releases](http://emberjs.com/blog/2016/02/25/announcing-embers-first-lts.html)
+* [Release Dashboard](http://emberjs.com/builds/)
+* [The Ember Release Cycle](http://emberjs.com/blog/2013/09/06/new-ember-release-process.html)
+* [The Ember Project](http://emberjs.com/blog/2015/06/16/ember-project-at-2-0.html)
+* [Ember LTS Releases](http://emberjs.com/blog/2016/02/25/announcing-embers-first-lts.html)
 
 ---
 
@@ -51,22 +51,22 @@ Two new deprecations are introduces in Ember.js 2.18:
 For more details on changes in Ember.js 2.18, please review the
 [Ember.js 2.18.0 release page](https://github.com/emberjs/ember.js/releases/tag/v2.18.0).
 
-### Upcoming Changes in Ember.js 2.19
+### Upcoming Changes in Ember.js 3.0
 
-Ember.js 2.19 will introduce two new features:
-
-* TODO
-* TODO
-
-#### Deprecations in Ember.js 2.19
-
-Two new deprecations are introduces in Ember.js 2.19:
+Ember.js 3.0 will introduce two new features:
 
 * TODO
 * TODO
 
-For more details on the upcoming changes in Ember.js 2.19, please review the
-[Ember.js 2.19.0-beta.1 release page](https://github.com/emberjs/ember.js/releases/tag/v2.19.0-beta.1).
+#### Deprecations in Ember.js 3.0
+
+Two new deprecations are introduces in Ember.js 3.0:
+
+* TODO
+* TODO
+
+For more details on the upcoming changes in Ember.js 3.0, please review the
+[Ember.js 3.0.0-beta.1 release page](https://github.com/emberjs/ember.js/releases/tag/v3.0.0-beta.1).
 
 ---
 
@@ -86,14 +86,12 @@ Two new deprecations are introduces in Ember Data 2.18:
 For more details on changes in Ember Data 2.18, please review the
 [Ember Data 2.18.0 release page](https://github.com/emberjs/data/releases/tag/v2.18.0).
 
+### Upcoming changes in Ember Data 3.0
 
-### Upcoming changes in Ember Data 2.19
+#### Deprecations in Ember Data 3.0
 
-
-#### Deprecations in Ember Data 2.19
-
-For more details on the upcoming changes in Ember Data 2.19, please review the
-[Ember Data 2.19.0-beta.1 release page](https://github.com/emberjs/data/releases/tag/v2.19.0-beta.1).
+For more details on the upcoming changes in Ember Data 3.0, please review the
+[Ember Data 3.0.0-beta.1 release page](https://github.com/emberjs/data/releases/tag/v3.0.0-beta.1).
 
 ---
 
@@ -132,14 +130,14 @@ Two new deprecations are introduces in Ember CLI 2.18:
 * TODO
 
 For more details on the changes in Ember CLI 2.18 and detailed upgrade
-instructions, please review the [Ember CLI  2.18.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/v2.18.0).
+instructions, please review the [Ember CLI 2.18.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/v2.18.0).
 
-### Upcoming Changes in Ember CLI 2.19
+### Upcoming Changes in Ember CLI 3.0
 
-#### Deprecations in Ember CLI 2.19
+#### Deprecations in Ember CLI 3.0
 
-For more details on the changes in Ember CLI 2.19.0-beta.1 and detailed upgrade
-instructions, please review the [Ember CLI 2.19.0-beta.1 release page](https://github.com/ember-cli/ember-cli/releases/tag/v2.19.0-beta.1).
+For more details on the changes in Ember CLI 3.0.0-beta.1 and detailed upgrade
+instructions, please review the [Ember CLI 3.0.0-beta.1 release page](https://github.com/ember-cli/ember-cli/releases/tag/v3.0.0-beta.1).
 
 ## Thank You!
 

--- a/source/blog/2018-01-01-ember-2-18-released.md
+++ b/source/blog/2018-01-01-ember-2-18-released.md
@@ -19,6 +19,12 @@ all of which have been deprecated since at least Ember 2.14 (released July 2017)
 Extended support for removed Ember.js APIs will be provided via an
 optional addon through Ember 3.4.
 
+Additionally Ember 3.0 removes support for Microsoft Internet Explorer 9,
+IE 10, and PhantomJS. This includes support for these platforms by Ember.js,
+Ember Data, and Ember CLI. For more details about this decision see
+[RFC 252](https://github.com/emberjs/rfcs/blob/master/text/0252-browser-support-changes.md)
+and the discussion on [RFC PR #252](https://github.com/emberjs/rfcs/pull/252).
+
 We need the help of the Ember community (especially addon authors) to help test
 the 3.0 beta builds and transition path for 2.x codebases. If you encounter any
 unexpected changes in features not marked as deprecated in 2.18 while testing
@@ -60,9 +66,12 @@ For more details on changes in Ember.js 2.18, please review the
 
 ### Upcoming Changes in Ember.js 3.0
 
-Ember.js 3.0 represents the first release in the 3.0 series.
-Repeating what happened in the previous cycle,
-Ember 3.0 will remove a number of public APIs.
+Ember.js 3.0 is the first release in the 3.x series. It introduces no new
+public API or deprecations. Included are bugfixes and most importantly the removal of
+previously deprecated public API from the 2.x cycle. This release drops support
+for IE9, IE10, and PhantomJS.
+
+#### Removed APIs in Ember.js 3.0
 
 Some developers might still be relying on some of these removed APIs.
 To enable these developers to upgrade piecemeal, we have created the [ember-2-legacy](https://github.com/emberjs/ember-2-legacy) addon.
@@ -81,11 +90,9 @@ Public APIs to be removed in 3.0 are as follows:
 * Using `Ember.Handlebars.SafeString` [instead of `Ember.String.htmlSafe`](https://www.emberjs.com/deprecations/v2.x/#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring)
 * `Ember.K` should be replaced with [inline functions](https://www.emberjs.com/deprecations/v2.x/#toc_deprecations-added-in-2-12)
 
+#### Browser Support in Ember.js 3.0
+
 The Ember 3.x series will also drop support for Internet Explorer 9 and 10. Earlier this year, Microsoft [announced end of life](https://www.microsoft.com/en-us/WindowsForBusiness/End-of-IE-support) for these browser versions, ending their own technical and security updates.
-
-#### Deprecations in Ember.js 3.0
-
-No new deprecations are introduced in Ember.js 3.0.
 
 For more details on the upcoming changes in Ember.js 3.0, please review the
 [Ember.js 3.0.0-beta.1 release page](https://github.com/emberjs/ember.js/releases/tag/v3.0.0-beta.1).

--- a/source/blog/2018-01-01-ember-2-18-released.md
+++ b/source/blog/2018-01-01-ember-2-18-released.md
@@ -105,7 +105,7 @@ Ember Data is the official data persistence library for Ember.js applications.
 
 ### Changes in Ember Data 2.18
 
-Ember.js 2.18 contains no new features. The changes introduced in
+Ember.js Data 2.18 contains no new features. The changes introduced in
 Ember Data 2.18 mostly focus on bug fixes and improved documentation.
 
 #### Deprecations in Ember Data 2.18
@@ -121,7 +121,7 @@ For more details on changes in Ember Data 2.18, please review the
 ### Upcoming changes in Ember Data 3.0
 
 Ember Data 3.0 contains major improvements in the testing blueprints
-that are shipped with Ember Data and use by ember-cli when you use
+that are shipped with Ember Data and used by ember-cli when you use
 `ember generate` `model`, `adapter`, or `serializer`.  Big thanks to
 [@alexander-alvarez](https://github.com/alexander-alvarez) for all his
 work on the [QUnit Blueprints Quest

--- a/source/blog/2018-01-01-ember-2-18-released.md
+++ b/source/blog/2018-01-01-ember-2-18-released.md
@@ -82,10 +82,10 @@ Ember Data is the official data persistence library for Ember.js applications.
 
 #### Deprecations in Ember Data 2.18
 
-Two new deprecations are introduces in Ember Data 2.18:
+One new deprecation is introduced in Ember Data 2.18:
 
-* TODO
-* TODO
+* Support for "production-like" values of `EMBER_ENV` [will be removed](https://github.com/emberjs/data/pull/5239).
+For example, custom production names like `production-qa` should be replaced with `production`
 
 For more details on changes in Ember Data 2.18, please review the
 [Ember Data 2.18.0 release page](https://github.com/emberjs/data/releases/tag/v2.18.0).

--- a/source/blog/2018-01-01-ember-2-18-released.md
+++ b/source/blog/2018-01-01-ember-2-18-released.md
@@ -1,0 +1,149 @@
+---
+title: Ember 2.18 and 2.19 Beta Released
+author: Ricardo Mendes
+tags: Releases
+---
+
+Today the Ember project is releasing version 2.18.0 of Ember.js, Ember Data, and Ember CLI.
+
+This release kicks off the 2.19 beta cycle for all sub-projects. We encourage our
+community (especially addon authors) to help test these beta builds and report
+any bugs before they are published as a final release in six weeks' time. The
+[ember-try](https://github.com/ember-cli/ember-try) addon is a great way to
+continuously test your projects against the latest Ember releases.
+
+You can read more about our general release process here:
+
+- [Release Dashboard](http://emberjs.com/builds/)
+- [The Ember Release Cycle](http://emberjs.com/blog/2013/09/06/new-ember-release-process.html)
+- [The Ember Project](http://emberjs.com/blog/2015/06/16/ember-project-at-2-0.html)
+- [Ember LTS Releases](http://emberjs.com/blog/2016/02/25/announcing-embers-first-lts.html)
+
+---
+
+## Ember.js
+
+Ember.js is the core framework for building ambitious web applications.
+
+### Changes in Ember.js 2.18
+
+Ember.js 2.18 is an incremental, backwards compatible release of Ember with
+bugfixes, performance improvements, and minor deprecations.
+
+#### Deprecations in Ember 2.18
+
+Deprecations are added to Ember.js when an API will be removed at a later date.
+
+Each deprecation has an entry in the deprecation guide describing the migration
+path to more stable API. Deprecated public APIs are not removed until a major
+release of the framework.
+
+Consider using the
+[ember-cli-deprecation-workflow](https://github.com/mixonic/ember-cli-deprecation-workflow)
+addon if you would like to upgrade your application without immediately addressing
+deprecations.
+
+Two new deprecations are introduces in Ember.js 2.18:
+
+* TODO
+* TODO
+
+For more details on changes in Ember.js 2.18, please review the
+[Ember.js 2.18.0 release page](https://github.com/emberjs/ember.js/releases/tag/v2.18.0).
+
+### Upcoming Changes in Ember.js 2.19
+
+Ember.js 2.19 will introduce two new features:
+
+* TODO
+* TODO
+
+#### Deprecations in Ember.js 2.19
+
+Two new deprecations are introduces in Ember.js 2.19:
+
+* TODO
+* TODO
+
+For more details on the upcoming changes in Ember.js 2.19, please review the
+[Ember.js 2.19.0-beta.1 release page](https://github.com/emberjs/ember.js/releases/tag/v2.19.0-beta.1).
+
+---
+
+## Ember Data
+
+Ember Data is the official data persistence library for Ember.js applications.
+
+### Changes in Ember Data 2.18
+
+#### Deprecations in Ember Data 2.18
+
+Two new deprecations are introduces in Ember Data 2.18:
+
+* TODO
+* TODO
+
+For more details on changes in Ember Data 2.18, please review the
+[Ember Data 2.18.0 release page](https://github.com/emberjs/data/releases/tag/v2.18.0).
+
+
+### Upcoming changes in Ember Data 2.19
+
+
+#### Deprecations in Ember Data 2.19
+
+For more details on the upcoming changes in Ember Data 2.19, please review the
+[Ember Data 2.19.0-beta.1 release page](https://github.com/emberjs/data/releases/tag/v2.19.0-beta.1).
+
+---
+
+## Ember CLI
+
+Ember CLI is the command line interface for managing and packaging Ember.js
+applications.
+
+### Upgrading Ember CLI
+
+You may upgrade Ember CLI separately from Ember.js and Ember Data! To upgrade
+your projects using `yarn` run:
+
+```
+yarn upgrade ember-cli
+```
+
+To upgrade your projects using `npm` run:
+
+```
+npm install --save-dev ember-cli
+```
+
+After running the
+upgrade command run `ember init` inside of the project directory to apply the
+blueprint changes. You can preview those changes for [applications](https://github.com/ember-cli/ember-new-output/compare/v2.17.0...v2.18.0)
+and [addons](https://github.com/ember-cli/ember-addon-output/compare/v2.17.0...v2.18.0).
+
+### Changes in Ember CLI 2.18
+
+#### Deprecations in Ember CLI 2.18
+
+Two new deprecations are introduces in Ember CLI 2.18:
+
+* TODO
+* TODO
+
+For more details on the changes in Ember CLI 2.18 and detailed upgrade
+instructions, please review the [Ember CLI  2.18.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/v2.18.0).
+
+### Upcoming Changes in Ember CLI 2.19
+
+#### Deprecations in Ember CLI 2.19
+
+For more details on the changes in Ember CLI 2.19.0-beta.1 and detailed upgrade
+instructions, please review the [Ember CLI 2.19.0-beta.1 release page](https://github.com/ember-cli/ember-cli/releases/tag/v2.19.0-beta.1).
+
+## Thank You!
+
+As a community-driven open-source project with an ambitious scope, each of
+these releases serve as a reminder that the Ember project would not have been
+possible without your continued support. We are extremely grateful to our
+contributors for their efforts.

--- a/source/blog/2018-01-01-ember-2-18-released.md
+++ b/source/blog/2018-01-01-ember-2-18-released.md
@@ -1,6 +1,6 @@
 ---
 title: Ember 2.18 and 3.0 Beta Released
-author: Ricardo Mendes
+author: Ricardo Mendes, Matthew Beale, Brendan McLoughlin
 tags: Releases
 ---
 

--- a/source/blog/2018-01-01-ember-2-18-released.md
+++ b/source/blog/2018-01-01-ember-2-18-released.md
@@ -98,6 +98,9 @@ Ember Data is the official data persistence library for Ember.js applications.
 
 ### Changes in Ember Data 2.18
 
+Ember.js 2.18 contains no new features. The changes introduced in
+Ember Data 2.18 mostly focus on bug fixes and improved documentation.
+
 #### Deprecations in Ember Data 2.18
 
 One new deprecation is introduced in Ember Data 2.18:
@@ -110,7 +113,16 @@ For more details on changes in Ember Data 2.18, please review the
 
 ### Upcoming changes in Ember Data 3.0
 
+Ember Data 3.0 contains major improvements in the testing blueprints
+that are shipped with Ember Data and use by ember-cli when you use
+`ember generate` `model`, `adapter`, or `serializer`.  Big thanks to
+[@alexander-alvarez](https://github.com/alexander-alvarez) for all his
+work on the [QUnit Blueprints Quest
+Issue](https://github.com/emberjs/data/issues/5292).
+
 #### Deprecations in Ember Data 3.0
+
+There are no new deprecations in Ember Data 3.0.
 
 For more details on the upcoming changes in Ember Data 3.0, please review the
 [Ember Data 3.0.0-beta.1 release page](https://github.com/emberjs/data/releases/tag/v3.0.0-beta.1).

--- a/source/blog/2018-01-01-ember-2-18-released.md
+++ b/source/blog/2018-01-01-ember-2-18-released.md
@@ -4,18 +4,30 @@ author: Ricardo Mendes
 tags: Releases
 ---
 
-Today the Ember project is releasing version 2.18.0 of Ember.js, Ember Data, and Ember CLI.
+Today the Ember project is releasing version 2.18.0 of Ember.js, Ember Data,
+and Ember CLI.
 
-This release kicks off the 3.0 beta cycle for all sub-projects. We encourage our
-community (especially addon authors) to help test these beta builds and report
-any bugs before they are published as a final release in six weeks' time. The
-[ember-try](https://github.com/ember-cli/ember-try) addon is a great way to
-continuously test your projects against the latest Ember releases.
+**After 2.5 years and 18 minor releases, Ember 2.18 marks the end of the project's 2.x series**.
+To ensure a smooth upgrade path going into the 3.x series, 2.18 has been
+declared an LTS candidate. In six weeks the latest 2.18 build will succeed
+Ember 2.16.2 as the latest LTS release. As an LTS it will
+receive bugfix support until Ember 3.5 is released.
 
-After 2.5 years and 18 minor releases, Ember 2.18 marks the end of the 2.x series.
-As the last release in the series, 2.18 is an LTS candidate to ensure a smooth upgrade path going into the 3.x series.
+**Today we also kick off the 3.0 beta cycle for all sub-projects.** Ember 3.0
+introduces no new features. Instead, it removes support for deprecated public APIs,
+all of which have been deprecated since at least Ember 2.14 (released July 2017).
+Extended support for removed Ember.js APIs will be provided via an
+optional addon through Ember 3.4.
 
-You can see the full release schedule up to 3.5 in [“The Road to Ember 3.0”](https://www.emberjs.com/blog/2017/10/03/the-road-to-ember-3-0.html).
+We need the help of the Ember community (especially addon authors) to help test
+the 3.0 beta builds and transition path for 2.x codebases. If you encounter any
+unexpected changes in features not marked as deprecated in 2.18 while testing
+Ember 3.0 beta, please open an issue on the appropriate repo.
+
+You can read more about our detailed transition plans through Ember 3.5
+in
+[The Road to Ember 3.0](https://www.emberjs.com/blog/2017/10/03/the-road-to-ember-3-0.html)
+and below.
 
 You can read more about our general release process here:
 
@@ -28,33 +40,39 @@ You can read more about our general release process here:
 
 ## Ember.js
 
-Ember.js is the core framework for building ambitious web applications.
+Ember.js is the core of the Ember framework. It provides routing,
+rendering, and dependency injection features.
 
 ### Changes in Ember.js 2.18
 
-Ember.js 2.18 is an incremental, backwards compatible release of Ember with
-bugfixes, performance improvements, and minor deprecations.
+Ember.js 2.18 is an incremental and backwards compatible release of Ember which
+includes minor bugfixes. No new features or public API deprecations are
+introduced.
 
-#### Deprecations in Ember 2.18
-
-Ember 2.18 does not introduce new deprecations.
+"Intimate API" refers to API surface that maintainers never intended to become
+public, but which still has some small use in the wild. 2.18.0 adds an intimate
+API deprecation for passing `targetObject` to a component invocation. Support
+for this API will be removed in Ember 3.5. See
+[PR #14590](https://github.com/emberjs/ember.js/pull/14590) for more details.
 
 For more details on changes in Ember.js 2.18, please review the
 [Ember.js 2.18.0 release page](https://github.com/emberjs/ember.js/releases/tag/v2.18.0).
 
 ### Upcoming Changes in Ember.js 3.0
 
-Ember.js 3.0 represents the first release in the 3,0 series.
-Repeating what happened in the previous cycle, Ember 3.0 will remove a number of public APIs.
+Ember.js 3.0 represents the first release in the 3.0 series.
+Repeating what happened in the previous cycle,
+Ember 3.0 will remove a number of public APIs.
 
 Some developers might still be relying on some of these removed APIs.
-To enable these developers to upgrade piecemeal, we have created the [ember=2=legacy](https://github.com/emberjs/ember-2-legacy) addon.
+To enable these developers to upgrade piecemeal, we have created the [ember-2-legacy](https://github.com/emberjs/ember-2-legacy) addon.
 
 The `ember-2-legacy` addon will enable developers to selectively opt into continuing to use removed APIs until a time when they can migrate away from them.
 
 Developers should reference the [2.x series deprecation guide](https://www.emberjs.com/deprecations/v2.x/) to see which pieces of public API will be removed in 3.x and how to migrate.
 
 Public APIs to be removed in 3.0 are as follows:
+
 * `didInitAttrs` is removed and can be [replaced with `init`](https://www.emberjs.com/deprecations/v2.x/#toc_ember-component-didinitattrs)
 * One form of declaring an `observer` where dependent keys are stated after the callback (they should go before the callback as described in the [API docs](https://emberjs.com/api/ember/2.17/classes/@ember%2Fobject/methods/observer?anchor=observer))
 * Enumerable and Array `contains` should be [replaced with `includes`](https://www.emberjs.com/deprecations/v2.x/#toc_enumerable-contains)

--- a/source/blog/2018-01-01-ember-2-18-released.md
+++ b/source/blog/2018-01-01-ember-2-18-released.md
@@ -11,7 +11,7 @@ and Ember CLI.
 To ensure a smooth upgrade path going into the 3.x series, 2.18 has been
 declared an LTS candidate. In six weeks the latest 2.18 build will succeed
 Ember 2.16.2 as the latest LTS release. As an LTS it will
-receive bugfix support until Ember 3.5 is released.
+receive bug fixes until Ember 3.5 is released.
 
 **Today we also kick off the 3.0 beta cycle for all sub-projects.** Ember 3.0
 introduces no new features. Instead, it removes support for deprecated public APIs,
@@ -19,16 +19,16 @@ all of which have been deprecated since at least Ember 2.14 (released July 2017)
 Extended support for removed Ember.js APIs will be provided via an
 optional addon through Ember 3.4.
 
-Additionally Ember 3.0 removes support for Microsoft Internet Explorer 9,
+Ember 3.0 removes support for Microsoft Internet Explorer 9,
 IE 10, and PhantomJS. This includes support for these platforms by Ember.js,
 Ember Data, and Ember CLI. For more details about this decision see
 [RFC 252](https://github.com/emberjs/rfcs/blob/master/text/0252-browser-support-changes.md)
 and the discussion on [RFC PR #252](https://github.com/emberjs/rfcs/pull/252).
 
-We need the help of the Ember community (especially addon authors) to help test
+We need the help of the Ember community (especially addon authors) to test
 the 3.0 beta builds and transition path for 2.x codebases. If you encounter any
-unexpected changes in features not marked as deprecated in 2.18 while testing
-Ember 3.0 beta, please open an issue on the appropriate repo.
+unexpected changes while testing Ember 3.0 beta, especially in features not
+previously marked as deprecated by 2.14, please open an issue on the appropriate repo.
 
 You can read more about our detailed transition plans through Ember 3.5
 in
@@ -73,26 +73,54 @@ for IE9, IE10, and PhantomJS.
 
 #### Removed APIs in Ember.js 3.0
 
+The public APIs removed in 3.0-beta.1 do not yet represent the complete list
+of removals planned for 3.0 stable.
+You can keep track of the effort on
+[emberjs/ember.js#15876](https://github.com/emberjs/ember.js/issues/15876).
+For an exhaustive list planned 3.0 removals and migration guidance see the
+[Ember.js 2.x deprecation guide](https://www.emberjs.com/deprecations/v2.x/)
+(any entry "until: 3.0").
+
+The list of public API removals included in 3.0-beta.1 is below.
+
+* The `{{render}}` helper has been removed. Any remaining usage should be
+  [migrated to components](https://emberjs.com/deprecations/v2.x/#toc_code-render-code-helper).
+* `didInitAttrs` is removed and can be [replaced with `init`](https://www.emberjs.com/deprecations/v2.x/#toc_ember-component-didinitattrs)
+* A form of declaring an observer where dependent keys are stated after the callback is removed. Dependent keys should be passed before the callback as described in the [API docs](https://emberjs.com/api/ember/2.17/classes/@ember%2Fobject/methods/observer?anchor=observer).
+* `Enumerable#contains` and `Array#contains` methods are removed. Instead usage should be [replaced with `includes`](https://www.emberjs.com/deprecations/v2.x/#toc_enumerable-contains).
+* A behavior of `{{link-to}}` where `model` properties would be unwrapped from
+  a passed controller has been removed.
+* Specifying `defaultLayout` on a component rather than [`layout`](https://www.emberjs.com/deprecations/v2.x/#toc_ember-component-defaultlayout) has been removed.
+* `Ember.Handlebars.SafeString` has been removed. Instead, use [`Ember.String.htmlSafe`](https://www.emberjs.com/deprecations/v2.x/#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring) or the `import { htmlSafe } from '@ember/string'`.
+* `Ember.K` has been removed. Usage should be replaced with [inline functions](https://www.emberjs.com/deprecations/v2.x/#toc_deprecations-added-in-2-12).
+* Support for legacy initializers with two arguments (container, application)
+  has been removed in favor of
+  [a single argument of `application`](https://emberjs.com/deprecations/v2.x/#toc_initializer-arity).
+
+Further planned public API removals for 3.0 include:
+
+* Ember's legacy binding system, including `Ember.Binding` and the `fooBinding`
+  microsyntax. See the [migration guide](https://emberjs.com/deprecations/v2.x/#toc_ember-binding) for details.
+* Ember's `Map`, `MapWithDefault`, and `OrderedSet` classes. These should be
+  replaced with native features or with implementations from other libraries.
+
+Please see [emberjs/ember.js#15876](https://github.com/emberjs/ember.js/issues/15876)
+for more details (including about previously deprecated private or intimate
+API removals) and updates during the beta cycle.
+
+#### Transitioning to 3.x with `ember-2-legacy`
+
 Some developers might still be relying on some of these removed APIs.
 To enable these developers to upgrade piecemeal, we have created the [ember-2-legacy](https://github.com/emberjs/ember-2-legacy) addon.
 
 The `ember-2-legacy` addon will enable developers to selectively opt into continuing to use removed APIs until a time when they can migrate away from them.
 
-Developers should reference the [2.x series deprecation guide](https://www.emberjs.com/deprecations/v2.x/) to see which pieces of public API will be removed in 3.x and how to migrate.
-
-Public APIs to be removed in 3.0 are as follows:
-
-* `didInitAttrs` is removed and can be [replaced with `init`](https://www.emberjs.com/deprecations/v2.x/#toc_ember-component-didinitattrs)
-* One form of declaring an `observer` where dependent keys are stated after the callback (they should go before the callback as described in the [API docs](https://emberjs.com/api/ember/2.17/classes/@ember%2Fobject/methods/observer?anchor=observer))
-* Enumerable and Array `contains` should be [replaced with `includes`](https://www.emberjs.com/deprecations/v2.x/#toc_enumerable-contains)
-* Providing `{{link-to}}` with a param wrapped in a controller
-* Specifying `defaultLayout` to a component, rather than [layout](https://www.emberjs.com/deprecations/v2.x/#toc_ember-component-defaultlayout)
-* Using `Ember.Handlebars.SafeString` [instead of `Ember.String.htmlSafe`](https://www.emberjs.com/deprecations/v2.x/#toc_use-ember-string-htmlsafe-over-ember-handlebars-safestring)
-* `Ember.K` should be replaced with [inline functions](https://www.emberjs.com/deprecations/v2.x/#toc_deprecations-added-in-2-12)
-
 #### Browser Support in Ember.js 3.0
 
 The Ember 3.x series will also drop support for Internet Explorer 9 and 10. Earlier this year, Microsoft [announced end of life](https://www.microsoft.com/en-us/WindowsForBusiness/End-of-IE-support) for these browser versions, ending their own technical and security updates.
+
+Finally, Ember 3.0 will not be published on Bower. 2.18 will be the last release
+of Ember published to Bower.
 
 For more details on the upcoming changes in Ember.js 3.0, please review the
 [Ember.js 3.0.0-beta.1 release page](https://github.com/emberjs/ember.js/releases/tag/v3.0.0-beta.1).
@@ -105,7 +133,7 @@ Ember Data is the official data persistence library for Ember.js applications.
 
 ### Changes in Ember Data 2.18
 
-Ember.js Data 2.18 contains no new features. The changes introduced in
+Ember Data 2.18 contains no new features. The changes introduced in
 Ember Data 2.18 mostly focus on bug fixes and improved documentation.
 
 #### Deprecations in Ember Data 2.18
@@ -121,7 +149,7 @@ For more details on changes in Ember Data 2.18, please review the
 ### Upcoming changes in Ember Data 3.0
 
 Ember Data 3.0 contains major improvements in the testing blueprints
-that are shipped with Ember Data and used by ember-cli when you use
+that are shipped with Ember Data and used by Ember CLI when you use
 `ember generate` `model`, `adapter`, or `serializer`.  Big thanks to
 [@alexander-alvarez](https://github.com/alexander-alvarez) for all his
 work on the [QUnit Blueprints Quest


### PR DESCRIPTION

- [Rendered](https://github.com/emberjs/website/blob/2-18-release-blog-post/source/blog/2018-01-01-ember-2-18-released.md)
- Preview

## Sign-offs

- [ ] Ember.js (@chancancode)
- [x] Ember Data (@bmac)
- [ ] Ember CLI (@rwjblue)
- [ ] Website (@locks, @mixonic)

## Checklist

- Ember
  - [ ] Blog
  - [ ] v2.18.0
  - [ ] v2.19.0-beta.1
- Ember Data
  - [x] Blog
  - [x] v2.18.0
  - [x] v3.0.0-beta.1
- Ember CLI
  - [ ] Blog
  - [ ] v2.18.0
  - [ ] v2.19.0-beta.1

See https://github.com/emberjs/website/pull/2824/files for inspiration.