### PR TITLE
3.x deprecation guides

### DIFF
--- a/source/deprecations/index.html.md
+++ b/source/deprecations/index.html.md
@@ -16,6 +16,7 @@ of change management is commonly referred to as [Semantic Versioning](http://sem
 
 * [Version 1.x](/deprecations/v1.x)
 * [Version 2.x](/deprecations/v2.x)
+* [Version 3.x](/deprecations/v3.x)
 
 ### Ember Data
 

--- a/source/deprecations/v3.x.html.md
+++ b/source/deprecations/v3.x.html.md
@@ -12,3 +12,37 @@ cycle.
 
 For more information on deprecations in Ember, see the [main deprecations page]
 (/deprecations).
+
+### Deprecations Added in 3.1
+
+#### Use notifyPropertyChange instead of propertyWillChange and propertyDidChange
+
+##### until: 3.5.0
+##### id: ember-metal.deprecate-propertyWillChange, ember-metal.deprecate-propertyDidChange
+
+The private APIs `propertyWillChange` and `propertyDidChange` will be removed after the first
+LTS of the 3.x cycle. You should remove and calls to `propertyWillChange` and replace any
+calls to `propertyDidChange` with `notifyPropertyChange`. This applies to both the Ember global
+version and then Ember Object method version.
+
+For example
+
+```javascript
+Ember.propertyWillChange(object, 'someProperty');
+doStuff(object);
+Ember.propertyDidChange(object, 'someProperty');
+
+object.propertyWillChange('someProperty');
+doStuff(object);
+object.propertyDidChange('someProperty');
+```
+
+should be changed to the following
+
+```javascript
+doStuff(object);
+Ember.notifyPropertyChange(object, 'someProperty');
+
+doStuff(object);
+object.notifyPropertyChange('someProperty');
+```

--- a/source/deprecations/v3.x.html.md
+++ b/source/deprecations/v3.x.html.md
@@ -21,11 +21,11 @@ For more information on deprecations in Ember, see the [main deprecations page]
 ##### id: ember-metal.deprecate-propertyWillChange, ember-metal.deprecate-propertyDidChange
 
 The private APIs `propertyWillChange` and `propertyDidChange` will be removed after the first
-LTS of the 3.x cycle. You should remove and calls to `propertyWillChange` and replace any
+LTS of the 3.x cycle. You should remove any calls to `propertyWillChange` and replace any
 calls to `propertyDidChange` with `notifyPropertyChange`. This applies to both the Ember global
-version and then Ember Object method version.
+version and the EmberObject method version.
 
-For example
+For example, the following:
 
 ```javascript
 Ember.propertyWillChange(object, 'someProperty');
@@ -37,7 +37,7 @@ doStuff(object);
 object.propertyDidChange('someProperty');
 ```
 
-should be changed to the following
+Should be changed to:
 
 ```javascript
 doStuff(object);

--- a/source/deprecations/v3.x.html.md
+++ b/source/deprecations/v3.x.html.md
@@ -1,0 +1,14 @@
+---
+title: Deprecations for v3.x
+alias: guides/deprecations/
+layout: deprecations
+responsive: true
+---
+
+## Deprecations Added in Ember 3.x
+
+What follows is a list of deprecations introduced to Ember.js during the 3.x
+cycle.
+
+For more information on deprecations in Ember, see the [main deprecations page]
+(/deprecations).

--- a/source/learn.html.erb
+++ b/source/learn.html.erb
@@ -47,6 +47,7 @@ responsive: true
           <ul>
             <li><a href="/deprecations/v1.x">1.x</a></li>
             <li><a href="/deprecations/v2.x">2.x</a></li>
+            <li><a href="/deprecations/v3.x">3.x</a></li>
           </ul>
         </div>
         <div class="flex-same-width">


### PR DESCRIPTION
- Add page for Ember 3.x deprecation guides
- Add deprecation guide for propertyWillChange and propertyDidChange.
  - See emberjs/ember.js#16175.
