### PR TITLE
RFC#297 | Ember.Logger deprecation

### DIFF
--- a/source/deprecations/v3.x.html.md
+++ b/source/deprecations/v3.x.html.md
@@ -54,41 +54,48 @@ object.notifyPropertyChange('someProperty');
 
 Calling `array.get('@each')` is deprecated. `@each` may only be used as dependency key.
 
+### Deprecations Added in Upcoming Versions
+
 #### Use console rather than Ember.Logger
 
-##### until: 3.5.0
+##### until: 4.0.0
 ##### id: ember-console.deprecate-logger
 
-The `Ember.Logger` module will be removed after the first LTS of the 3.x cycle. You should remove any calls to `Ember.Logger` and use calls to `console` instead.
+The `Ember.Logger` module will be removed at the start of the 4.x cycle. You should remove any calls to `Ember.Logger` and use calls to `console` instead.
 
 In Edge and IE11, uses of `console` beyond calling its methods may require more subtle changes than simply substituting `console` wherever `Logger` appears. In these browsers, they will behave just as they do in other browsers when your development tools window is open. However, when run normally, calls to its methods must not be bound to anything other than the console object or you will receive an `Invalid calling object` exception. This is a known inconsistency with these browsers. (Edge issue #14495220.)
 
-For example, the following uses will not work in Edge and IE11 except when the development tools window is open:
+To avoid this, transform the following usage:
 
 ``` javascript
-var print = console.log; // print is unbound, therefore bound to global
-print(message);
-
-// Using anonymous unbound local
-(console.debug ? console.debug : console.log)(message);
-
-//Explicitly binding to nothing or to something else
-console.info.apply(undefined, arguments);
-console.info.apply(null, arguments);
-console.info.apply(this, arguments);
+var print = Logger.log; // assigning method to variable
+```
+to:
+``` javascript
+var print = console.log.bind(console); // assigning method bound to console to variable
 ```
 
-Instead, use the following, which will work consistently across browsers:
-
+Also, transform any of the following:
 ``` javascript
-var print = console.log.bind(console);
-print(message);
-
-if (console.debug) {
-  console.debug(message);
-} else {
-  console.log(message);
-}
-
+Logger.info.apply(undefined, arguments); // or
+Logger.info.apply(null, arguments); // or
+Logger.info.apply(this, arguments); // or
+```
+to:
+``` javascript
 console.info.apply(console, arguments);
 ```
+
+Finally, because node versions before version 9 don't support console.debug, you may want to transform the following:
+``` javascript
+Logger.debug(message);
+```
+to:
+``` javascript
+if (console.debug) {
+console.debug(message);
+} else {
+console.log(message);
+}
+```
+

--- a/source/deprecations/v3.x.html.md
+++ b/source/deprecations/v3.x.html.md
@@ -53,3 +53,42 @@ object.notifyPropertyChange('someProperty');
 ##### id: ember-metal.getting-each
 
 Calling `array.get('@each')` is deprecated. `@each` may only be used as dependency key.
+
+#### Use console rather than Ember.Logger
+
+##### until: 3.5.0
+##### id: ember-console.deprecate-logger
+
+The `Ember.Logger` module will be removed after the first LTS of the 3.x cycle. You should remove any calls to `Ember.Logger` and use calls to `console` instead.
+
+In Edge and IE11, uses of `console` beyond calling its methods may require more subtle changes than simply substituting `console` wherever `Logger` appears. In these browsers, they will behave just as they do in other browsers when your development tools window is open. However, when run normally, calls to its methods must not be bound to anything other than the console object or you will receive an `Invalid calling object` exception. This is a known inconsistency with these browsers. (Edge issue #14495220.)
+
+For example, the following uses will not work in Edge and IE11 except when the development tools window is open:
+
+``` javascript
+var print = console.log; // print is unbound, therefore bound to global
+print(message);
+
+// Using anonymous unbound local
+(console.debug ? console.debug : console.log)(message);
+
+//Explicitly binding to nothing or to something else
+console.info.apply(undefined, arguments);
+console.info.apply(null, arguments);
+console.info.apply(this, arguments);
+```
+
+Instead, use the following, which will work consistently across browsers:
+
+``` javascript
+var print = console.log.bind(console);
+print(message);
+
+if (console.debug) {
+  console.debug(message);
+} else {
+  console.log(message);
+}
+
+console.info.apply(console, arguments);
+```

--- a/source/deprecations/v3.x.html.md
+++ b/source/deprecations/v3.x.html.md
@@ -92,7 +92,7 @@ to:
 console.info.apply(console, arguments);
 ```
 
-Finally, because node versions before version 9 don't support console.debug, you may want to transform the following:
+Finally, because Node versions before version 9 don't support `console.debug`, you may want to transform the following:
 
 ``` javascript
 Logger.debug(message);

--- a/source/deprecations/v3.x.html.md
+++ b/source/deprecations/v3.x.html.md
@@ -54,7 +54,7 @@ object.notifyPropertyChange('someProperty');
 
 Calling `array.get('@each')` is deprecated. `@each` may only be used as dependency key.
 
-### Deprecations Added in Upcoming Versions
+### Deprecations Added in 3.2
 
 #### Use console rather than Ember.Logger
 
@@ -63,47 +63,62 @@ Calling `array.get('@each')` is deprecated. `@each` may only be used as dependen
 
 The `Ember.Logger` module will be removed at the start of the 4.x cycle. You should remove any calls to `Ember.Logger` and use calls to `console` instead.
 
-In Edge and IE11, uses of `console` beyond calling its methods may require more subtle changes than simply substituting `console` wherever `Logger` appears. In these browsers, they will behave just as they do in other browsers when your development tools window is open. However, when run normally, calls to its methods must not be bound to anything other than the console object or you will receive an `Invalid calling object` exception. This is a known inconsistency with these browsers. (Edge issue #14495220.)
+``` javascript
+// Before
+Ember.Logger.log('significant event occurred');
 
-To avoid this, transform the following usage:
+// After
+console.log('significant event occurred');
+```
+
+###### Calling `console` methods unbound
+
+In Edge and IE11, uses of `console` beyond calling its methods may require more subtle changes than simply substituting `console` wherever `Logger` appears. When the development tools window is open, these browsers will handle the console just as other browsers do. However, when run normally, calls to its methods must be bound to the console object or you will receive an `Invalid calling object` exception. This is a known inconsistency with these browsers. (Edge issue #14495220.)
+
+You can address the issue by binding the method to the console object:
 
 ``` javascript
+// Before - assigning raw method to a variable for later use
 var print = Logger.log; // assigning method to variable
-```
+print('Message');
 
-to:
-
-``` javascript
-// assigning method bound to console to variable
+// After - assigning console-bound method to variable for later use
 var print = console.log.bind(console);
+print('Message');
 ```
 
-Also, transform any of the following:
+In some cases, you can use rest parameter syntax to avoid the issue entirely:
 
 ``` javascript
+// Before
 Logger.info.apply(undefined, arguments); // or
 Logger.info.apply(null, arguments); // or
 Logger.info.apply(this, arguments); // or
+
+// After
+console.info(...arguments);
 ```
 
-to:
+###### `console.debug` method not available in Node 8 and earlier
+
+Because Node versions before version 9 don't support `console.debug`, you may want to either use `console.log`  instead or transform the usage as follows:
 
 ``` javascript
-console.info.apply(console, arguments);
-```
-
-Finally, because Node versions before version 9 don't support `console.debug`, you may want to transform the following:
-
-``` javascript
+// Before
 Logger.debug(message);
-```
 
-to:
-
-``` javascript
+// After
 if (console.debug) {
-  console.debug(message);
+console.debug(message);
 } else {
-  console.log(message);
+console.log(message);
 }
 ```
+
+###### Addons that support both 2.x and 3.x
+
+If your add-on needs to support both Ember 2.x and Ember 3.x clients, you will
+need to test for the existence of `console` before calling its methods. If you
+do much logging, you may find it convenient to define your own wrapper. Writing
+the wrapper as a service will provide for dependency injection by tests and
+perhaps even clients.

--- a/source/deprecations/v3.x.html.md
+++ b/source/deprecations/v3.x.html.md
@@ -70,32 +70,40 @@ To avoid this, transform the following usage:
 ``` javascript
 var print = Logger.log; // assigning method to variable
 ```
+
 to:
+
 ``` javascript
-var print = console.log.bind(console); // assigning method bound to console to variable
+// assigning method bound to console to variable
+var print = console.log.bind(console);
 ```
 
 Also, transform any of the following:
+
 ``` javascript
 Logger.info.apply(undefined, arguments); // or
 Logger.info.apply(null, arguments); // or
 Logger.info.apply(this, arguments); // or
 ```
+
 to:
+
 ``` javascript
 console.info.apply(console, arguments);
 ```
 
 Finally, because node versions before version 9 don't support console.debug, you may want to transform the following:
+
 ``` javascript
 Logger.debug(message);
 ```
+
 to:
+
 ``` javascript
 if (console.debug) {
-console.debug(message);
+  console.debug(message);
 } else {
-console.log(message);
+  console.log(message);
 }
 ```
-


### PR DESCRIPTION
This is the deprecation text to go with RFC 297 ("Deprecation of Ember.Logger") currently a PR on emberjs/ember.js. I'm entertaining feedback on the text now, but it shouldn't be merged until that PR is also merged.