### PR TITLE
clean up messaging around deprecations on the learn page

### DIFF
--- a/source/learn.html.erb
+++ b/source/learn.html.erb
@@ -37,32 +37,14 @@ responsive: true
     <section>
       <h2 id="deprecations" class="anchorable-toc"> <a href="http://emberjs.com/deprecations/">Deprecation Guides<i class="icon-link-ext"></i></a></h2>
       <p>
-        Over the course of the years cruft inevitably sneaks into all software projects. In order to clean up outdated functionality and guide users, Ember has a deprecation process. You can read our <a href="http://emberjs.com/deprecations/">deprecation guides</a> for more information. You can find below more direct links to Ember and Ember Data versions.
+        The broader JavaScript ecosystem is always changing and evolving, so Ember has processes and tools in place to protect your app from churn while still providing the best new web app features. Ember uses a careful deprecation process to roll out changes to the API. You can read our <a href="http://emberjs.com/deprecations/">deprecation guides</a> to see past and upcoming deprecations. <a href="https://github.com/ember-cli/ember-cli/releases">Upgrade your ember-cli version</a> to see which of them affect your app, when they are scheduled to change, and how to fix them. You can use newer versions of the CLI with older Ember apps.
       </p>
-
-      <div class="flex-container learn-deprecations">
-        <div class="flex-same-width">
-          <h3 id="deprecations-ember" class="anchorable-toc" >Ember</h3>
-
-          <ul>
-            <li><a href="/deprecations/v1.x">1.x</a></li>
-            <li><a href="/deprecations/v2.x">2.x</a></li>
-            <li><a href="/deprecations/v3.x">3.x</a></li>
-          </ul>
-        </div>
-        <div class="flex-same-width">
-          <h3 id="deprecations-ember-data" class="anchorable-toc">Ember Data</h3>
-          <ul>
-            <li><a href="/deprecations/ember-data/v2.x">2.x</a></li>
-          </ul>
-        </div>
-      </div>
-    </section>
+   </section>
     <section>
       <h2>Ecosystem</h2>
 
       <p>
-        One of the main strengths of Ember is how shared conventions enable developers to build on top of each other's work and improve the ecosystem for everyone. What follows are some of the projects more closely maintained by the several Ember teams.
+        One of the main strengths of Ember is how shared conventions enable developers to build on top of each other's work and improve the ecosystem for everyone. For example, here are some projects closely maintained by Ember teams:
       </p>
 
       <p>

--- a/source/learn.html.erb
+++ b/source/learn.html.erb
@@ -37,7 +37,17 @@ responsive: true
     <section>
       <h2 id="deprecations" class="anchorable-toc"> <a href="http://emberjs.com/deprecations/">Deprecation Guides<i class="icon-link-ext"></i></a></h2>
       <p>
-        The broader JavaScript ecosystem is always changing and evolving, so Ember has processes and tools in place to protect your app from churn while still providing the best new web app features. Ember uses a careful deprecation process to roll out changes to the API. You can read our <a href="http://emberjs.com/deprecations/">deprecation guides</a> to see past and upcoming deprecations. <a href="https://github.com/ember-cli/ember-cli/releases">Upgrade your ember-cli version</a> to see which of them affect your app, when they are scheduled to change, and how to fix them. You can use newer versions of the CLI with older Ember apps.
+        The broader JavaScript ecosystem is always changing and evolving, so Ember has processes
+        and tools in place to protect your app from churn while still providing the best new web
+        app features. Ember uses a careful deprecation process to roll out changes to the API.
+        You can read our <a href="http://emberjs.com/deprecations/">deprecation guides</a>
+        to see past and upcoming deprecations. 
+        <a href="https://github.com/ember-cli/ember-cli/releases">
+          Upgrade your ember-cli version
+        </a> 
+        to see which of them affect your app, when they are scheduled to change, and how to fix
+        them. You can use newer versions of the CLI with older Ember apps. Major changes
+        are often accompanied by codemod tools.
       </p>
    </section>
     <section>


### PR DESCRIPTION
We can do better from a marketing perspective than this:

> Over the course of the years cruft inevitably sneaks into all software projects. 

Proposed changes:
![screen shot 2018-03-31 at 9 11 26 am](https://user-images.githubusercontent.com/16627268/38163556-8ca20b70-34c3-11e8-928a-06354be10e07.png)

I removed the extended links to different versions. With the new app and nicer landing page, I don't think they're necessary.

Sister PR in the deprecations app https://github.com/ember-learn/deprecation-app/pull/112