### PR TITLE
Issue 3103 - normalize styling for blog

### DIFF
--- a/source/blog/index.html.erb
+++ b/source/blog/index.html.erb
@@ -7,7 +7,7 @@ per_page: 10
 
 <% partial_for :head, 'head' %>
 <% partial_for :sidebar, 'sidebar' %>
-
+<h1>Ember Blog</h1>
 <% page_articles.each_with_index do |article, i| %>
   <article class="blog-post-summary">
     <h2 class="blog-post-title"><%= link_to article.title, article %> <time><%= article.date.strftime('%b %d, %Y') %></time></span></h2>
@@ -17,9 +17,9 @@ per_page: 10
       <span class="post-tag">Syndicated Post</span>
     <% end %>
     <% if article.data.author %>
-      <h5 class="blog-post-summary-author">
+      <p class="blog-post-summary-author">
         Posted By: <%= article.data.author %>
-      </h5>
+      </p>
     <% end %>
     <%= article.summary %>
     <%= link_to "Read more...", article, :class => "read-more" %>

--- a/source/layouts/blog.erb
+++ b/source/layouts/blog.erb
@@ -13,8 +13,8 @@
       <span class="post-tag">Syndicated Post</span>
     <% end %>
     <% if current_page.data.author %>
-      <h3 class="blog-post-author">By <%= current_page.data.author %></h3>
-      <h3 class="blog-post-date"><time><%= current_article.date.strftime('%B %-d, %Y') %></time></h3>
+      <div class="blog-post-author">By <%= current_page.data.author %></div>
+      <div class="blog-post-date"><time><%= current_article.date.strftime('%B %-d, %Y') %></time></div>
     <% end %>
 
     <hr>

--- a/source/stylesheets/base/_typography.scss
+++ b/source/stylesheets/base/_typography.scss
@@ -89,3 +89,6 @@ ol {
 p {
   margin: 1em 0;
 }
+.lead {
+  font-size: 1.3em;
+}

--- a/source/stylesheets/base/_variables.scss
+++ b/source/stylesheets/base/_variables.scss
@@ -11,6 +11,8 @@ $blue-lighter: #74b0ce;
 $gray: #454545;
 $gray-lighter: #999999;
 $gray-lightest: #eeeeee;
+$gray-darker: darken($gray, 10%);
+$gray-darkest: darken($gray, 15%);
 
 $linen: #f9e7e4; //white-darkest? but I think this is the same as brown-lightest aka "tan"
 

--- a/source/stylesheets/blog.css.scss
+++ b/source/stylesheets/blog.css.scss
@@ -124,17 +124,12 @@ article.blog-post {
   h1 {
     background-position: left 9px;
     text-transform: none;
-    font-size: 34px;
-    min-height: 34px;
-    padding-left: 25px;
-    color: #E04E39;
   }
 
   .blog-post-author,
   .blog-post-date {
     color: $gray;
-    margin-left: 25px;
-    font-size: 16px;
+    font-size: 1em;
     font-weight: normal;
     text-transform: none;
   }

--- a/source/stylesheets/blog.css.scss
+++ b/source/stylesheets/blog.css.scss
@@ -130,30 +130,21 @@ article.blog-post {
     color: #E04E39;
   }
 
-  h2 {
-    text-transform: capitalize;
-    &.anchorable-toc {
-      margin-top: 1.8em !important;
-      font-size: 1.66667em; //to match elsewhere
-
-    }
-  }
-
-  h3.blog-post-author,
-  h3.blog-post-date {
-    color: #777;
+  .blog-post-author,
+  .blog-post-date {
+    color: $gray;
     margin-left: 25px;
     font-size: 16px;
     font-weight: normal;
     text-transform: none;
   }
 
-  h3.blog-post-author {
-    color: #333;
+  .blog-post-author {
+    color: $black;
   }
 
   hr:first-of-type {
-    margin: 1em 0 1.5em;
+    margin-bottom: 1.5em;
   }
 
   li {
@@ -169,13 +160,6 @@ article.blog-post {
   }
 
   .chapter {
-    h1 {
-      padding-bottom: 0.5em;
-    }
-
-    h2 {
-      text-transform: capitalize;
-    }
     ul,
     ol {
       margin-left: $list-indent;

--- a/source/stylesheets/guides.css.scss
+++ b/source/stylesheets/guides.css.scss
@@ -2,24 +2,24 @@
 @import "mixins/hidpi";
 @import "base/typography";
 
-body.guides, body.blog, body.api {
+body.guides, body.api {
   p {
     margin: 1.5em 0;
     line-height: 1.5em;
-    color: #0c0c0c;//TODO replace with variable to ensure consistency
+    color: $black;
   }
 
   sup {
     vertical-align: super;
     font-weight: 100;
-    color: gray; //TODO replace with variable to ensure consistency
+    color: $gray; 
     font-size: 11px
   }
 
   code {
     font-family: Menlo, Courier, monospace;
     font-size: 90%;
-    color: #666; //TODO replace with variable to ensure consistency
+    color: $gray;
     background-color: rgba(0, 0, 0, 0.04); //TODO replace with variable to ensure consistency
     padding: 3px;
     border-radius: 5px;

--- a/source/stylesheets/pages/blog.css.scss
+++ b/source/stylesheets/pages/blog.css.scss
@@ -1,9 +1,16 @@
 @import 'base/variables';
 
+#content.has-sidebar {
+  h1 {
+    margin-top: 0; //get rid of this after you eliminate all of the #content CSS rules. 
+    border-bottom: 1px solid lightgray;
+  }
+}
 .blog {
   .blog-post-summary-author {
     font-size: 0.9em;
     color: $gray;
+    margin-top: 0;
   }
 
   article {
@@ -29,8 +36,8 @@
       margin-bottom: 0;
       time {
         display: block;
-        font-size: 0.6em;
-        color: $dark-gray;
+        font-size: 0.5em;
+        color: $gray-darker;
       }
     }
 

--- a/source/stylesheets/pages/blog.css.scss
+++ b/source/stylesheets/pages/blog.css.scss
@@ -10,6 +10,16 @@
   article.blog-post {
     h1 {
       border-bottom: none;
+      font-size: 2.9em; //TODO revisit h1 size, maybe we need to bump them all down one size
+      line-height: 1;
+      margin-bottom: 0;
+    }
+    h1, h2 {
+      + p {
+        &:first-of-type {
+          font-size: 1.3em;
+        }
+      }
     }
   }
 }

--- a/source/stylesheets/pages/blog.css.scss
+++ b/source/stylesheets/pages/blog.css.scss
@@ -1,15 +1,14 @@
 @import 'base/variables';
 
 .blog {
-  h5.blog-post-summary-author {
+  .blog-post-summary-author {
     font-size: 0.9em;
-    color: gray;//TODO replace with variable to ensure consistency
+    color: $gray;
   }
 
   article {
     margin: 0 0 3em 0;
     padding: 0 0 3em 0;
-
     border-bottom: solid 1px #e0e0e0;//TODO replace with variable to ensure consistency
 
     &:last-child {
@@ -26,43 +25,39 @@
       }
     }
 
-    h2.blog-post-title {
+    .blog-post-title {
       margin-bottom: 0;
       time {
         display: block;
-        font-size: 0.7em;
+        font-size: 0.6em;
         color: $dark-gray;
       }
     }
 
     .post-tag {
-      color: #4d4d4d;//TODO replace with variable to ensure consistency
+      color: $gray;
       font-size: 1em;
       font-weight: bold;
     }
 
     .blog-post-author {
       font-size: 10px;
-      color: gray;//TODO replace with variable to ensure consistency
+      color: $gray;
       top: 59px;
       margin-left: 45px;
     }
 
     .original-post-url {
-      color: gray;
+      color: $gray;
       font-size: 12px;
       text-transform: none;
-    }
-
-    h1 {
-      padding-bottom: 0;
     }
 
     figure {
       width: 100%;
       background-color: $white;
       padding: 10px;
-      border: 1px solid #cccccc; //TODO replace with variable to ensure consistency
+      border: 1px solid $gray-lightest; 
     }
 
     blockquote {

--- a/source/stylesheets/pages/blog.css.scss
+++ b/source/stylesheets/pages/blog.css.scss
@@ -6,6 +6,13 @@
     border-bottom: 1px solid lightgray;
   }
 }
+#content.has-sidebar {
+  article.blog-post {
+    h1 {
+      border-bottom: none;
+    }
+  }
+}
 .blog {
   .blog-post-summary-author {
     font-size: 0.9em;
@@ -35,9 +42,10 @@
     .blog-post-title {
       margin-bottom: 0;
       time {
+        color: $gray-darker;
         display: block;
         font-size: 0.5em;
-        color: $gray-darker;
+        margin-top: 7px; //so when you hover over the title, you don't chop off the top of the date. 
       }
     }
 
@@ -45,13 +53,6 @@
       color: $gray;
       font-size: 1em;
       font-weight: bold;
-    }
-
-    .blog-post-author {
-      font-size: 10px;
-      color: $gray;
-      top: 59px;
-      margin-left: 45px;
     }
 
     .original-post-url {


### PR DESCRIPTION
This PR resolves #3103 
- removed extra h1-h6 styling
- added h1 to blog page 
- removed gray color values and replaced with variable (consistency) 
- removed extra specificity for items that already had a specific enough class name. 
- removed classes that were defined in multiple files (kept only one definition)
- added some scoped styles to differentiate between main blog page and individual posts page(s).

Screenshot of blog page: 
![image](https://user-images.githubusercontent.com/4587451/34155752-33885f8c-e480-11e7-885f-cc8eb29bd6e6.png)

Screenshot of "Recent Posts": 
![image](https://user-images.githubusercontent.com/4587451/34155769-4a0fe6ee-e480-11e7-85c6-0d1bc1979ee8.png)

Screenshot of individual blog post page: 
![image](https://user-images.githubusercontent.com/4587451/34155705-08c69e12-e480-11e7-9b26-24b768ee5028.png)
