### PR TITLE
Make the learning resources text be actual links, not just the symbol #3141

### DIFF
--- a/source/learn.html.erb
+++ b/source/learn.html.erb
@@ -11,9 +11,9 @@ responsive: true
     </p>
     
     <ul>
-      <li><strong>Quick start</strong> <a href="https://guides.emberjs.com/current/getting-started/quick-start/"><i class="icon-link-ext"></i></a>: An easy breezy introduction to the framework.</li>
-      <li><strong>Tutorial</strong> <a href="https://guides.emberjs.com/current/tutorial/ember-cli/"><i class="icon-link-ext"></i></a>: Follow our tutorial to build, and deploy, your first Ember.js application!</li>
-      <li><strong>Guides</strong> <a href="https://guides.emberjs.com/"><i class="icon-link-ext"></i></a>: Whether you're just getting started and want to get familiar with Ember, or you're looking to refresh your knowledge on a certain feature, the Guides are the place for you.</li>
+      <li> <a href="https://guides.emberjs.com/current/getting-started/quick-start/"><strong>Quick start</strong><i class="icon-link-ext"></i></a>: An easy breezy introduction to the framework.</li>
+      <li> <a href="https://guides.emberjs.com/current/tutorial/ember-cli/"><strong>Tutorial</strong><i class="icon-link-ext"></i></a>: Follow our tutorial to build, and deploy, your first Ember.js application!</li>
+      <li> <a href="https://guides.emberjs.com/"><strong>Guides</strong><i class="icon-link-ext"></i></a>: Whether you're just getting started and want to get familiar with Ember, or you're looking to refresh your knowledge on a certain feature, the Guides are the place for you.</li>
     </ul>
     <section>
       <h2>API Reference</h2>
@@ -35,7 +35,7 @@ responsive: true
       </ul>
     </section>
     <section>
-      <h2 id="deprecations" class="anchorable-toc">Deprecation Guides <a href="http://emberjs.com/deprecations/"><i class="icon-link-ext"></i></a></h2>
+      <h2 id="deprecations" class="anchorable-toc"> <a href="http://emberjs.com/deprecations/">Deprecation Guides<i class="icon-link-ext"></i></a></h2>
       <p>
         Over the course of the years cruft inevitably sneaks into all software projects. In order to clean up outdated functionality and guide users, Ember has a deprecation process. You can read our <a href="http://emberjs.com/deprecations/">deprecation guides</a> for more information. You can find below more direct links to Ember and Ember Data versions.
       </p>
@@ -89,7 +89,7 @@ responsive: true
               <img class="showcase--image" src="/images/learn/<%= showcase.image.src %>" alt="<%= showcase.image.alt %>">
             </div>
             <div class="showcase--description">
-              <h3><%= showcase.name %> <a href="<%= replace_current_version showcase.demo %>"><i class="icon-link-ext"></i></a></h3>
+              <h3> <a href="<%= replace_current_version showcase.demo %>"><%= showcase.name %><i class="icon-link-ext"></i></a></h3>
 
               <p>Repository: <a href="<%= showcase.repository %>"><%= showcase.repository %></a></p>
 


### PR DESCRIPTION
fixes #3141 