### PR TITLE
Clean up Community Help Links

### DIFF
--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -18,20 +18,25 @@ responsive: true
 
   <div class="image"></div>
 
-  <p><a href="http://stackoverflow.com/questions/tagged/ember.js">StackOverflow</a> is used to
-  track questions. Just tag your question with <code>ember.js</code> or
-  <a href="http://stackoverflow.com/questions/tagged/ember.js">search for questions with that tag</a>.
-  Please check to see if your question has already been answered before asking a new one.</p>
-
-  <p>You can participate in our <a href="http://discuss.emberjs.com">discussion forum</a>, which is a great
-  venue for discussing features, architecture and best practices.</p>
 
   <p>
-    You can also join the <a href="https://embercommunity.slack.com">Ember Community Slack</a>.
-    Use <a href="https://ember-community-slackin.herokuapp.com/">the Slackin app</a> to receive an invitation.
+    <a href="http://discuss.emberjs.com">Ember Discussion Forum</a> &mdash; a great
+    venue for discussing features, architecture and best practices.
   </p>
+  
   <p>
-    Please note that neither the IRC channel nor the Slack room are managed or moderated by the Ember Core Team. They are public forums.
+    <a href="https://embercommunity.slack.com">Ember Community Slack</a> &mdash; use <a href="https://ember-community-slackin.herokuapp.com/">the Slackin app</a> to receive an invitation.
+  </p>
+    
+  <p>
+    <a href="http://stackoverflow.com/questions/tagged/ember.js">StackOverflow</a> &mdash; used to
+    track questions. Just tag your question with <code>ember.js</code> or
+    <a href="http://stackoverflow.com/questions/tagged/ember.js">search for questions with that tag</a>.
+    Please check to see if your question has already been answered before asking a new one.
+  </p>
+
+  <p>
+    Please note that these resources are not managed or moderated by the Ember Core Team. They are public forums.
   </p>
 </div>
 


### PR DESCRIPTION
First pass at fixing #3217 . This just cleans up that section and makes it more apparent where the help is.

![image](https://user-images.githubusercontent.com/176297/37303685-7a7d49d6-25ec-11e8-9cc6-600feac29e05.png)
