### PR TITLE
update to the teams page

### DIFF
--- a/data/team.yml
+++ b/data/team.yml
@@ -1,40 +1,54 @@
 - name: Yehuda Katz
+  first: Yehuda
+  last: Katz
   github: https://github.com/wycats
   twitter: https://twitter.com/wycats
   image: ykatz.jpg
   teams:
     - core
 - name: Tom Dale
+  first: Tom
+  Last: Dale
   github: https://github.com/tomdale
   twitter: https://twitter.com/tomdale
   image: tdale.jpg
   teams:
     - core
 - name: Peter Wagenet
+  first: Peter
+  last: Wagenet
   github: https://github.com/wagenet
   twitter: https://twitter.com/wagenet
   image: pwagenet.jpg
   teams:
     - corealumni
 - name: Trek Glowacki
+  first: Trek
+  last: Glowack
   github: https://github.com/trek
   twitter: https://twitter.com/trek
   image: tglowaki.jpg
   teams:
     - corealumni
 - name: Erik Bryn
+  first: Erik
+  last: Bryn
   github: https://github.com/ebryn
   twitter: https://twitter.com/ebryn
   image: ebryn.jpg
   teams:
     - corealumni
 - name: Kris Selden
+  first: Kris
+  last: Selden
   github: https://github.com/krisselden
   twitter: https://twitter.com/krisselden
   image: kselden.jpg
   teams:
     - core
 - name: Stefan Penner
+  first: Stefan
+  last: Penner
   github: https://github.com/stefanpenner
   twitter: https://twitter.com/stefanpenner
   image: spenner.jpg
@@ -42,6 +56,8 @@
     - core
     - cli
 - name: Leah Silber
+  first: Leah
+  last: Silber
   github: https://github.com/wifelette
   twitter: https://twitter.com/wifelette
   image: lsilber.jpg
@@ -49,12 +65,16 @@
     - core
     - learning
 - name: Alex Matchneer
+  first: Alex
+  last: Matchneer
   github: https://github.com/machty
   twitter: https://twitter.com/machty
   image: amatchneer.jpg
   teams:
     - corealumni
 - name: Robert Jackson
+  first: Robert
+  last: Jackson
   github: https://github.com/rwjblue
   twitter: https://twitter.com/rwjblue
   image: rjackson.jpg
@@ -62,6 +82,8 @@
     - core
     - cli
 - name: Igor Terzic
+  first: Igor
+  last: Terzic
   github: https://github.com/igorT
   twitter: https://twitter.com/terzicigor
   image: iterzic.jpeg
@@ -69,65 +91,88 @@
     - core
     - data
 - name: Matthew Beale
+  first: Matthew
+  last: Beale
   github: https://github.com/mixonic
   twitter: https://twitter.com/mixonic
   image: mbeale.jpg
   teams:
     - core
 - name: Edward Faulkner
+  first: Edward
+  last: Faulkner
   github: https://github.com/ef4
   twitter: https://twitter.com/eaf4
   image: efaulkner.jpg
   teams:
     - core
 - name: Martin Muñoz
+  first: Martin
+  last: Muñoz
   github: https://github.com/mmun
   twitter: https://twitter.com/_mmun
   image: mmunoz.jpg
   teams:
     - core
 - name: Dan Gebhardt
+  first: Dan
+  last: Gebhardt
   github: https://github.com/dgeb
   twitter: https://twitter.com/dgeb
   image: dgeb.jpg
   teams:
     - core
 - name: Godfrey Chan
+  first: Godfrey
+  last: Chan
   github: https://github.com/chancancode
   twitter: https://twitter.com/chancancode
   image: godfrey.jpg
   teams:
     - core
-
 - name: Brendan McLoughlin
+  first: Brendan
+  last: McLoughlin
   github: https://github.com/bmac
+  twitter: https://twitter.com/
   image: bmcloughlin.png
   teams:
     - data
 - name: Christoffer Persson
+  first: Christoffer
+  last: Persson
   github: https://github.com/wecc
   twitter: https://twitter.com/ChristofferP
   image: cpersson.jpg
   teams:
     - data
 - name: Clemens Müller
+  first: Clemens
+  last: Müller
   github: https://github.com/pangratz
+  twitter: https://twitter.com/
   image: cmueller.jpg
   teams:
     - data
 - name: Stanley Stuart
+  first: Stanley
+  last: Stuart
   github: https://github.com/fivetanley
   twitter: https://twitter.com/fivetanley
   image: fivetanley.jpg
   teams:
     - data
-
 - name: David Baker
+  first: David
+  last: Baker
   github: https://github.com/acorncom
+  twitter: https://twitter.com/
   image: dbaker.jpg
   teams:
     - learning
 - name: Ricardo Mendes
+  first: Ricardo
+  last: Mendes
   github: https://github.com/locks
   twitter: https://twitter.com/locks
   image: rmendes.jpg
@@ -135,12 +180,17 @@
     - core
     - learning
 - name: Todd Jordan
+  first: Todd
+  last: Jordan
   github: https://github.com/toddjordan
+  twitter: https://twitter.com/ 
   image: tjordan.jpg
   teams:
     - learning
 
 - name: Chad Hietala
+  first: Chad
+  last: Hietala
   github: https://github.com/chadhietala
   twitter: https://twitter.com/chadhietala
   image: chietala.jpg
@@ -148,11 +198,16 @@
     - core
     - cli
 - name: Jacob Bixby
+  first: Jacob
+  last: Bixby
   github: https://github.com/trabus
+  twitter: https://twitter.com/
   image: jbixby.jpg
   teams:
     - cli
 - name: Katie Gengler
+  first: Katie
+  last: Gengler
   github: https://github.com/kategengler
   twitter: https://twitter.com/katiegengler
   image: kgengler.jpg
@@ -160,54 +215,83 @@
     - core
     - cli
 - name: Kelly Selden
+  first: Kelly
+  last: Selden
   github: https://github.com/kellyselden
+  twitter: https://twitter.com/
   image: kellyselden.jpg
   teams:
     - cli
 - name: Nathan Hammond
+  first: Nathan
+  last: Hammond
   github: https://github.com/nathanhammond
   twitter: https://twitter.com/nathanhammond
   image: nhammond.jpg
   teams:
     - cli
 - name: Tobias Bieniek
+  first: Tobias
+  last: Bieniek
   github: https://github.com/Turbo87
+  twitter: https://twitter.com/
   image: tbieniek.jpg
   teams:
     - cli
 - name: Krati Ahuja
+  first: Krati
+  last: Ahuja
   github: https://github.com/kratiahuja
+  twitter: https://twitter.com/
   image: kratiahuja.jpg
   teams:
     - cli
 - name: Sivakumar Kailasam
+  first: Sivakumar
+  last: Kailasam
   github: https://github.com/sivakumar-kailasam
+  twitter: https://twitter.com/
   image: skailasam.jpg
   teams:
     - learning
 - name: Terence Lee
+  first: Terence
+  last: Lee
   github: https://github.com/hone
+  twitter: https://twitter.com/
   image: tlee.png
   teams:
     - learning
 - name: Jen Weber
+  first: Jen
+  last: Weber
   github: https://github.com/jenweber
+  twitter: https://twitter.com/
   image: jweber.jpg
   teams:
     - learning
 - name: Jessica Jordan
+  first: Jessica
+  last: Jordan
   github: https://github.com/jessica-jordan
+  twitter: https://twitter.com/
   image: jjordan.jpg
   teams:
     - learning
 - name: Melanie Sumner
+  first: Melanie
+  last: Sumner
   github: https://github.com/melsumner
+  twitter: https://twitter.com/melaniersumner
   image: msumner.jpg
   teams:
     - core
     - learning
 - name: Alex Navasardyan
+  first: Alex
+  last: Navasardyan
   github: https://github.com/twokul
+  twitter: https://twitter.com/
   image: anavasardyan.jpg
   teams:
     - cli

--- a/source/stylesheets/base/_typography.scss
+++ b/source/stylesheets/base/_typography.scss
@@ -32,6 +32,7 @@ h1 {
   font-size: 2.25em;
   font-weight: bold;
   line-height: 1.125;
+  margin-bottom: 0.5em;
   max-width: 100%;
   @media screen and (min-width: 0) and (max-width: $screen-sm-max) {
     text-align: center;

--- a/source/stylesheets/pages/teams.css.scss
+++ b/source/stylesheets/pages/teams.css.scss
@@ -8,38 +8,42 @@ body.team {
   }
 
   #content .headshots { /* #content is needed for specifity override */
-    max-width: 760px;
-    width: 100%;
     margin: 0 auto;
+    max-width: 90%;
+    text-align: center;
+    width: 100%;
 
     a:hover {
       border-bottom: none;
     }
 
     > li {
+      box-sizing: border-box;
       display: inline-block;
-      width: 24%;
-      text-align: center;
       padding: 40px 0 0;
+      text-align: center;
+      width: 20%;
 
-      @media screen and (max-width: 860px) {
-        width: 32%;
-      }
-      @media screen and (max-width: 560px) {
+      @media screen and (max-width: 600px) {
         width: 49%;
       }
 
       p {
-        margin: 0px 0px 5px 0px;
         font-weight: bold;
+        margin: 0px 0px 5px 0px;
       }
 
       img {
-        margin-bottom: 10px;
         border-radius: 50%;
-        width: 130px;
-        height: 130px;
         border: 2px solid #faf4f1;
+        height: 120px;
+        margin-bottom: 10px;
+        width: 120px;
+
+        &.alumni {
+          height: 90px;
+          width: 90px;
+        }
 
         &:hover,
         &:active,
@@ -47,7 +51,6 @@ body.team {
           border: 0;
         }
       }
-
       .social {
         margin: 0 auto !important;
 
@@ -68,26 +71,20 @@ body.team {
     }
 
     &.contributors {
+      li {
+        width: 19%;
+      }
       .avatar {
         position: relative;
       }
 
       img {
-        width: 100px;
-        height: 100px;
+        height: 90px;
+        width: 90px;
       }
 
       .type {
         display: none;
-        // position: absolute;
-        // left: 5px;
-        // right: 5px;
-        // top: -9px;
-        // color: #fff;
-        // font-size: 12px;
-        // line-height: 1.5em;
-        // border-radius: 2px;
-        // background-color: $orange-darker;
       }
     }
   }

--- a/source/stylesheets/pages/teams.css.scss
+++ b/source/stylesheets/pages/teams.css.scss
@@ -3,7 +3,7 @@ body.team {
   hr {
     height: 1px;
     border: none;
-    margin: 4em 0;
+    margin: 1em 0 0.5em 0;
     background-color: #dfd7d4;
   }
 
@@ -30,7 +30,7 @@ body.team {
       }
 
       p {
-        margin: 0px 0px 10px 0px;
+        margin: 0px 0px 5px 0px;
         font-weight: bold;
       }
 
@@ -49,7 +49,7 @@ body.team {
       }
 
       .social {
-        margin-bottom: 0;
+        margin: 0 auto !important;
 
         > li {
           display: inline-block;
@@ -73,21 +73,21 @@ body.team {
       }
 
       img {
-        width: 66px;
-        height: 66px;
+        width: 100px;
+        height: 100px;
       }
 
       .type {
-        display: block;
-        position: absolute;
-        left: 5px;
-        right: 5px;
-        top: -9px;
-        color: #fff;
-        font-size: 12px;
-        line-height: 1.5em;
-        border-radius: 2px;
-        background-color: $orange-darker;
+        display: none;
+        // position: absolute;
+        // left: 5px;
+        // right: 5px;
+        // top: -9px;
+        // color: #fff;
+        // font-size: 12px;
+        // line-height: 1.5em;
+        // border-radius: 2px;
+        // background-color: $orange-darker;
       }
     }
   }

--- a/source/team.html.erb
+++ b/source/team.html.erb
@@ -7,8 +7,7 @@ responsive: true
   The Team Behind Ember
 </h1>
 <p class="lead">
-<br/>
-  Ember is an Open Source project that relies on the tireless support of individual contributors.<br>
+  Ember is an Open Source project that relies on the tireless support of individual contributors. These are the teams that guide the development and instruction of Ember.js. 
 </p>
 
 <section class="team section">
@@ -52,19 +51,64 @@ responsive: true
 <hr/>
 <section class="team section">
   <h2 class="text-center">
-    The Ember Subteams
+    The Ember CLI Team
   </h2>
   <p class="lead">
-    In addition to the Core Team, the following people contribute significantly to the Ember project. We're grateful for their assistance.
+    
   </p>
 
   <%
-  subteams = ['cli', 'data', 'learning'];
+  subteams = ['cli'];
   subteams = subteams.map { |team|
     data.team.select {|u| u.teams.include?(team); }.map {|u| u['type'] = team; u }
   }.flatten
 
-  subteams.sort_by! {|u| [u.type, u.name] }
+  subteams.sort_by! {|u| [u.last] }
+  %>
+
+  <ul class="contributors headshots">
+    <% subteams.each do |user| %>
+      <li>
+        <a href="<%= user.github %>" rel="nofollow" class="avatar" >
+          <img src="/images/team/<%= user.image %>" alt="<%= user.name %>">
+        </a>
+
+        <p class="name">
+          <%= user.name %>
+        </p>
+        <ul class="social">
+        <li>
+          <a class="twitter" href="<%= user.twitter %>" aria-label="<%= user.name %> Twitter">
+            <i class="icon-twitter" aria-hidden="true"></i>
+          </a>
+        </li>
+
+        <li>
+          <a class="github" href="<%= user.github %>" aria-label="<%= user.name %> Github Profile">
+            <i class="icon-github" aria-hidden="true"></i>
+          </a>
+        </li>
+      </ul>
+    </li>
+    <% end %>
+  </ul>
+</section>
+<hr/>
+<section class="team section">
+  <h2 class="text-center">
+    The Ember Data Team
+  </h2>
+  <p class="lead">
+    
+  </p>
+
+  <%
+  subteams = ['data'];
+  subteams = subteams.map { |team|
+    data.team.select {|u| u.teams.include?(team); }.map {|u| u['type'] = team; u }
+  }.flatten
+
+  subteams.sort_by! {|u| [u.last] }
   %>
 
   <ul class="contributors headshots">
@@ -72,13 +116,69 @@ responsive: true
       <li>
         <a href="<%= user.github %>" rel="nofollow" class="avatar" aria-label="<%= user.name %>">
           <img src="/images/team/<%= user.image %>" role="presentation" alt="">
-
-          <span class="type"><%= user.type %></span>
         </a>
 
         <p class="name">
           <%= user.name %>
         </p>
+        <ul class="social">
+        <li>
+          <a class="twitter" href="<%= user.twitter %>" aria-label="<%= user.name %> Twitter">
+            <i class="icon-twitter" aria-hidden="true"></i>
+          </a>
+        </li>
+
+        <li>
+          <a class="github" href="<%= user.github %>" aria-label="<%= user.name %> Github Profile">
+            <i class="icon-github" aria-hidden="true"></i>
+          </a>
+        </li>
+      </ul>
+    </li>
+    <% end %>
+  </ul>
+</section>
+<hr/>
+<section class="team section">
+  <h2 class="text-center">
+    The Ember Learning Team
+  </h2>
+  <p class="lead">
+    
+  </p>
+
+  <%
+  subteams = ['learning'];
+  subteams = subteams.map { |team|
+    data.team.select {|u| u.teams.include?(team); }.map {|u| u['type'] = team; u }
+  }.flatten
+
+  subteams.sort_by! {|u| [u.last] }
+  %>
+
+  <ul class="contributors headshots">
+    <% subteams.each do |user| %>
+      <li>
+        <a href="<%= user.github %>" rel="nofollow" class="avatar" aria-label="<%= user.name %>">
+          <img src="/images/team/<%= user.image %>" role="presentation" alt="">
+        </a>
+
+        <p class="name">
+          <%= user.name %>
+        </p>
+        <ul class="social">
+        <li>
+          <a class="twitter" href="<%= user.twitter %>" aria-label="<%= user.name %> Twitter">
+            <i class="icon-twitter" aria-hidden="true"></i>
+          </a>
+        </li>
+
+        <li>
+          <a class="github" href="<%= user.github %>" aria-label="<%= user.name %> Github Profile">
+            <i class="icon-github" aria-hidden="true"></i>
+          </a>
+        </li>
+      </ul>
     </li>
     <% end %>
   </ul>

--- a/source/team.html.erb
+++ b/source/team.html.erb
@@ -18,8 +18,8 @@ responsive: true
 <ul class="headshots">
   <% core.each do |user| %>
     <li>
-      <a href="<%= user.github %>" rel="nofollow" class="avatar" aria-label="<%= user.name %>">
-        <img src="/images/team/<%= user.image %>" alt="" role="presentation">
+      <a href="<%= user.github %>" rel="nofollow" class="avatar">
+        <img src="/images/team/<%= user.image %>" alt="<%= user.name %>">
       </a>
 
       <p class="name">
@@ -159,8 +159,8 @@ responsive: true
   <ul class="contributors headshots">
     <% subteams.each do |user| %>
       <li>
-        <a href="<%= user.github %>" rel="nofollow" class="avatar" aria-label="<%= user.name %>">
-          <img src="/images/team/<%= user.image %>" role="presentation" alt="">
+        <a href="<%= user.github %>" rel="nofollow" class="avatar">
+          <img src="/images/team/<%= user.image %>" alt="<%= user.name %>">
         </a>
 
         <p class="name">
@@ -197,8 +197,8 @@ responsive: true
   <ul class="headshots">
     <% alumni.each do |user| %>
       <li>
-        <a href="<%= user.github %>" rel="nofollow" aria-label="<%= user.name %>">
-          <img src="/images/team/<%= user.image %>" width="150" height="150" alt="" role="presentation"/>
+        <a href="<%= user.github %>" rel="nofollow">
+          <img class="alumni" src="/images/team/<%= user.image %>" alt="<%= user.name %>" />
         </a>
         <p>
           <%= user.name %>


### PR DESCRIPTION
**Done:**
- updated the data so names can be sorted by last name
- separated teams into section
- removed subteams reference, replaced it with team name headings
- added Github and twitter to everyone
- removed team badges (team headings take care of it)

**Still to do:** 
- [ ] need twitter handles for everyone (or plan for what to do in lieu of twitter handles)
- [ ] need descriptor sentences for each team- 1-2 sentences that explain what each team is primarily responsible for.  I'm going to tag a few people in each team- please weigh in on the comments if you have a suggestion.  
  - Ember CLI (@kategengler @kellyselden @Turbo87) 
  - Ember Data (@dgeb @igorT)
  - Learning Team (@locks @jenweber @acorncom)
- [ ] need details for each team (repo for the public meeting notes, when do they meet, etc)