### PR TITLE
Add deprecation for Route#router

### DIFF
--- a/source/deprecations/v3.x.html.md
+++ b/source/deprecations/v3.x.html.md
@@ -82,3 +82,22 @@ object.notifyPropertyChange('someProperty');
 ##### id: ember-metal.getting-each
 
 Calling `array.get('@each')` is deprecated. `@each` may only be used as dependency key.
+
+#### Router#route
+
+##### until: 3.5.0
+##### id: ember-routing.route-router
+
+The `Router#route` private API has been renamed to `Router#_route` to avoid colliding with user defined
+properties or methods.
+If you want access to the router, you are probably better served injecting the router service into
+the route like this:
+
+```javascript
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+
+export default Route.extend({
+  router: service()
+});
+```


### PR DESCRIPTION
I initially added it two 3.1 thinking that the deprecation itself can be considered a [BUGFIX beta], but it's not confirmed.