### PR TITLE
Fixing the ul/li rendering in Blog posts

### DIFF
--- a/source/stylesheets/blog.css.scss
+++ b/source/stylesheets/blog.css.scss
@@ -153,11 +153,7 @@ body.blog.responsive {
       list-style: disc;
       li {
         max-width: 100% !important;
-        overflow: hidden;
-        white-space: nowrap;
-        code {
-          overflow-x: scroll;
-        }
+        word-wrap: break-word;
       }
     }
   }


### PR DESCRIPTION
The ul/li were not allowed to wrap and their overflow was hidden.
This resulted in content being cut and inaccessible on mobile and desktop.

This commit tries to fix the issue. It allows `code` content in `li` to wrap to also prevent overflow on mobile that would cause the annoying result of "the page scrolls horizontally".

I could not find a `li code` example that was broken by this. If you find one I'd be happy to find a better solution. In the meantime this allows for the Ember 3.0 release post to be readable.

:heart:

EDIT: The issue fixed by this PR was just fixed on master. The "the page scrolls horizontally" point is still valid though.