### PR TITLE
Ember 3.1 Release Blog Post

### DIFF
--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -258,7 +258,7 @@ Ember.js 3.2 will introduce one new feature:
 
 1. Use of `Ember.Logger` is deprecated. You should replace any calls to `Ember.Logger` with calls to `console`. Read more about this deprecation on the [deprecation page.](https://emberjs.com/deprecations/v3.x#toc_ember-console-deprecate-logger)
 2. The `Router#route` private API has been renamed to `Router#_route` to avoid collisions with user-defined properties or methods. Read more about this deprecation on the [deprecation page.](https://emberjs.com/deprecations/v3.x#toc_ember-routing-route-router)
-3. Use defineProperty to define computed properties. Read more about this deprecation on the [deprecation page.](https://emberjs.com/deprecations/v3.x#toc_ember-meta-descriptor-on-object)
+3. Update: replace directly assigned computed properties. Use `defineProperty` to define computed properties. Read more about this deprecation on the [deprecation page.](https://emberjs.com/deprecations/v3.x#toc_ember-meta-descriptor-on-object)
 
 For more details on the upcoming changes in Ember.js 3.2, please review the
 [Ember.js 3.2.0-beta.1 release page](https://github.com/emberjs/ember.js/releases/tag/v3.2.0-beta.1).

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -246,13 +246,13 @@ For more details on changes in Ember.js 3.1, please review the
 
 ### Upcoming Changes in Ember.js 3.2
 
-#### New Feature(s)
+#### New Features
 
 Ember.js 3.2 will introduce one new feature:
 
 1. Enabled block `let` handlebars helper by default - [emberjs/rfcs#286](https://github.com/emberjs/rfcs/blob/master/text/0286-block-let-template-helper.md)
 
-#### Deprecation(s)
+#### Deprecations
 
 **Three** new deprecations are introduced in Ember.js 3.2:
 
@@ -273,11 +273,11 @@ Ember Data 3.1 contains bug fixes and build improvements for Ember Data.
 
 ### Changes in Ember Data 3.1
 
-#### New Feature(s)
+#### New Features
 
 [#5273](https://github.com/emberjs/data/pull/5273) client-side-delete semantics `unloadRecord`
 
-#### Deprecation(s)
+#### Deprecations
 
 **Two** new deprecations are introduced in Ember Data 3.1.
 
@@ -370,40 +370,38 @@ Ember CLI is the command line interface for managing and packaging Ember.js appl
 
 ### Upgrading Ember CLI
 
-You may upgrade Ember CLI separately from Ember.js and Ember Data! To upgrade your projects using `yarn` run:
+You may upgrade Ember CLI separately from Ember.js and Ember Data! You can do this either with yarn or npm. 
+
+To upgrade your projects using `yarn`, run:
 
 ```bash
 yarn upgrade ember-cli
 ```
 
-To upgrade your projects using `npm` run:
+To upgrade your projects using `npm`, run:
 
 ```bash
 npm install --save-dev ember-cli
 ```
 
-After running the upgrade command run `ember init` inside of the project directory to apply the blueprint changes. You can preview those changes for [applications](https://github.com/ember-cli/ember-new-output/compare/v3.0.0...v3.1.0) and [addons](https://github.com/ember-cli/ember-addon-output/compare/v3.0.0...v3.1.0).
+After running the upgrade command, run `ember init` inside of the project directory to apply the blueprint changes.
+
+You can preview those changes for [applications](https://github.com/ember-cli/ember-new-output/compare/v3.0.0...v3.1.0) and [addons](https://github.com/ember-cli/ember-addon-output/compare/v3.0.0...v3.1.0).
 
 ### Changes in Ember CLI 3.1
 
-- [#7601](https://github.com/ember-cli/ember-cli/pull/7601) blueprints/addon: Replace `test` with `test:all` [@Turbo87](https://github.com/Turbo87)
+#### New Features
 
-`test` will run `ember test` now (like in apps), `test:all` will use `ember-try` to run tests in all configured scenarios
+- Updates to blueprints & addons- replace `test` with `test:all`. The command `test` will now run `ember test` (like it does in apps); the `test:all` command will use `ember-try` to run tests in all configured scenarios [(#7601)](https://github.com/ember-cli/ember-cli/pull/7601).
+- Yarn related changes: 
+  - [#7492](https://github.com/ember-cli/ember-cli/pull/7492) Use yarn instead of npm when part of a yarn workspace root.
+  - `yarn.lock` file detection improved
+- Ability to install optional dependencies when creating a new project [(#7573)](https://github.com/ember-cli/ember-cli/pull/7573).
+- Glimmer blueprint fixes:
+  - Added feature flag to `project.isModuleUnification` [(#7586)](https://github.com/ember-cli/ember-cli/pull/7586).
+  - Added `project.isModuleUnification()` [(#7541)](https://github.com/ember-cli/ember-cli/pull/7541).
 
-- [#7492](https://github.com/ember-cli/ember-cli/pull/7492) Use yarn instead of npm when part of a yarn workspace root [@thetimothyp](https://github.com/thetimothyp)
-
-`yarn.lock` file detection improved
-
-- [#7573](https://github.com/ember-cli/ember-cli/pull/7573) Install optional dependencies when creating a new project [@t-sauer](https://github.com/t-sauer)
-
-Fixes issues with the Glimmer blueprints
-
-- [#7586](https://github.com/ember-cli/ember-cli/pull/7586) add feature flag to project.isModuleUnification [@GavinJoyce](https://github.com/GavinJoyce)
-- [#7541](https://github.com/ember-cli/ember-cli/pull/7541) Add `project.isModuleUnification()` [@GavinJoyce](https://github.com/GavinJoyce)
-
-Module Unification continues...
-
-### Deprecations in Ember CLI 3.1
+#### Deprecations
 
 No new deprecations are introduced in Ember CLI 3.1:
 
@@ -411,35 +409,47 @@ For more details on the changes in Ember CLI 3.1 and detailed upgrade instructio
 
 ### Upcoming Changes in Ember CLI 3.2
 
-- [#7605](https://github.com/ember-cli/ember-cli/pull/7605) blueprints/app: Add `qunit-dom` dependency by default [@Turbo87](https://github.com/Turbo87)
+- [#7605](https://github.com/ember-cli/ember-cli/pull/7605) blueprints/app: Add `qunit-dom` dependency by default 
 
-`qunit-dom` will be added by default to all apps and addons, if you don't (plan to) use it, you don't have to add it. https://github.com/simplabs/qunit-dom-codemod exists to ease migration.
+<!-- in beta qunit-dom is a big deal, needs maybe an example and definitely links to docs etc. -->
+Qunit-Dom - `qunit-dom` will be added by default to all apps and addons, if you don't (plan to) use it, you don't have to add it. https://github.com/simplabs/qunit-dom-codemod exists to ease migration.
 
-- [#7501](https://github.com/ember-cli/ember-cli/pull/7501) add delayed transpilation [@kellyselden](https://github.com/kellyselden)
-- [#7650](https://github.com/ember-cli/ember-cli/pull/7650) compile all addons at once optimization [@kellyselden](https://github.com/kellyselden)
+- [#7501](https://github.com/ember-cli/ember-cli/pull/7501) add delayed transpilation 
+- [#7650](https://github.com/ember-cli/ember-cli/pull/7650) compile all addons at once optimization 
 
-experiments with more efficient transpilation
+Experiments with more efficient transpilation
+<!-- there is probably something to say about the transpilation improvements -->
 
-- [#7637](https://github.com/ember-cli/ember-cli/pull/7637) More comprehensive detect if ember-cli is being run within CI or not. [@ember-cli](https://github.com/ember-cli)
+- [#7637](https://github.com/ember-cli/ember-cli/pull/7637) More comprehensive detect if ember-cli is being run within CI or not.
 
 see https://github.com/watson/ci-info/
 
-- [#7658](https://github.com/ember-cli/ember-cli/pull/7658) Module Unification Addon blueprint [@cibernox](https://github.com/cibernox)
-- [#7490](https://github.com/ember-cli/ember-cli/pull/7490) Module Unification Addons [@ember-cli](https://github.com/ember-cli)
-- [#7660](https://github.com/ember-cli/ember-cli/pull/7660) improve logic for if addon is module-unification [@iezer](https://github.com/iezer)
-- [#7667](https://github.com/ember-cli/ember-cli/pull/7667) MU addons must generate a MU dummy app [@cibernox](https://github.com/cibernox)
-- [#7678](https://github.com/ember-cli/ember-cli/pull/7678) Use a recent release of Ember canary for MU [@ember-cli](https://github.com/ember-cli)
+- [#7658](https://github.com/ember-cli/ember-cli/pull/7658) Module Unification Addon blueprint
+- [#7490](https://github.com/ember-cli/ember-cli/pull/7490) Module Unification Addons
+- [#7660](https://github.com/ember-cli/ember-cli/pull/7660) improve logic for if addon is module-unification
+- [#7667](https://github.com/ember-cli/ember-cli/pull/7667) MU addons must generate a MU dummy app
+- [#7678](https://github.com/ember-cli/ember-cli/pull/7678) Use a recent release of Ember canary for MU
 
-Module Unification continues...
 
 ### Deprecations in Ember CLI 3.2
 
-- [#7676](https://github.com/ember-cli/ember-cli/pull/7676) Deprecate ember-cli-babel 5.x [@raytiley](https://github.com/raytiley)
+- [#7676](https://github.com/ember-cli/ember-cli/pull/7676) Deprecate ember-cli-babel 5.x 
 
 Babel 6 support has been out for a long time now and works quite well. Babel 5 support is deprecated and will be dropped soon.
 
 For more details on the changes in Ember CLI 3.2.0-beta.1 and detailed upgrade
 instructions, please review the [Ember CLI 3.2.0-beta.1 release page](https://github.com/ember-cli/ember-cli/releases/tag/v3.2.0-beta.1).
+
+Thank you to 
+[@Turbo87](https://github.com/Turbo87), 
+[@cibernox](https://github.com/cibernox), 
+[@iezer](https://github.com/iezer)
+[@kellyselden](https://github.com/kellyselden), 
+[@raytiley](https://github.com/raytiley) & 
+[@t-sauer](https://github.com/t-sauer)
+[@thetimothyp](https://github.com/thetimothyp), 
+[@GavinJoyce](https://github.com/GavinJoyce)
+for your incredible work on ember-cli! 
 
 ## Thank You!
 

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -1,6 +1,6 @@
 ---
 title: Ember 3.1 and 3.2 Beta Released
-author: Melanie Sumner
+author: Melanie Sumner, Kenneth Larsen
 tags: Releases
 responsive: true
 ---

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -246,12 +246,13 @@ For more details on changes in Ember.js 3.1, please review the
 
 ### Upcoming Changes in Ember.js 3.2
 
-Ember.js 3.2 will introduce two new features:
+#### New Feature(s)
 
-- TODO
-- TODO
+Ember.js 3.2 will introduce one new feature:
 
-### Deprecations in Ember.js 3.2
+1. Enabled block `let` handlebars helper by default - [emberjs/rfcs#286](https://github.com/emberjs/rfcs/blob/master/text/0286-block-let-template-helper.md)
+
+#### Deprecation(s)
 
 **Three** new deprecations are introduced in Ember.js 3.2:
 
@@ -272,9 +273,11 @@ Ember Data 3.1 contains bug fixes and build improvements for Ember Data.
 
 ### Changes in Ember Data 3.1
 
+#### New Feature(s)
+
 [#5273](https://github.com/emberjs/data/pull/5273) client-side-delete semantics `unloadRecord`
 
-### Deprecations in Ember Data 3.1
+#### Deprecation(s)
 
 **Two** new deprecations are introduced in Ember Data 3.1.
 

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -416,31 +416,21 @@ For more details on the changes in Ember CLI 3.1 and detailed upgrade instructio
   - compile all addons at once optimization [#7650](https://github.com/ember-cli/ember-cli/pull/7650).
 - More comprehensive detect if ember-cli is being run within CI or not. [(#7637)](https://github.com/ember-cli/ember-cli/pull/7637) - see https://github.com/watson/ci-info/.
 - Module Unification Continues...
-  - [#7658](https://github.com/ember-cli/ember-cli/pull/7658) Module Unification Addon blueprint
-  - [#7490](https://github.com/ember-cli/ember-cli/pull/7490) Module Unification Addons
-  - [#7660](https://github.com/ember-cli/ember-cli/pull/7660) improve logic for if addon is module-unification
-  - [#7667](https://github.com/ember-cli/ember-cli/pull/7667) MU addons must generate a MU dummy app
-  - [#7678](https://github.com/ember-cli/ember-cli/pull/7678) Use a recent release of Ember canary for MU
+  - Module Unification Addon blueprint [(#7658)](https://github.com/ember-cli/ember-cli/pull/7658).
+  - Module Unification Addons [(#7490)](https://github.com/ember-cli/ember-cli/pull/7490).
+  - Improve logic for if addon is module-unification [(#7660)](https://github.com/ember-cli/ember-cli/pull/7660).
+  - MU addons must generate a MU dummy app [(#7667)](https://github.com/ember-cli/ember-cli/pull/7667).
+  - Use a recent release of Ember canary for MU [(#7678)](https://github.com/ember-cli/ember-cli/pull/7678).
 
 ### Deprecations in Ember CLI 3.2
 
-- [#7676](https://github.com/ember-cli/ember-cli/pull/7676) Deprecate ember-cli-babel 5.x 
-
-Babel 6 support has been out for a long time now and works quite well. Babel 5 support is deprecated and will be dropped soon.
+- Deprecate ember-cli-babel 5.x [(#7676)](https://github.com/ember-cli/ember-cli/pull/7676). Babel 6 support has been out for a long time now and works quite well. Babel 5 support is deprecated and will be dropped soon.
 
 For more details on the changes in Ember CLI 3.2.0-beta.1 and detailed upgrade
 instructions, please review the [Ember CLI 3.2.0-beta.1 release page](https://github.com/ember-cli/ember-cli/releases/tag/v3.2.0-beta.1).
 
-Thank you to 
-[@Turbo87](https://github.com/Turbo87), 
-[@cibernox](https://github.com/cibernox), 
-[@iezer](https://github.com/iezer)
-[@kellyselden](https://github.com/kellyselden), 
-[@raytiley](https://github.com/raytiley) & 
-[@t-sauer](https://github.com/t-sauer)
-[@thetimothyp](https://github.com/thetimothyp), 
-[@GavinJoyce](https://github.com/GavinJoyce)
-for your incredible work on ember-cli! 
+Thank you to [@GavinJoyce](https://github.com/GavinJoyce), [@Turbo87](https://github.com/Turbo87), [@cibernox](https://github.com/cibernox), [@iezer](https://github.com/iezer), [@kellyselden](https://github.com/kellyselden), [@raytiley](https://github.com/raytiley), [@t-sauer](https://github.com/t-sauer), and [@thetimothyp](https://github.com/thetimothyp)
+for your incredible work on ember-cli!
 
 ## Thank You!
 

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -426,7 +426,7 @@ For more details on the changes in Ember CLI 3.1 and detailed upgrade instructio
 This is, to put it quite simply, totally awesome. It means that this code:
 
 ```js
-assert.equal(document.querySelector('.title').textContent.trim(), 'Hello World!');
+assert.equal(this.element.querySelector('.title').textContent.trim(), 'Hello World!');
 ```
 
 becomes this:

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -268,7 +268,7 @@ You can read more about it in [RFC #286 - Block `let` template helper](https://g
 
 1. Use of `Ember.Logger` is deprecated. You should replace any calls to `Ember.Logger` with calls to `console`. Read more about this deprecation on the [deprecation page.](https://emberjs.com/deprecations/v3.x#toc_ember-console-deprecate-logger)
 2. The `Router#route` private API has been renamed to `Router#_route` to avoid collisions with user-defined properties or methods. Read more about this deprecation on the [deprecation page.](https://emberjs.com/deprecations/v3.x#toc_ember-routing-route-router)
-3. This next one typically won't affect most apps, but it might affect some addons. You'll need to replace directly assigned computed properties, and use `defineProperty` to define computed properties instead. Read more about this deprecation on the [deprecation page.](https://emberjs.com/deprecations/v3.x#toc_ember-meta-descriptor-on-object)
+3. Update: replace directly assigned computed properties. Use `defineProperty` to define computed properties. Read more about this deprecation on the [deprecation page.](https://emberjs.com/deprecations/v3.x#toc_ember-meta-descriptor-on-object)
 
 For more details on the upcoming changes in Ember.js 3.2, please review the
 [Ember.js 3.2.0-beta.1 release page](https://github.com/emberjs/ember.js/releases/tag/v3.2.0-beta.1).
@@ -291,7 +291,7 @@ Ember Data 3.1 contains bug fixes and build improvements for Ember Data.
 
 **Two** new deprecations are introduced in Ember Data 3.1.
 
-* `Ember.Map` was a private API provided by Ember (for quite some time). Unfortunately, Ember Data made `Ember.Map` part of its public API surface via documentation blocks. `Ember.Map` will be deprecated and removed from Ember "soon" [(https://github.com/emberjs/rfcs/pull/237)](https://github.com/emberjs/rfcs/pull/237) and we would like to confirm that Ember Data will work without deprecation before and after that happens.`Ember.Map` differs from native `Map` in a few ways:
+* `Ember.Map` was a private API provided by Ember (for quite some time). Unfortunately, Ember Data made `Ember.Map` part of its public API surface via documentation blocks. `Ember.Map` is [scheduled for deprecation](scheduled for deprecation), after we make sure that Ember Data will continue working after this feature is deprecated and removed.`Ember.Map` differs from native `Map` in a few ways:
     * `Ember.Map` has custom `copy` and `isEmpty` methods which are not present in native `Map`
     * `Ember.Map` adds a static `create` method (which simply instantiates itself with `new Ember.Map()`)
     * `Ember.Map` does not accept constructor arguments
@@ -303,7 +303,7 @@ Ember Data 3.1 contains bug fixes and build improvements for Ember Data.
           * `copy`
           * `isEmpty`
 
-This is needed because `Map` requires instantiation with `new` and by default Babel transpilation will do `superConstructor.apply(this, arguments)` which throws an error with native `Map`. The desired code (if we lived in an "only native class" world) would be:
+This is needed because `Map` requires instantiation with `new`, and by default Babel transpilation will do `superConstructor.apply(this, arguments)` which throws an error with native `Map`. The desired code (if we lived in an "only native class" world) would be:
 
   ```js
   export default class MapWithDeprecations extends Map {
@@ -331,7 +331,8 @@ For more details on changes in Ember Data 3.1, please review the
 
 #### Lazy Relationship Payloads (1 of 4)
 
-[#5230](https://github.com/emberjs/data/pull/5230) [BUGFIX] enable lazy-relationship payloads to work with polymorphic relationships
+Due to [implementation details](https://github.com/emberjs/data/pull/5230) in the parsing of lazy relationships, polymorphic relationships were not supported, causing newly encountered polymorphic types to dereference previous payloads.
+This issue is now addressed.
 
 #### Ember Data Feature Flag Removal (2 of 4)
 

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -258,7 +258,7 @@ Ember.js 3.2 will introduce one new feature:
 
 1. Use of `Ember.Logger` is deprecated. You should replace any calls to `Ember.Logger` with calls to `console`. Read more about this deprecation on the [deprecation page.](https://emberjs.com/deprecations/v3.x#toc_ember-console-deprecate-logger)
 2. The `Router#route` private API has been renamed to `Router#_route` to avoid collisions with user-defined properties or methods. Read more about this deprecation on the [deprecation page.](https://emberjs.com/deprecations/v3.x#toc_ember-routing-route-router)
-3. Update: replace directly assigned computed properties. Use `defineProperty` to define computed properties. Read more about this deprecation on the [deprecation page.](https://emberjs.com/deprecations/v3.x#toc_ember-meta-descriptor-on-object)
+3. This next one typically won't affect most apps, but it might affect some addons. You'll need to replace directly assigned computed properties, and use `defineProperty` to define computed properties instead. Read more about this deprecation on the [deprecation page.](https://emberjs.com/deprecations/v3.x#toc_ember-meta-descriptor-on-object)
 
 For more details on the upcoming changes in Ember.js 3.2, please review the
 [Ember.js 3.2.0-beta.1 release page](https://github.com/emberjs/ember.js/releases/tag/v3.2.0-beta.1).

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -412,16 +412,16 @@ For more details on the changes in Ember CLI 3.1 and detailed upgrade instructio
 
 **Qunit Dom** - In order to make DOM assertions more readable, the `qunit-dom` dependency will be added **by default** to all apps and addons. Opt out by removing it from your package.json file. See [https://github.com/simplabs/qunit-dom-codemod](https://github.com/simplabs/qunit-dom-codemod) to ease migration [(#7605)](https://github.com/ember-cli/ember-cli/pull/7605). 
 
-This is, to put it quite simply, totally awesome. It means that this code: 
+This is, to put it quite simply, totally awesome. It means that this code:
 
 ```js
-assert.equal(this.element.querySelector('.title').textContent.trim(), 'Hello World!');
+assert.equal(document.querySelector('.title').textContent.trim(), 'Hello World!');
 ```
 
-becomes this: 
+becomes this:
 
 ```js
-assert.equal(find('.title').textContent.trim(), 'Hello World!');
+assert.dom('.title').hasText('Hello World!');
 ```
 
 See what I mean? Totally awesome. <3

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -410,15 +410,25 @@ For more details on the changes in Ember CLI 3.1 and detailed upgrade instructio
 
 #### New Features
 
-**Qunit Dom** - The `qunit-dom` dependency will be added by default to all apps and addons; opt out by removing it from your package.json file. See https://github.com/simplabs/qunit-dom-codemod to ease migration [(#7605)](https://github.com/ember-cli/ember-cli/pull/7605). 
+**Qunit Dom** - In order to make DOM assertions more readable, the `qunit-dom` dependency will be added **by default** to all apps and addons. Opt out by removing it from your package.json file. See [https://github.com/simplabs/qunit-dom-codemod](https://github.com/simplabs/qunit-dom-codemod) to ease migration [(#7605)](https://github.com/ember-cli/ember-cli/pull/7605). 
 
-**Experiments with more efficient transpilation** - Until now, addons were responsible for compiling their own JS/HBS/CSS and returning AMD/CSS. Now they return the raw code, and the app uses its own processors (babel, htmlbars) to compile it. This is required to do proper tree-shaking and code-splitting. Delayed transpilation [(#7501)](https://github.com/ember-cli/ember-cli/pull/7501) and all-at-once addon optimization after compilation [(#7650)](https://github.com/ember-cli/ember-cli/pull/7650) have been added. Additionally, more comprehensive methods to detect if ember-cli is being run within CI or not have also been added [(#7637)](https://github.com/ember-cli/ember-cli/pull/7637) - see https://github.com/watson/ci-info/.
+This is, to put it quite simply, totally awesome. It means that this code: 
 
-**Module Unification Continues** - You can now generate an addon using the module unification layout with the command `MODULE_UNIFICATION=true ember addon my-addon` or `MODULE_UNIFICATION=true ember addon my-addon --yarn` [(#7658)](https://github.com/ember-cli/ember-cli/pull/7658).
-  - Module Unification Addons [(#7490)](https://github.com/ember-cli/ember-cli/pull/7490).
-  - Improve logic for if addon is module-unification [(#7660)](https://github.com/ember-cli/ember-cli/pull/7660).
-  - MU addons must generate a MU dummy app [(#7667)](https://github.com/ember-cli/ember-cli/pull/7667).
-  - Use a recent release of Ember canary for MU [(#7678)](https://github.com/ember-cli/ember-cli/pull/7678).v
+```js
+assert.equal(this.element.querySelector('.title').textContent.trim(), 'Hello World!');
+```
+
+becomes this: 
+
+```js
+assert.equal(find('.title').textContent.trim(), 'Hello World!');
+```
+
+See what I mean? Totally awesome. <3
+
+**Experiments with more efficient transpilation** - Until now, addons were responsible for compiling their own JS/HBS/CSS and returning AMD/CSS. Now they return the raw code, and the app uses its own processors (babel, htmlbars) to compile it. This is required to do proper tree-shaking and code-splitting. Delayed transpilation [(#7501)](https://github.com/ember-cli/ember-cli/pull/7501) and all-at-once addon optimization after compilation [(#7650)](https://github.com/ember-cli/ember-cli/pull/7650) have been added. Additionally, more comprehensive methods to detect if ember-cli is being run within CI or not have also been added [(#7637)](https://github.com/ember-cli/ember-cli/pull/7637) - see [https://github.com/watson/ci-info/](https://github.com/watson/ci-info/).
+
+**Module Unification Continues** - You can now generate an addon using the Module Unification layout [(#7490)](https://github.com/ember-cli/ember-cli/pull/7490)! Use the command `MODULE_UNIFICATION=true ember addon my-addon` to try it out [(#7658)](https://github.com/ember-cli/ember-cli/pull/7658). We also improved the logic to support addons that use Module Unification [(#7660)](https://github.com/ember-cli/ember-cli/pull/7660), added the blueprint for a dummy app to addons that use Module Unification [(#7667)](https://github.com/ember-cli/ember-cli/pull/7667), and updated the version of Ember used in Module Unification [(#7678)](https://github.com/ember-cli/ember-cli/pull/7678).
 
 #### Deprecations
 

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -1,6 +1,6 @@
 ---
 title: Ember 3.1 and 3.2 Beta Released
-author: Ricardo Mendes
+author: Melanie Sumner
 tags: Releases
 responsive: true
 ---
@@ -32,7 +32,7 @@ Ember 3.1 is a minor release containing several new features and bug fixes. It i
 
 #### ES5 Getters for Computed Properties (1 of 5)
 
-Ember's object system has long used `set` and `get` to access properties. These APIs came from the codebase's origins in SproutCore, and predated ES5's `defineProperty`. In recent years native JavaScript setter and getter implementations have become fast and mature.
+Ember's object system has long used `set` and `get` to access properties. These APIs came from the codebase's origins in SproutCore, and predated ES5's `defineProperty`. In recent years, native JavaScript setter and getter implementations have become fast and mature.
 
 Starting in Ember 3.1 (and described in [RFC281](https://github.com/emberjs/rfcs/blob/master/text/0281-es5-getters.md)) you are now able to read the value of a computed property using a native ES5 getter. For example, this component which uses computed properties:
 
@@ -80,7 +80,7 @@ to `this.a.b.c` when `b` is `undefined` would instead raise an exception.
 - If your object is using `unknownProperty` you must continue to use `get`. Using an ES5 getter on an object with `unknownProperty` will cause an assertion failure in development.
 - Ember Data returns promise proxy objects when you read an async relationship and from other API. Ember proxy objects, including promise proxies, still require that you call `get` to read values.
 
-With these caveats in mind, how should you know if you can convert a `get` call to a native getter? If you have code where `get` is called on `this` you likely can convert it. If you have a `get` on another object, `anything.get('foo')`, you should exercise caution when converting to a native getter.
+With these caveats in mind, how should you know if you can convert a `get` call to a native getter? If you have code where `get` is called on `this`, you likely can convert it. If you have a `get` on another object, `anything.get('foo')`, you should exercise caution when converting to a native getter.
 
 The community-provided [es5-getter-ember-codemod](https://github.com/rondale-sc/es5-getter-ember-codemod) is a great way to convert your existing codebase to ES5 getters. It follows the conservative guidelines and only converts `this.get`. Note that it cannot make all possible conversions to the new API, nor can it ensure 100% of the conversions it makes are correct. If your app has poor test coverage or you lack any confidence in your ability to make regression checks, a manual and gradual conversion process may be more appropriate.
 
@@ -281,7 +281,7 @@ Ember Data 3.1 contains bug fixes and build improvements for Ember Data.
 
 **Two** new deprecations are introduced in Ember Data 3.1.
 
-* `Ember.Map` was a private API provided by Ember (for quite some time). Unfortunately, ember-data made `Ember.Map` part of its public API surface via documentation blocks. `Ember.Map` will be deprecated and removed from Ember "soon" [(https://github.com/emberjs/rfcs/pull/237)](https://github.com/emberjs/rfcs/pull/237) and we would like to confirm that Ember Data will work without deprecation before and after that happens.`Ember.Map` differs from native `Map` in a few ways:
+* `Ember.Map` was a private API provided by Ember (for quite some time). Unfortunately, Ember Data made `Ember.Map` part of its public API surface via documentation blocks. `Ember.Map` will be deprecated and removed from Ember "soon" [(https://github.com/emberjs/rfcs/pull/237)](https://github.com/emberjs/rfcs/pull/237) and we would like to confirm that Ember Data will work without deprecation before and after that happens.`Ember.Map` differs from native `Map` in a few ways:
     * `Ember.Map` has custom `copy` and `isEmpty` methods which are not present in native `Map`
     * `Ember.Map` adds a static `create` method (which simply instantiates itself with `new Ember.Map()`)
     * `Ember.Map` does not accept constructor arguments
@@ -334,7 +334,7 @@ During the Ember Data 3.2 beta cycle, the Ember Data team is planning on releasi
 
 #### Feature Flag `ds-pushpayload-return` (4 of 4)
 
-If you rely on the `ds-pushpayload-return` feature flag you can use the following pattern to manually serialize the API response and push the record into the store.
+If you rely on the `ds-pushpayload-return` feature flag, you can use the following pattern to manually serialize the API response and push the record into the store.
 
 ```js
 export function pushPayload(store, modelName, rawPayload) {
@@ -392,7 +392,7 @@ You can preview those changes for [applications](https://github.com/ember-cli/em
 
 #### New Features
 
-1. Updates to blueprints & addons- replace `test` with `test:all`. The command `test` will now run `ember test` (like it does in apps); the `test:all` command will use `ember-try` to run tests in all configured scenarios [(#7601)](https://github.com/ember-cli/ember-cli/pull/7601).
+1. Updates to blueprints and addons–replace `test` with `test:all`. The command `test` will now run `ember test` (like it does in apps); the `test:all` command will use `ember-try` to run tests in all configured scenarios [(#7601)](https://github.com/ember-cli/ember-cli/pull/7601).
 2. Yarn related changes: 
   - `yarn.lock` file detection improved - Use yarn instead of npm when part of a yarn workspace root [(#7492)](https://github.com/ember-cli/ember-cli/pull/7492).
 3. Ability to install optional dependencies when creating a new project [(#7573)](https://github.com/ember-cli/ember-cli/pull/7573).
@@ -408,7 +408,7 @@ For more details on the changes in Ember CLI 3.1 and detailed upgrade instructio
 
 ### Upcoming Changes in Ember CLI 3.2
 
-1. Qunit-dom
+1. qunit-dom
   - `qunit-dom` will be added by default to all apps and addons, if you don't (plan to) use it, you don't have to add it. https://github.com/simplabs/qunit-dom-codemod exists to ease migration.
   - Added `qunit-dom` dependency by default for blueprints/addons [(#7605)](https://github.com/ember-cli/ember-cli/pull/7605).
 2. Experiments with more efficient transpilation

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -408,14 +408,14 @@ For more details on the changes in Ember CLI 3.1 and detailed upgrade instructio
 
 ### Upcoming Changes in Ember CLI 3.2
 
-- Qunit-dom <!-- in beta qunit-dom is a big deal, needs maybe an example and definitely links to docs etc. -->
+1. Qunit-dom
   - `qunit-dom` will be added by default to all apps and addons, if you don't (plan to) use it, you don't have to add it. https://github.com/simplabs/qunit-dom-codemod exists to ease migration.
   - Added `qunit-dom` dependency by default for blueprints/addons [(#7605)](https://github.com/ember-cli/ember-cli/pull/7605).
-- Experiments with more efficient transpilation <!-- there is probably something to say about the transpilation improvements -->
+2. Experiments with more efficient transpilation
   - add delayed transpilation [(#7501)](https://github.com/ember-cli/ember-cli/pull/7501).
   - compile all addons at once optimization [#7650](https://github.com/ember-cli/ember-cli/pull/7650).
-- More comprehensive detect if ember-cli is being run within CI or not. [(#7637)](https://github.com/ember-cli/ember-cli/pull/7637) - see https://github.com/watson/ci-info/.
-- Module Unification Continues...
+3. More comprehensive detect if ember-cli is being run within CI or not. [(#7637)](https://github.com/ember-cli/ember-cli/pull/7637) - see https://github.com/watson/ci-info/.
+4. Module Unification Continues...
   - Module Unification Addon blueprint [(#7658)](https://github.com/ember-cli/ember-cli/pull/7658).
   - Module Unification Addons [(#7490)](https://github.com/ember-cli/ember-cli/pull/7490).
   - Improve logic for if addon is module-unification [(#7660)](https://github.com/ember-cli/ember-cli/pull/7660).

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -394,8 +394,7 @@ You can preview those changes for [applications](https://github.com/ember-cli/em
 
 - Updates to blueprints & addons- replace `test` with `test:all`. The command `test` will now run `ember test` (like it does in apps); the `test:all` command will use `ember-try` to run tests in all configured scenarios [(#7601)](https://github.com/ember-cli/ember-cli/pull/7601).
 - Yarn related changes: 
-  - [#7492](https://github.com/ember-cli/ember-cli/pull/7492) Use yarn instead of npm when part of a yarn workspace root.
-  - `yarn.lock` file detection improved
+  - `yarn.lock` file detection improved - Use yarn instead of npm when part of a yarn workspace root [(#7492)](https://github.com/ember-cli/ember-cli/pull/7492).
 - Ability to install optional dependencies when creating a new project [(#7573)](https://github.com/ember-cli/ember-cli/pull/7573).
 - Glimmer blueprint fixes:
   - Added feature flag to `project.isModuleUnification` [(#7586)](https://github.com/ember-cli/ember-cli/pull/7586).
@@ -409,27 +408,19 @@ For more details on the changes in Ember CLI 3.1 and detailed upgrade instructio
 
 ### Upcoming Changes in Ember CLI 3.2
 
-- [#7605](https://github.com/ember-cli/ember-cli/pull/7605) blueprints/app: Add `qunit-dom` dependency by default 
-
-<!-- in beta qunit-dom is a big deal, needs maybe an example and definitely links to docs etc. -->
-Qunit-Dom - `qunit-dom` will be added by default to all apps and addons, if you don't (plan to) use it, you don't have to add it. https://github.com/simplabs/qunit-dom-codemod exists to ease migration.
-
-- [#7501](https://github.com/ember-cli/ember-cli/pull/7501) add delayed transpilation 
-- [#7650](https://github.com/ember-cli/ember-cli/pull/7650) compile all addons at once optimization 
-
-Experiments with more efficient transpilation
-<!-- there is probably something to say about the transpilation improvements -->
-
-- [#7637](https://github.com/ember-cli/ember-cli/pull/7637) More comprehensive detect if ember-cli is being run within CI or not.
-
-see https://github.com/watson/ci-info/
-
-- [#7658](https://github.com/ember-cli/ember-cli/pull/7658) Module Unification Addon blueprint
-- [#7490](https://github.com/ember-cli/ember-cli/pull/7490) Module Unification Addons
-- [#7660](https://github.com/ember-cli/ember-cli/pull/7660) improve logic for if addon is module-unification
-- [#7667](https://github.com/ember-cli/ember-cli/pull/7667) MU addons must generate a MU dummy app
-- [#7678](https://github.com/ember-cli/ember-cli/pull/7678) Use a recent release of Ember canary for MU
-
+- Qunit-dom <!-- in beta qunit-dom is a big deal, needs maybe an example and definitely links to docs etc. -->
+  - `qunit-dom` will be added by default to all apps and addons, if you don't (plan to) use it, you don't have to add it. https://github.com/simplabs/qunit-dom-codemod exists to ease migration.
+  - Added `qunit-dom` dependency by default for blueprints/addons [(#7605)](https://github.com/ember-cli/ember-cli/pull/7605).
+- Experiments with more efficient transpilation <!-- there is probably something to say about the transpilation improvements -->
+  - add delayed transpilation [(#7501)](https://github.com/ember-cli/ember-cli/pull/7501).
+  - compile all addons at once optimization [#7650](https://github.com/ember-cli/ember-cli/pull/7650).
+- More comprehensive detect if ember-cli is being run within CI or not. [(#7637)](https://github.com/ember-cli/ember-cli/pull/7637) - see https://github.com/watson/ci-info/.
+- Module Unification Continues...
+  - [#7658](https://github.com/ember-cli/ember-cli/pull/7658) Module Unification Addon blueprint
+  - [#7490](https://github.com/ember-cli/ember-cli/pull/7490) Module Unification Addons
+  - [#7660](https://github.com/ember-cli/ember-cli/pull/7660) improve logic for if addon is module-unification
+  - [#7667](https://github.com/ember-cli/ember-cli/pull/7667) MU addons must generate a MU dummy app
+  - [#7678](https://github.com/ember-cli/ember-cli/pull/7678) Use a recent release of Ember canary for MU
 
 ### Deprecations in Ember CLI 3.2
 

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -408,21 +408,19 @@ For more details on the changes in Ember CLI 3.1 and detailed upgrade instructio
 
 ### Upcoming Changes in Ember CLI 3.2
 
-1. qunit-dom
-  - `qunit-dom` will be added by default to all apps and addons, if you don't (plan to) use it, you don't have to add it. https://github.com/simplabs/qunit-dom-codemod exists to ease migration.
-  - Added `qunit-dom` dependency by default for blueprints/addons [(#7605)](https://github.com/ember-cli/ember-cli/pull/7605).
-2. Experiments with more efficient transpilation
-  - add delayed transpilation [(#7501)](https://github.com/ember-cli/ember-cli/pull/7501).
-  - compile all addons at once optimization [#7650](https://github.com/ember-cli/ember-cli/pull/7650).
-3. More comprehensive detect if ember-cli is being run within CI or not. [(#7637)](https://github.com/ember-cli/ember-cli/pull/7637) - see https://github.com/watson/ci-info/.
-4. Module Unification Continues...
-  - Module Unification Addon blueprint [(#7658)](https://github.com/ember-cli/ember-cli/pull/7658).
+#### New Features
+
+**Qunit Dom** - The `qunit-dom` dependency will be added by default to all apps and addons; opt out by removing it from your package.json file. See https://github.com/simplabs/qunit-dom-codemod to ease migration [(#7605)](https://github.com/ember-cli/ember-cli/pull/7605). 
+
+**Experiments with more efficient transpilation** - Until now, addons were responsible for compiling their own JS/HBS/CSS and returning AMD/CSS. Now they return the raw code, and the app uses its own processors (babel, htmlbars) to compile it. This is required to do proper tree-shaking and code-splitting. Delayed transpilation [(#7501)](https://github.com/ember-cli/ember-cli/pull/7501) and all-at-once addon optimization after compilation [(#7650)](https://github.com/ember-cli/ember-cli/pull/7650) have been added. Additionally, more comprehensive methods to detect if ember-cli is being run within CI or not have also been added [(#7637)](https://github.com/ember-cli/ember-cli/pull/7637) - see https://github.com/watson/ci-info/.
+
+**Module Unification Continues** - You can now generate an addon using the module unification layout with the command `MODULE_UNIFICATION=true ember addon my-addon` or `MODULE_UNIFICATION=true ember addon my-addon --yarn` [(#7658)](https://github.com/ember-cli/ember-cli/pull/7658).
   - Module Unification Addons [(#7490)](https://github.com/ember-cli/ember-cli/pull/7490).
   - Improve logic for if addon is module-unification [(#7660)](https://github.com/ember-cli/ember-cli/pull/7660).
   - MU addons must generate a MU dummy app [(#7667)](https://github.com/ember-cli/ember-cli/pull/7667).
-  - Use a recent release of Ember canary for MU [(#7678)](https://github.com/ember-cli/ember-cli/pull/7678).
+  - Use a recent release of Ember canary for MU [(#7678)](https://github.com/ember-cli/ember-cli/pull/7678).v
 
-### Deprecations in Ember CLI 3.2
+#### Deprecations
 
 #### ember-cli-babel 5
 

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -392,11 +392,11 @@ You can preview those changes for [applications](https://github.com/ember-cli/em
 
 #### New Features
 
-- Updates to blueprints & addons- replace `test` with `test:all`. The command `test` will now run `ember test` (like it does in apps); the `test:all` command will use `ember-try` to run tests in all configured scenarios [(#7601)](https://github.com/ember-cli/ember-cli/pull/7601).
-- Yarn related changes: 
+1. Updates to blueprints & addons- replace `test` with `test:all`. The command `test` will now run `ember test` (like it does in apps); the `test:all` command will use `ember-try` to run tests in all configured scenarios [(#7601)](https://github.com/ember-cli/ember-cli/pull/7601).
+2. Yarn related changes: 
   - `yarn.lock` file detection improved - Use yarn instead of npm when part of a yarn workspace root [(#7492)](https://github.com/ember-cli/ember-cli/pull/7492).
-- Ability to install optional dependencies when creating a new project [(#7573)](https://github.com/ember-cli/ember-cli/pull/7573).
-- Glimmer blueprint fixes:
+3. Ability to install optional dependencies when creating a new project [(#7573)](https://github.com/ember-cli/ember-cli/pull/7573).
+4. Glimmer blueprint fixes:
   - Added feature flag to `project.isModuleUnification` [(#7586)](https://github.com/ember-cli/ember-cli/pull/7586).
   - Added `project.isModuleUnification()` [(#7541)](https://github.com/ember-cli/ember-cli/pull/7541).
 

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -30,7 +30,7 @@ Ember.js is the core framework for building ambitious web applications.
 
 Ember 3.1 is a minor release containing several new features and bug fixes. It includes a bump of Glimmer VM, Ember's rendering implementation, to version 0.30.5.
 
-#### ES5 Getters for Computed Properties (1 of 5)
+#### ES5 Getters for Computed Properties (1 of 3)
 
 Ember's object system has long used `set` and `get` to access properties. These APIs came from the codebase's origins in SproutCore, and predated ES5's `defineProperty`. In recent years, native JavaScript setter and getter implementations have become fast and mature.
 
@@ -86,7 +86,7 @@ The community-provided [es5-getter-ember-codemod](https://github.com/rondale-sc/
 
 Thanks to [Chris Garrett](https://twitter.com/pzuraq) for pushing forward work on ES5 getters with support from [Godfrey Chan](https://twitter.com/chancancode), [Robert Jackson](https://twitter.com/rwjblue/), and [Kris Selden](https://twitter.com/krisselden)). Thanks to [Jonathan Jackson](https://twitter.com/rondale_sc/) for his work on the codemod.
 
-#### Introducing Optional Features (2 of 5)
+#### Introducing Optional Features (2 of 3)
 
 Because major releases of Ember are not supposed to make breaking changes without prior deprecation, the project has been extremely conservative about changing behaviors that don't have a clear deprecation path. As a result, we've had several quirks of the framework linger into the 3.x series.
 
@@ -102,7 +102,7 @@ ember install @ember/optional-features
 
 Thanks to [Godfrey Chan](https://twitter.com/chancancode) and [Robert Jackson](https://twitter.com/rwjblue/) for their work on the optional features system.
 
-#### New Optional Feature: Application Template Wrapper (3 of 5) 
+**New Optional Feature: Application Template Wrapper**
 
 Ember applications have long created a wrapping `div` around their rendered content: `<div class="ember-view">`. With ember-optional-features, this functionality can now be disabled:
 
@@ -116,7 +116,7 @@ Additionally, enabling this feature will prompt you to optionally run a codemod 
 
 Although disabling this feature will eventually be the default for Ember, leaving the feature enabled is not deprecated in this release. You can read more details about this optional feature and the motivations for introducing it in [RFC #280](https://github.com/emberjs/rfcs/blob/master/text/0280-remove-application-wrapper.md).
 
-#### New Optional Feature: Template-only Glimmer Components (4 of 5)
+**New Optional Feature: Template-only Glimmer Components**
 
 Ember components implicitly create an element in the DOM where they are invoked, and the contents of their templates are then treated as "innerHTML" inside that DOM element. For example, this component template:
 
@@ -180,7 +180,7 @@ However, enabling this feature will prompt you to optionally run a codemod which
 
 Although enabling this feature will eventually be the default for Ember, leaving the feature disabled is not deprecated in this release. You can read more details about this optional feature and the motivations for introducing it in [RFC #278](https://github.com/emberjs/rfcs/blob/master/text/0278-template-only-components.md).
 
-#### Positional Params Bug Fix (5 of 5)
+#### Positional Params Bug Fix (3 of 3)
 
 Ember introduced contextual components in Ember 2.3. Contextual components close over arguments and are intended to do so in a manner consistent with closures in JavaScript.
 

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -390,19 +390,19 @@ You can preview those changes for [applications](https://github.com/ember-cli/em
 
 ### Changes in Ember CLI 3.1
 
-#### New Features
+#### `ember test:all`
 
-1. Updates to blueprints and addons–replace `test` with `test:all`. The command `test` will now run `ember test` (like it does in apps); the `test:all` command will use `ember-try` to run tests in all configured scenarios [(#7601)](https://github.com/ember-cli/ember-cli/pull/7601).
-2. Yarn related changes: 
-  - `yarn.lock` file detection improved - Use yarn instead of npm when part of a yarn workspace root [(#7492)](https://github.com/ember-cli/ember-cli/pull/7492).
-3. Ability to install optional dependencies when creating a new project [(#7573)](https://github.com/ember-cli/ember-cli/pull/7573).
-4. Glimmer blueprint fixes:
-  - Added feature flag to `project.isModuleUnification` [(#7586)](https://github.com/ember-cli/ember-cli/pull/7586).
-  - Added `project.isModuleUnification()` [(#7541)](https://github.com/ember-cli/ember-cli/pull/7541).
+Previously, `npm test` would run all configured scenarios of `ember-try`. This was confusing due to `npm test` and `ember test` having different behaviors, as well as `npm test` doing different things depending on whether it was being run by an app or an addon. The fact that the command would also run several hard to cancel processes for the `ember-try` scenarios also worsened the developer experience.
+
+To address this, `npm test` was changed to run `ember test`, and a new `npm test:all` was introduced with the old behavior of running `ember-try` scenarios.
+
+#### Yarn lock file detection
+
+Ember CLI will now correctly detect if the project is part of a Yarn workspace root, and adequately use Yarn instead of npm.
 
 #### Deprecations
 
-No new deprecations are introduced in Ember CLI 3.1:
+No new deprecations are introduced in Ember CLI 3.1.
 
 For more details on the changes in Ember CLI 3.1 and detailed upgrade instructions, please review the [Ember CLI  3.1.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/v3.1.0).
 
@@ -424,7 +424,9 @@ For more details on the changes in Ember CLI 3.1 and detailed upgrade instructio
 
 ### Deprecations in Ember CLI 3.2
 
-- Deprecate ember-cli-babel 5.x [(#7676)](https://github.com/ember-cli/ember-cli/pull/7676). Babel 6 support has been out for a long time now and works quite well. Babel 5 support is deprecated and will be dropped soon.
+#### ember-cli-babel 5
+
+This release of Ember CLI [deprecates `ember-cli-babel` 5.x](https://github.com/ember-cli/ember-cli/pull/7676). Babel 6 support has been out for a long time now and works quite well. Babel 5 support is deprecated and is expected to be dropped soon.
 
 For more details on the changes in Ember CLI 3.2.0-beta.1 and detailed upgrade
 instructions, please review the [Ember CLI 3.2.0-beta.1 release page](https://github.com/ember-cli/ember-cli/releases/tag/v3.2.0-beta.1).

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -1,0 +1,149 @@
+---
+title: Ember 3.1 and 3.2 Beta Released
+author: Ricardo Mendes
+tags: Releases
+---
+
+Today the Ember project is releasing version 3.1.0 of Ember.js, Ember Data, and Ember CLI.
+
+This release kicks off the 3.2 beta cycle for all sub-projects. We encourage our
+community (especially addon authors) to help test these beta builds and report
+any bugs before they are published as a final release in six weeks' time. The
+[ember-try](https://github.com/ember-cli/ember-try) addon is a great way to
+continuously test your projects against the latest Ember releases.
+
+You can read more about our general release process here:
+
+- [Release Dashboard](http://emberjs.com/builds/)
+- [The Ember Release Cycle](http://emberjs.com/blog/2013/09/06/new-ember-release-process.html)
+- [The Ember Project](http://emberjs.com/blog/2015/06/16/ember-project-at-2-0.html)
+- [Ember LTS Releases](http://emberjs.com/blog/2016/02/25/announcing-embers-first-lts.html)
+
+---
+
+## Ember.js
+
+Ember.js is the core framework for building ambitious web applications.
+
+### Changes in Ember.js 3.1
+
+Ember.js 3.1 is an incremental, backwards compatible release of Ember with
+bugfixes, performance improvements, and minor deprecations.
+
+#### Deprecations in Ember 3.1
+
+Deprecations are added to Ember.js when an API will be removed at a later date.
+
+Each deprecation has an entry in the deprecation guide describing the migration
+path to more stable API. Deprecated public APIs are not removed until a major
+release of the framework.
+
+Consider using the
+[ember-cli-deprecation-workflow](https://github.com/mixonic/ember-cli-deprecation-workflow)
+addon if you would like to upgrade your application without immediately addressing
+deprecations.
+
+Two new deprecations are introduces in Ember.js 3.1:
+
+* TODO
+* TODO
+
+For more details on changes in Ember.js 3.1, please review the
+[Ember.js 3.1.0 release page](https://github.com/emberjs/ember.js/releases/tag/v3.1.0).
+
+### Upcoming Changes in Ember.js 3.2
+
+Ember.js 3.2 will introduce two new features:
+
+* TODO
+* TODO
+
+#### Deprecations in Ember.js 3.2
+
+Two new deprecations are introduces in Ember.js 3.2:
+
+* TODO
+* TODO
+
+For more details on the upcoming changes in Ember.js 3.2, please review the
+[Ember.js 3.2.0-beta.1 release page](https://github.com/emberjs/ember.js/releases/tag/v3.2.0-beta.1).
+
+---
+
+## Ember Data
+
+Ember Data is the official data persistence library for Ember.js applications.
+
+### Changes in Ember Data 3.1
+
+#### Deprecations in Ember Data 3.1
+
+Two new deprecations are introduces in Ember Data 3.1:
+
+* TODO
+* TODO
+
+For more details on changes in Ember Data 3.1, please review the
+[Ember Data 3.1.0 release page](https://github.com/emberjs/data/releases/tag/v3.1.0).
+
+
+### Upcoming changes in Ember Data 3.2
+
+
+#### Deprecations in Ember Data 3.2
+
+For more details on the upcoming changes in Ember Data 3.2, please review the
+[Ember Data 3.2.0-beta.1 release page](https://github.com/emberjs/data/releases/tag/v3.2.0-beta.1).
+
+---
+
+## Ember CLI
+
+Ember CLI is the command line interface for managing and packaging Ember.js
+applications.
+
+### Upgrading Ember CLI
+
+You may upgrade Ember CLI separately from Ember.js and Ember Data! To upgrade
+your projects using `yarn` run:
+
+```
+yarn upgrade ember-cli
+```
+
+To upgrade your projects using `npm` run:
+
+```
+npm install --save-dev ember-cli
+```
+
+After running the
+upgrade command run `ember init` inside of the project directory to apply the
+blueprint changes. You can preview those changes for [applications](https://github.com/ember-cli/ember-new-output/compare/v3.0.0...v3.1.0)
+and [addons](https://github.com/ember-cli/ember-addon-output/compare/v3.0.0...v3.1.0).
+
+### Changes in Ember CLI 3.1
+
+#### Deprecations in Ember CLI 3.1
+
+Two new deprecations are introduces in Ember CLI 3.1:
+
+* TODO
+* TODO
+
+For more details on the changes in Ember CLI 3.1 and detailed upgrade
+instructions, please review the [Ember CLI  3.1.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/v3.1.0).
+
+### Upcoming Changes in Ember CLI 3.2
+
+#### Deprecations in Ember CLI 3.2
+
+For more details on the changes in Ember CLI 3.2.0-beta.1 and detailed upgrade
+instructions, please review the [Ember CLI 3.2.0-beta.1 release page](https://github.com/ember-cli/ember-cli/releases/tag/v3.2.0-beta.1).
+
+## Thank You!
+
+As a community-driven open-source project with an ambitious scope, each of
+these releases serve as a reminder that the Ember project would not have been
+possible without your continued support. We are extremely grateful to our
+contributors for their efforts.

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -287,7 +287,7 @@ flags](https://github.com/emberjs/data/pull/5384) for Ember
 Data. These feature flags have gone stale and Ember Data is going to
 attempt to go a different direction with some of the planned changes
 for 2018. Many of these feature flags have been around for a long
-time, if your app depends on enabling these feature flag to run please
+time. If your app depends on enabling these feature flag to run, please
 reach out to the Ember Data team by opening a github issue on the
 [Ember Data repo](https://github.com/emberjs/data/issues) and the
 Ember Data team will try to assist with the transition.

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -99,7 +99,7 @@ reach out to the Ember Data team by opening a github issue on the
 Ember Data team will try to assist with the transition.
 
 #### `ds-improved-ajax` Feature Flag
-Durring the Ember Data 3.2 beta cycle, the Ember Data team is planning
+During the Ember Data 3.2 beta cycle, the Ember Data team is planning
 on releasing an addon that will support the `ds-improved-ajax` API.
 
 #### `ds-pushpayload-return` Feature Flag
@@ -109,12 +109,23 @@ the following pattern to manually serialize the API response and push
 the record into the store.
 
 ```js
-let store = this.get('store');
-let ModelClass = store.modelFor('foo');
-let serializer = store.serializerFor('foo');
-let normalized = store.normalizeResponse(store, ModelClass, payload, null, 'query');
+export function pushPayload(store, modelName, rawPayload) {
+   let ModelClass = store.modelFor(modelName);
+   let serializer = store.serializerFor(modelName);
 
-return store.push(normalized);
+   let jsonApiPayload = serializer.normalizeResponse(store, ModelClass, rawPayload, null, 'query');
+
+  return store.push(jsonApiPayload);
+}
+```
+
+```diff
++import { pushPayload } from '<app-name>/utils/push-payload';
+
+...
+
+-this.get('store').pushPayload(modelName, rawPayload);
++pushPayload(this.get('store'), modelName, rawPayload);
 ```
 
 #### Deprecations in Ember Data 3.2

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -74,14 +74,13 @@ For more details on the upcoming changes in Ember.js 3.2, please review the
 
 Ember Data is the official data persistence library for Ember.js applications.
 
+Ember Data 3.1 contains bug fixes and build improvements for Ember Data.
+
 ### Changes in Ember Data 3.1
 
 #### Deprecations in Ember Data 3.1
 
-Two new deprecations are introduces in Ember Data 3.1:
-
-* TODO
-* TODO
+No new deprecations are introduced in Ember Data 3.1.
 
 For more details on changes in Ember Data 3.1, please review the
 [Ember Data 3.1.0 release page](https://github.com/emberjs/data/releases/tag/v3.1.0).
@@ -89,8 +88,38 @@ For more details on changes in Ember Data 3.1, please review the
 
 ### Upcoming changes in Ember Data 3.2
 
+Ember Data 3.2 removes [all current feature
+flags](https://github.com/emberjs/data/pull/5384) for Ember
+Data. These feature flags have gone stale and Ember Data is going to
+attempt to go a different direction with some of the planned changes
+for 2018. Many of these feature flags have been around for a long
+time, if your app depends on enabling these feature flag to run please
+reach out to the Ember Data team by opening a github issue on the
+[Ember Data repo](https://github.com/emberjs/data/issues) and the
+Ember Data team will try to assist with the transition.
+
+#### `ds-improved-ajax` Feature Flag
+Durring the Ember Data 3.2 beta cycle, the Ember Data team is planning
+on releasing an addon that will support the `ds-improved-ajax` API.
+
+#### `ds-pushpayload-return` Feature Flag
+
+If you rely on the `ds-pushpayload-return` feature flag you can use
+the following pattern to manually serialize the API response and push
+the record into the store.
+
+```js
+let store = this.get('store');
+let ModelClass = store.modelFor('foo');
+let serializer = store.serializerFor('foo');
+let normalized = store.normalizeResponse(store, ModelClass, payload, null, 'query');
+
+return store.push(normalized);
+```
 
 #### Deprecations in Ember Data 3.2
+
+There are no new deprecations planned for Ember Data 3.2.
 
 For more details on the upcoming changes in Ember Data 3.2, please review the
 [Ember Data 3.2.0-beta.1 release page](https://github.com/emberjs/data/releases/tag/v3.2.0-beta.1).

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -248,16 +248,15 @@ For more details on changes in Ember.js 3.1, please review the
 
 Ember.js 3.2 will introduce two new features:
 
-* TODO
-* TODO
+- TODO
+- TODO
 
 ### Deprecations in Ember.js 3.2
 
 **Three** new deprecations are introduced in Ember.js 3.2:
 
 1. Use of `Ember.Logger` is deprecated. You should replace any calls to `Ember.Logger` with calls to `console`. Read more about this deprecation on the [deprecation page.](https://emberjs.com/deprecations/v3.x#toc_ember-console-deprecate-logger)
-2. The `Router#route` private API has been renamed to `Router#_route` to avoid collisions with user-defined
-properties or methods. Read more about this deprecation on the [deprecation page.](https://emberjs.com/deprecations/v3.x#toc_ember-routing-route-router)
+2. The `Router#route` private API has been renamed to `Router#_route` to avoid collisions with user-defined properties or methods. Read more about this deprecation on the [deprecation page.](https://emberjs.com/deprecations/v3.x#toc_ember-routing-route-router)
 3. Use defineProperty to define computed properties. Read more about this deprecation on the [deprecation page.](https://emberjs.com/deprecations/v3.x#toc_ember-meta-descriptor-on-object)
 
 For more details on the upcoming changes in Ember.js 3.2, please review the
@@ -279,18 +278,17 @@ Ember Data 3.1 contains bug fixes and build improvements for Ember Data.
 
 **Two** new deprecations are introduced in Ember Data 3.1.
 
-- `Ember.Map` was a private API provided by Ember (for quite some time). Unfortunately, ember-data made `Ember.Map` part of its public API surface via documentation blocks. `Ember.Map` will be deprecated and removed from Ember "soon" [(https://github.com/emberjs/rfcs/pull/237)](https://github.com/emberjs/rfcs/pull/237) and we would like to confirm that Ember Data will work without deprecation before and after that happens.`Ember.Map` differs from native `Map` in a few ways:
-  * `Ember.Map` has custom `copy` and `isEmpty` methods which are not present in native `Map`
-  * `Ember.Map` adds a static `create` method (which simply instantiates itself with `new Ember.Map()`)
-  * `Ember.Map` does not accept constructor arguments
-  * `Ember.Map` does not have:
-    * `@@species`
-    * `@@iterator`
-    * `entries`
-    * `values`
-  This implementation adds a deprecated backwards compatibility for:
-  * `copy`
-  * `isEmpty`
+* `Ember.Map` was a private API provided by Ember (for quite some time). Unfortunately, ember-data made `Ember.Map` part of its public API surface via documentation blocks. `Ember.Map` will be deprecated and removed from Ember "soon" [(https://github.com/emberjs/rfcs/pull/237)](https://github.com/emberjs/rfcs/pull/237) and we would like to confirm that Ember Data will work without deprecation before and after that happens.`Ember.Map` differs from native `Map` in a few ways:
+    * `Ember.Map` has custom `copy` and `isEmpty` methods which are not present in native `Map`
+    * `Ember.Map` adds a static `create` method (which simply instantiates itself with `new Ember.Map()`)
+    * `Ember.Map` does not accept constructor arguments
+    * `Ember.Map` does not have:
+      * `@@species`
+      * `@@iterator`
+      * `entries`
+      * `values` This implementation adds a deprecated backwards compatibility for:
+          * `copy`
+          * `isEmpty`
 
 This is needed because `Map` requires instantiation with `new` and by default Babel transpilation will do `superConstructor.apply(this, arguments)` which throws an error with native `Map`. The desired code (if we lived in an "only native class" world) would be:
 
@@ -316,7 +314,6 @@ This is needed because `Map` requires instantiation with `new` and by default Ba
 For more details on changes in Ember Data 3.1, please review the
 [Ember Data 3.1.0 release page](https://github.com/emberjs/data/releases/tag/v3.1.0).
 
-
 ### Upcoming changes in Ember Data 3.2
 
 #### Lazy Relationship Payloads (1 of 4)
@@ -325,26 +322,16 @@ For more details on changes in Ember Data 3.1, please review the
 
 #### Ember Data Feature Flag Removal (2 of 4)
 
-Ember Data 3.2 removes [all current feature
-flags](https://github.com/emberjs/data/pull/5384) for Ember
-Data. These feature flags have gone stale and Ember Data is going to
-attempt to go a different direction with some of the planned changes
-for 2018. Many of these feature flags have been around for a long
-time. If your app depends on enabling these feature flag to run, please
-reach out to the Ember Data team by opening a github issue on the
-[Ember Data repo](https://github.com/emberjs/data/issues) and the
-Ember Data team will try to assist with the transition.
+Ember Data 3.2 removes [all current feature flags](https://github.com/emberjs/data/pull/5384) for Ember Data. These feature flags have gone stale and Ember Data is going to
+attempt to go a different direction with some of the planned changes for 2018. Many of these feature flags have been around for a long time. If your app depends on enabling these feature flag to run, please reach out to the Ember Data team by opening a github issue on the [Ember Data repo](https://github.com/emberjs/data/issues) and the Ember Data team will try to assist with the transition.
 
 #### Feature Flag `ds-improved-ajax` (3 of 4)
 
-During the Ember Data 3.2 beta cycle, the Ember Data team is planning
-on releasing an addon that will support the `ds-improved-ajax` API.
+During the Ember Data 3.2 beta cycle, the Ember Data team is planning on releasing an addon that will support the `ds-improved-ajax` API.
 
 #### Feature Flag `ds-pushpayload-return` (4 of 4)
 
-If you rely on the `ds-pushpayload-return` feature flag you can use
-the following pattern to manually serialize the API response and push
-the record into the store.
+If you rely on the `ds-pushpayload-return` feature flag you can use the following pattern to manually serialize the API response and push the record into the store.
 
 ```js
 export function pushPayload(store, modelName, rawPayload) {
@@ -370,35 +357,29 @@ export function pushPayload(store, modelName, rawPayload) {
 
 There are no new deprecations planned for Ember Data 3.2.
 
-For more details on the upcoming changes in Ember Data 3.2, please review the
-[Ember Data 3.2.0-beta.1 release page](https://github.com/emberjs/data/releases/tag/v3.2.0-beta.1).
+For more details on the upcoming changes in Ember Data 3.2, please review the [Ember Data 3.2.0-beta.1 release page](https://github.com/emberjs/data/releases/tag/v3.2.0-beta.1).
 
 ---
 
 ## Ember CLI
 
-Ember CLI is the command line interface for managing and packaging Ember.js
-applications.
+Ember CLI is the command line interface for managing and packaging Ember.js applications.
 
 ### Upgrading Ember CLI
 
-You may upgrade Ember CLI separately from Ember.js and Ember Data! To upgrade
-your projects using `yarn` run:
+You may upgrade Ember CLI separately from Ember.js and Ember Data! To upgrade your projects using `yarn` run:
 
-```
+```bash
 yarn upgrade ember-cli
 ```
 
 To upgrade your projects using `npm` run:
 
-```
+```bash
 npm install --save-dev ember-cli
 ```
 
-After running the
-upgrade command run `ember init` inside of the project directory to apply the
-blueprint changes. You can preview those changes for [applications](https://github.com/ember-cli/ember-new-output/compare/v3.0.0...v3.1.0)
-and [addons](https://github.com/ember-cli/ember-addon-output/compare/v3.0.0...v3.1.0).
+After running the upgrade command run `ember init` inside of the project directory to apply the blueprint changes. You can preview those changes for [applications](https://github.com/ember-cli/ember-new-output/compare/v3.0.0...v3.1.0) and [addons](https://github.com/ember-cli/ember-addon-output/compare/v3.0.0...v3.1.0).
 
 ### Changes in Ember CLI 3.1
 
@@ -423,15 +404,13 @@ Module Unification continues...
 
 No new deprecations are introduced in Ember CLI 3.1:
 
-For more details on the changes in Ember CLI 3.1 and detailed upgrade
-instructions, please review the [Ember CLI  3.1.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/v3.1.0).
+For more details on the changes in Ember CLI 3.1 and detailed upgrade instructions, please review the [Ember CLI  3.1.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/v3.1.0).
 
 ### Upcoming Changes in Ember CLI 3.2
 
 - [#7605](https://github.com/ember-cli/ember-cli/pull/7605) blueprints/app: Add `qunit-dom` dependency by default [@Turbo87](https://github.com/Turbo87)
 
-`qunit-dom` will be added by default to all apps and addons, if you don't (plan to) use it you don't have to add it.
-https://github.com/simplabs/qunit-dom-codemod exists to ease migration.
+`qunit-dom` will be added by default to all apps and addons, if you don't (plan to) use it, you don't have to add it. https://github.com/simplabs/qunit-dom-codemod exists to ease migration.
 
 - [#7501](https://github.com/ember-cli/ember-cli/pull/7501) add delayed transpilation [@kellyselden](https://github.com/kellyselden)
 - [#7650](https://github.com/ember-cli/ember-cli/pull/7650) compile all addons at once optimization [@kellyselden](https://github.com/kellyselden)

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -30,8 +30,9 @@ Ember.js is the core framework for building ambitious web applications.
 
 Ember 3.1 is a minor release containing several new features and bug fixes. It includes a bump of Glimmer VM, Ember's rendering implementation, to version 0.30.5.
 
-#### ES5 Getters for Computed Properties
-Ember's object system has long used `set` and `get` to access properties. These APIs came from the codebase's origins in SproutCore, and predated ES5's`defineProperty`. In recent years native JavaScript setter and getter implementations have become fast and mature.
+#### ES5 Getters for Computed Properties (1 of 5)
+
+Ember's object system has long used `set` and `get` to access properties. These APIs came from the codebase's origins in SproutCore, and predated ES5's `defineProperty`. In recent years native JavaScript setter and getter implementations have become fast and mature.
 
 Starting in Ember 3.1 (and described in [RFC281](https://github.com/emberjs/rfcs/blob/master/text/0281-es5-getters.md)) you are now able to read the value of a computed property using a native ES5 getter. For example, this component which uses computed properties:
 
@@ -74,10 +75,10 @@ export default Component.extend({
 Legacy `get` features are not deprecated or removed in 3.1. In fact there are
 several cases where you must still use `get`:
 
-* If you are calling `get` with a chained path. For example in `this.get('a.b.c')` if `b` is `undefined` the return value is `undefined`. Converting this
+- If you are calling `get` with a chained path. For example in `this.get('a.b.c')` if `b` is `undefined` the return value is `undefined`. Converting this
 to `this.a.b.c` when `b` is `undefined` would instead raise an exception.
-* If your object is using `unknownProperty` you must continue to use `get`. Using an ES5 getter on an object with `unknownProperty` will cause an assertion failure in development.
-* Ember Data returns promise proxy objects when you read an async relationship and from other API. Ember proxy objects, including promise proxies, still require that you call `get` to read values.
+- If your object is using `unknownProperty` you must continue to use `get`. Using an ES5 getter on an object with `unknownProperty` will cause an assertion failure in development.
+- Ember Data returns promise proxy objects when you read an async relationship and from other API. Ember proxy objects, including promise proxies, still require that you call `get` to read values.
 
 With these caveats in mind, how should you know if you can convert a `get` call to a native getter? If you have code where `get` is called on `this` you likely can convert it. If you have a `get` on another object, `anything.get('foo')`, you should exercise caution when converting to a native getter.
 
@@ -85,7 +86,7 @@ The community-provided [es5-getter-ember-codemod](https://github.com/rondale-sc/
 
 Thanks to [Chris Garrett](https://twitter.com/pzuraq) for pushing forward work on ES5 getters with support from [Godfrey Chan](https://twitter.com/chancancode), [Robert Jackson](https://twitter.com/rwjblue/), and [Kris Selden](https://twitter.com/krisselden)). Thanks to [Jonathan Jackson](https://twitter.com/rondale_sc/) for his work on the codemod.
 
-#### Introducing Optional Features
+#### Introducing Optional Features (2 of 5)
 
 Because major releases of Ember are not supposed to make breaking changes without prior deprecation, the project has been extremely conservative about changing behaviors that don't have a clear deprecation path. As a result, we've had several quirks of the framework linger into the 3.x series.
 
@@ -101,7 +102,7 @@ ember install @ember/optional-features
 
 Thanks to [Godfrey Chan](https://twitter.com/chancancode) and [Robert Jackson](https://twitter.com/rwjblue/) for their work on the optional features system.
 
-#### New Optional Feature: Application Template Wrapper
+#### New Optional Feature: Application Template Wrapper (3 of 5) 
 
 Ember applications have long created a wrapping `div` around their rendered content: `<div class="ember-view">`. With ember-optional-features, this functionality can now be disabled:
 
@@ -115,7 +116,7 @@ Additionally, enabling this feature will prompt you to optionally run a codemod 
 
 Although disabling this feature will eventually be the default for Ember, leaving the feature enabled is not deprecated in this release. You can read more details about this optional feature and the motivations for introducing it in [RFC #280](https://github.com/emberjs/rfcs/blob/master/text/0280-remove-application-wrapper.md).
 
-#### New Optional Feature: Template-only Glimmer Components
+#### New Optional Feature: Template-only Glimmer Components (4 of 5)
 
 Ember components implicitly create an element in the DOM where they are invoked, and the contents of their templates are then treated as "innerHTML" inside that DOM element. For example, this component template:
 
@@ -179,7 +180,7 @@ However, enabling this feature will prompt you to optionally run a codemod which
 
 Although enabling this feature will eventually be the default for Ember, leaving the feature disabled is not deprecated in this release. You can read more details about this optional feature and the motivations for introducing it in [RFC #278](https://github.com/emberjs/rfcs/blob/master/text/0278-template-only-components.md).
 
-#### Positional Params Bug Fix
+#### Positional Params Bug Fix (5 of 5)
 
 Ember introduced contextual components in Ember 2.3. Contextual components close over arguments and are intended to do so in a manner consistent with closures in JavaScript.
 
@@ -198,7 +199,7 @@ In Ember 3.1 we've corrected the implementation to act like a proper closure. In
 For more information about this change see
 [emberjs/ember.js#15287](https://github.com/emberjs/ember.js/pull/15287).
 
-#### Deprecations in Ember 3.1
+### Deprecations in Ember 3.1
 
 Deprecations are added to Ember.js when an API will be removed at a later date.
 
@@ -211,10 +212,10 @@ Consider using the
 addon if you would like to upgrade your application without immediately addressing
 deprecations.
 
-Two new deprecations are introduced in Ember.js 3.1:
+**Two** new deprecations are introduced in Ember.js 3.1:
 
-- Calling `array.get('@each')` is deprecated. `@each` may only be used as dependency key.
-- The private APIs `propertyWillChange` and `propertyDidChange` will be removed after the first LTS of the 3.x cycle. You should remove any calls to `propertyWillChange` and replace any calls to `propertyDidChange` with `notifyPropertyChange`. This applies to both the Ember global version and the EmberObject method version.
+1. Calling `array.get('@each')` is deprecated. `@each` may only be used as dependency key.
+2. The private APIs `propertyWillChange` and `propertyDidChange` will be removed after the first LTS of the 3.x cycle. You should remove any calls to `propertyWillChange` and replace any calls to `propertyDidChange` with `notifyPropertyChange`. This applies to both the Ember global version and the EmberObject method version.
 
 For example, the following:
 
@@ -238,7 +239,7 @@ doStuff(object);
 object.notifyPropertyChange('someProperty');
 ```
 
-If you are an addon author and need to support both Ember applications greater than 3.1 *and* less than 3.1 you can use the polyfill [ember-notify-property-change-polyfill](https://github.com/rondale-sc/ember-notify-property-change-polyfill)
+If you are an addon author and need to support both Ember applications greater than 3.1 *and* less than 3.1 you can use the polyfill [ember-notify-property-change-polyfill](https://github.com/rondale-sc/ember-notify-property-change-polyfill).
 
 For more details on changes in Ember.js 3.1, please review the
 [Ember.js 3.1.0 release page](https://github.com/emberjs/ember.js/releases/tag/v3.1.0).
@@ -250,14 +251,14 @@ Ember.js 3.2 will introduce two new features:
 * TODO
 * TODO
 
-#### Deprecations in Ember.js 3.2
+### Deprecations in Ember.js 3.2
 
-Three new deprecations are introduced in Ember.js 3.2:
+**Three** new deprecations are introduced in Ember.js 3.2:
 
-- Use of `Ember.Logger` is deprecated. You should replace any calls to `Ember.Logger` with calls to `console`. Read more about this deprecation on the [deprecation page.](https://emberjs.com/deprecations/v3.x#toc_ember-console-deprecate-logger)
-- The `Router#route` private API has been renamed to `Router#_route` to avoid collisions with user-defined
+1. Use of `Ember.Logger` is deprecated. You should replace any calls to `Ember.Logger` with calls to `console`. Read more about this deprecation on the [deprecation page.](https://emberjs.com/deprecations/v3.x#toc_ember-console-deprecate-logger)
+2. The `Router#route` private API has been renamed to `Router#_route` to avoid collisions with user-defined
 properties or methods. Read more about this deprecation on the [deprecation page.](https://emberjs.com/deprecations/v3.x#toc_ember-routing-route-router)
-- Use defineProperty to define computed properties. Read more about this deprecation on the [deprecation page.](https://emberjs.com/deprecations/v3.x#toc_ember-meta-descriptor-on-object)
+3. Use defineProperty to define computed properties. Read more about this deprecation on the [deprecation page.](https://emberjs.com/deprecations/v3.x#toc_ember-meta-descriptor-on-object)
 
 For more details on the upcoming changes in Ember.js 3.2, please review the
 [Ember.js 3.2.0-beta.1 release page](https://github.com/emberjs/ember.js/releases/tag/v3.2.0-beta.1).
@@ -272,15 +273,57 @@ Ember Data 3.1 contains bug fixes and build improvements for Ember Data.
 
 ### Changes in Ember Data 3.1
 
-#### Deprecations in Ember Data 3.1
+[#5273](https://github.com/emberjs/data/pull/5273) client-side-delete semantics `unloadRecord`
 
-No new deprecations are introduced in Ember Data 3.1.
+### Deprecations in Ember Data 3.1
+
+**Two** new deprecations are introduced in Ember Data 3.1.
+
+- `Ember.Map` was a private API provided by Ember (for quite some time). Unfortunately, ember-data made `Ember.Map` part of its public API surface via documentation blocks. `Ember.Map` will be deprecated and removed from Ember "soon" [(https://github.com/emberjs/rfcs/pull/237)](https://github.com/emberjs/rfcs/pull/237) and we would like to confirm that Ember Data will work without deprecation before and after that happens.`Ember.Map` differs from native `Map` in a few ways:
+  * `Ember.Map` has custom `copy` and `isEmpty` methods which are not present in native `Map`
+  * `Ember.Map` adds a static `create` method (which simply instantiates itself with `new Ember.Map()`)
+  * `Ember.Map` does not accept constructor arguments
+  * `Ember.Map` does not have:
+    * `@@species`
+    * `@@iterator`
+    * `entries`
+    * `values`
+  This implementation adds a deprecated backwards compatibility for:
+  * `copy`
+  * `isEmpty`
+
+This is needed because `Map` requires instantiation with `new` and by default Babel transpilation will do `superConstructor.apply(this, arguments)` which throws an error with native `Map`. The desired code (if we lived in an "only native class" world) would be:
+
+  ```js
+  export default class MapWithDeprecations extends Map {
+    constructor(options) {
+      super();
+      this.defaultValue = options.defaultValue;
+    }
+    get(key) {
+      let hasValue = this.has(key);
+      if (hasValue) {
+        return super.get(key);
+      } else {
+        let defaultValue = this.defaultValue(key);
+        this.set(key, defaultValue);
+        return defaultValue;
+      }
+    }
+  }
+  ```
 
 For more details on changes in Ember Data 3.1, please review the
 [Ember Data 3.1.0 release page](https://github.com/emberjs/data/releases/tag/v3.1.0).
 
 
 ### Upcoming changes in Ember Data 3.2
+
+#### Lazy Relationship Payloads (1 of 4)
+
+[#5230](https://github.com/emberjs/data/pull/5230) [BUGFIX] enable lazy-relationship payloads to work with polymorphic relationships
+
+#### Ember Data Feature Flag Removal (2 of 4)
 
 Ember Data 3.2 removes [all current feature
 flags](https://github.com/emberjs/data/pull/5384) for Ember
@@ -292,11 +335,12 @@ reach out to the Ember Data team by opening a github issue on the
 [Ember Data repo](https://github.com/emberjs/data/issues) and the
 Ember Data team will try to assist with the transition.
 
-#### `ds-improved-ajax` Feature Flag
+#### Feature Flag `ds-improved-ajax` (3 of 4)
+
 During the Ember Data 3.2 beta cycle, the Ember Data team is planning
 on releasing an addon that will support the `ds-improved-ajax` API.
 
-#### `ds-pushpayload-return` Feature Flag
+#### Feature Flag `ds-pushpayload-return` (4 of 4)
 
 If you rely on the `ds-pushpayload-return` feature flag you can use
 the following pattern to manually serialize the API response and push
@@ -322,7 +366,7 @@ export function pushPayload(store, modelName, rawPayload) {
 +pushPayload(this.get('store'), modelName, rawPayload);
 ```
 
-#### Deprecations in Ember Data 3.2
+### Deprecations in Ember Data 3.2
 
 There are no new deprecations planned for Ember Data 3.2.
 
@@ -358,19 +402,59 @@ and [addons](https://github.com/ember-cli/ember-addon-output/compare/v3.0.0...v3
 
 ### Changes in Ember CLI 3.1
 
-#### Deprecations in Ember CLI 3.1
+- [#7601](https://github.com/ember-cli/ember-cli/pull/7601) blueprints/addon: Replace `test` with `test:all` [@Turbo87](https://github.com/Turbo87)
 
-Two new deprecations are introduced in Ember CLI 3.1:
+`test` will run `ember test` now (like in apps), `test:all` will use `ember-try` to run tests in all configured scenarios
 
-* TODO
-* TODO
+- [#7492](https://github.com/ember-cli/ember-cli/pull/7492) Use yarn instead of npm when part of a yarn workspace root [@thetimothyp](https://github.com/thetimothyp)
+
+`yarn.lock` file detection improved
+
+- [#7573](https://github.com/ember-cli/ember-cli/pull/7573) Install optional dependencies when creating a new project [@t-sauer](https://github.com/t-sauer)
+
+Fixes issues with the Glimmer blueprints
+
+- [#7586](https://github.com/ember-cli/ember-cli/pull/7586) add feature flag to project.isModuleUnification [@GavinJoyce](https://github.com/GavinJoyce)
+- [#7541](https://github.com/ember-cli/ember-cli/pull/7541) Add `project.isModuleUnification()` [@GavinJoyce](https://github.com/GavinJoyce)
+
+Module Unification continues...
+
+### Deprecations in Ember CLI 3.1
+
+No new deprecations are introduced in Ember CLI 3.1:
 
 For more details on the changes in Ember CLI 3.1 and detailed upgrade
 instructions, please review the [Ember CLI  3.1.0 release page](https://github.com/ember-cli/ember-cli/releases/tag/v3.1.0).
 
 ### Upcoming Changes in Ember CLI 3.2
 
-#### Deprecations in Ember CLI 3.2
+- [#7605](https://github.com/ember-cli/ember-cli/pull/7605) blueprints/app: Add `qunit-dom` dependency by default [@Turbo87](https://github.com/Turbo87)
+
+`qunit-dom` will be added by default to all apps and addons, if you don't (plan to) use it you don't have to add it.
+https://github.com/simplabs/qunit-dom-codemod exists to ease migration.
+
+- [#7501](https://github.com/ember-cli/ember-cli/pull/7501) add delayed transpilation [@kellyselden](https://github.com/kellyselden)
+- [#7650](https://github.com/ember-cli/ember-cli/pull/7650) compile all addons at once optimization [@kellyselden](https://github.com/kellyselden)
+
+experiments with more efficient transpilation
+
+- [#7637](https://github.com/ember-cli/ember-cli/pull/7637) More comprehensive detect if ember-cli is being run within CI or not. [@ember-cli](https://github.com/ember-cli)
+
+see https://github.com/watson/ci-info/
+
+- [#7658](https://github.com/ember-cli/ember-cli/pull/7658) Module Unification Addon blueprint [@cibernox](https://github.com/cibernox)
+- [#7490](https://github.com/ember-cli/ember-cli/pull/7490) Module Unification Addons [@ember-cli](https://github.com/ember-cli)
+- [#7660](https://github.com/ember-cli/ember-cli/pull/7660) improve logic for if addon is module-unification [@iezer](https://github.com/iezer)
+- [#7667](https://github.com/ember-cli/ember-cli/pull/7667) MU addons must generate a MU dummy app [@cibernox](https://github.com/cibernox)
+- [#7678](https://github.com/ember-cli/ember-cli/pull/7678) Use a recent release of Ember canary for MU [@ember-cli](https://github.com/ember-cli)
+
+Module Unification continues...
+
+### Deprecations in Ember CLI 3.2
+
+- [#7676](https://github.com/ember-cli/ember-cli/pull/7676) Deprecate ember-cli-babel 5.x [@raytiley](https://github.com/raytiley)
+
+Babel 6 support has been out for a long time now and works quite well. Babel 5 support is deprecated and will be dropped soon.
 
 For more details on the changes in Ember CLI 3.2.0-beta.1 and detailed upgrade
 instructions, please review the [Ember CLI 3.2.0-beta.1 release page](https://github.com/ember-cli/ember-cli/releases/tag/v3.2.0-beta.1).

--- a/source/blog/2018-03-26-ember-3-1-released.md
+++ b/source/blog/2018-03-26-ember-3-1-released.md
@@ -211,7 +211,7 @@ Consider using the
 addon if you would like to upgrade your application without immediately addressing
 deprecations.
 
-Two new deprecations are introduces in Ember.js 3.1:
+Two new deprecations are introduced in Ember.js 3.1:
 
 - Calling `array.get('@each')` is deprecated. `@each` may only be used as dependency key.
 - The private APIs `propertyWillChange` and `propertyDidChange` will be removed after the first LTS of the 3.x cycle. You should remove any calls to `propertyWillChange` and replace any calls to `propertyDidChange` with `notifyPropertyChange`. This applies to both the Ember global version and the EmberObject method version.
@@ -252,7 +252,7 @@ Ember.js 3.2 will introduce two new features:
 
 #### Deprecations in Ember.js 3.2
 
-Three new deprecations are introduces in Ember.js 3.2:
+Three new deprecations are introduced in Ember.js 3.2:
 
 - Use of `Ember.Logger` is deprecated. You should replace any calls to `Ember.Logger` with calls to `console`. Read more about this deprecation on the [deprecation page.](https://emberjs.com/deprecations/v3.x#toc_ember-console-deprecate-logger)
 - The `Router#route` private API has been renamed to `Router#_route` to avoid collisions with user-defined
@@ -360,7 +360,7 @@ and [addons](https://github.com/ember-cli/ember-addon-output/compare/v3.0.0...v3
 
 #### Deprecations in Ember CLI 3.1
 
-Two new deprecations are introduces in Ember CLI 3.1:
+Two new deprecations are introduced in Ember CLI 3.1:
 
 * TODO
 * TODO

--- a/source/stylesheets/base/_typography.scss
+++ b/source/stylesheets/base/_typography.scss
@@ -107,7 +107,11 @@ p {
     margin: 0 auto;
     padding: 0.5em;
   }
+  strong {
+    font-weight: bold !important;
+  }
 }
+
 
 // helper classes
 .lead { font-size: 1.3em; }

--- a/source/stylesheets/blog.css.scss
+++ b/source/stylesheets/blog.css.scss
@@ -158,9 +158,16 @@ body.blog.responsive {
   .blog-post-body {
     max-width: 100%;
     h2 {
-      margin-bottom: 0;
+      margin-bottom: 0.5em;
       margin-top: 0.75em;
       text-align: left;
+    }
+    code {
+      // this is different than code in other places. We are making it more readable for the blog.
+      background-color: rgba(0,0,0,0.1);
+      color: #222;
+      font-size: 0.9em;
+      padding: 0 4px 1px;
     }
     p {
       @media screen and (max-width: 991px) and (min-width: 0) {


### PR DESCRIPTION

- [Rendered](https://github.com/emberjs/website/blob/3-1-release-blog-post/source/blog/2018-03-26-ember-3-1-released.md)
- Preview

## Sign-offs

- [ ] Ember.js (@chancancode)
- [x] Ember Data (@bmac)
- [ ] Ember CLI (@rwjblue)
- [ ] Website (@locks, @mixonic)

## Checklist

- Ember
  - [ ] Blog
  - [ ] v3.1.0
  - [ ] v3.2.0-beta.1
- Ember Data
  - [ ] Blog
  - [ ] v3.1.0
  - [ ] v3.2.0-beta.1
- Ember CLI
  - [ ] Blog
  - [ ] v3.1.0
  - [ ] v3.2.0-beta.1

See https://github.com/emberjs/website/pull/2824/files for inspiration.