### PR TITLE
fixed a css bug

### DIFF
--- a/source/ember-users.html.erb
+++ b/source/ember-users.html.erb
@@ -16,7 +16,7 @@ responsive: true
 
 <div class="users section">
 
-<ul class="showcase">
+<ul class="user-showcase">
   <% data.users.each do |user| %>
     <li>
       <a href="<%= user.url %>" rel="nofollow" target="_blank" class="user-showcase__link">

--- a/source/stylesheets/pages/ember-users.css.scss
+++ b/source/stylesheets/pages/ember-users.css.scss
@@ -3,7 +3,7 @@
   .main {
       margin: 0 auto;
   }
-  .showcase {
+  .user-showcase {
     align-content: middle;
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
Fixed the naming of the ember users CSS because it conflicted with the CSS on the learn page and it was making things look all wonky. 