### PR TITLE
Add deprecation for ember-metal.getting-each

### DIFF
--- a/source/deprecations/v3.x.html.md
+++ b/source/deprecations/v3.x.html.md
@@ -46,3 +46,10 @@ Ember.notifyPropertyChange(object, 'someProperty');
 doStuff(object);
 object.notifyPropertyChange('someProperty');
 ```
+
+#### Getting the @each property
+
+##### until: 3.5.0
+##### id: ember-metal.getting-each
+
+Calling `array.get('@each')` is deprecated. `@each` may only be used as dependency key.


### PR DESCRIPTION
Adds a deprecation for getting `@each`.

Depends on https://github.com/emberjs/ember.js/pull/16215 being merged first.