### PR TITLE
fixing issue 3166 with option 2

### DIFF
--- a/source/stylesheets/components/call-to-action.css.scss
+++ b/source/stylesheets/components/call-to-action.css.scss
@@ -8,20 +8,23 @@
 
   a {
     background-color: $white;
-    border-radius: 7px;
+    border-radius: 3px;
     border: 1px $orange-darker solid;
     color: $orange-darker;
     font-size: 0.9em;
     font-weight: bold;
+    height: 48px;
     letter-spacing: 1px;
     padding: 0.5em 1em;
     text-transform: uppercase;
     transition: all 0.3s ease 0s;
 
     &:hover {
-      color: $white;
       background-color: $orange-darker;
+      color: $white;
       cursor: pointer;
+      text-decoration: none;
+
     }
   }
 }
@@ -48,14 +51,13 @@
 }
 
 .call-to-action__bottom {
-  // display: none;
   background-color: $orange;
   color: $white;
   font-family: monospace;
   line-height: 0.5;
   margin: 0;
   overflow: hidden;
-  padding-left: 2em;
+  padding-left: 1em;
   text-align: left;
 }
 
@@ -84,6 +86,13 @@
     display: inherit;
     border-bottom-left-radius: 10px;
     border-bottom-right-radius: 10px;
+    padding: 1em;
 
+    p {
+      font-size: 1.34em;
+      line-height: 1.2;
+      margin: 0;
+      padding: 0;
+    }
   }
 }


### PR DESCRIPTION
Fixes #3166 

- after a vote during the team-learning call, option 2 was selected
- made a minor adjustment to the border radius of the button so it was more in balance
- increased the font size of the monospace text large enough to pass AA conformance requirements. 
- adjusted some of the paddings and line heights to even it out

Screenshot on large viewport: 
![image](https://user-images.githubusercontent.com/4587451/36277044-597dda2a-1255-11e8-8157-22b7fa2043ae.png)
