### PR TITLE
Improved color contrast on Emberconf CTA button background

### DIFF
--- a/source/stylesheets/components/ember-conf.css.scss
+++ b/source/stylesheets/components/ember-conf.css.scss
@@ -69,7 +69,7 @@
   }
 
   a {
-    background: #4AA0B8;
+    background: #00829a;
     border-radius: 0.25em;
     color: white;
     font-size: 0.75em;


### PR DESCRIPTION
Resolves #3164 

How it looks with the new color:
<img width="823" alt="screen shot 2018-01-24 at 19 33 20" src="https://user-images.githubusercontent.com/1408595/35350263-b40c2704-013d-11e8-858b-cb475d30bf97.png">
