### PR TITLE
Remove reference to api doc being a good pwa example

### DIFF
--- a/data/showcase.yml
+++ b/data/showcase.yml
@@ -30,11 +30,10 @@
   repository: https://github.com/ember-learn/ember-api-docs
   demo: https://emberjs.com/api/
   description: |
-    This application was built to display our <a href="http://emberjs.com/api/">versioned API docs</a>. It is a good example of a <a href="https://www.smashingmagazine.com/2016/08/a-beginners-guide-to-progressive-web-apps/"><abbr title="Progressive Web App">PWA</abbr></a>.  You'll be able to learn about:
+    This application was built to display our <a href="http://emberjs.com/api/">versioned API docs</a>.  You'll be able to learn about:
   features:
-    - See a more full-featured Ember web app in action
+    - A more full-featured Ember web app in action
     - Usage of <a href="https://ember-fastboot.com/">Ember FastBoot</a>.
-    - Enabling <a href="https://developers.google.com/web/fundamentals/getting-started/primers/service-workers">service workers</a> and defining <a href="https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/">web app manifests</a> to enhance your ember apps into progressive web apps.
 # - name:
 #   image:
 #     src:


### PR DESCRIPTION
Ran across this text the other day on the learn page and felt it was a bit of false advertising since we never completed pwa support in api docs.  we may get there someday but we ran into issues with api docs being a proxied host to emberjs.com, and the rfc176-driven redesign took higher priority.