### PR TITLE
updating some specific link styling

### DIFF
--- a/source/stylesheets/components/ember-button.css.scss
+++ b/source/stylesheets/components/ember-button.css.scss
@@ -1,7 +1,7 @@
 @import 'base/variables';
 
 .ember-button {
-  background-color: #E46651;
+  background-color: $orange;
   border-radius: 5px;
   box-shadow: 0 1px 0 rgba(255, 255, 255, 0.35);
   color: $white;
@@ -13,11 +13,15 @@
   text-align: center;
   text-decoration: none;
   text-transform: uppercase;
-  transition: 0.3s box-shadow;
+  transition: all 0.3s ease 0s;
   width: 220px;
 
   &:hover {
+    background-color: darken($orange, 2%);
+    border-bottom: none;
     box-shadow: 0px 2px 4px -1px #666;
+    color: white;
+    text-decoration:none;
     transform: translateY(-1px);
     transition: 0.3s translateY;
   }

--- a/source/stylesheets/pages/mascots.css.scss
+++ b/source/stylesheets/pages/mascots.css.scss
@@ -73,6 +73,10 @@
       text-transform: uppercase;
       flex-grow: 1;
       text-align: left;
+      &:hover, :focus {
+        border-bottom: none;
+        text-decoration: underline;
+      }
     }
 
     .date {


### PR DESCRIPTION
- resolved the issue where the mascot title links where getting a border-bottom instead of an underline on hover. The border-bottom usually works but doesn't here because of the way the link space is bigger than the text 
- updated the ember-button styling (used when links want to look like buttons) to use ember orange
- resolved the issue where these links-as-buttons were getting link treatment on hover instead of button treatment