### PR TITLE
font mismatch on apple devices

### DIFF
--- a/source/stylesheets/base/_variables.scss
+++ b/source/stylesheets/base/_variables.scss
@@ -44,7 +44,7 @@ $content-width: $page-width - $sidebar-width - $col-spacing * 2;
 /* Typography */
 $base-line-height: 1.5;
 $list-indent: 32px;
-$base-font-family: 'Helvetica Neue','Source Sans Pro', sans-serif;
+$base-font-family: 'Source Sans Pro', 'Helvetica Neue', sans-serif;
 $heading-font-family: $base-font-family;
 $monospace-font-family: Menlo, Courier, monospace;
 $footer-font-family: proxima-nova, sans-serif;

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -31,6 +31,7 @@ $small-max-width: 767px;
 body {
   background-color: $white;
   font-family: $base-font-family;
+  font-weight: normal; //for iOS
   line-height: 1.5;
   color: #444444;
   -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
- font family declaration was in the wrong order, causing a mismatch between apple devices and everything else. 
- put them in the correct order; confirmed that it looks as intended on a macbook. 