### PR TITLE
typography: more spacing below h1 and h2

### DIFF
--- a/source/stylesheets/about.css.scss
+++ b/source/stylesheets/about.css.scss
@@ -93,6 +93,11 @@ body.index {
   background: no-repeat top center #faf4f1;
   background-image: url("/images/background-shades.png");
   background-image: url('/images/background-shades.svg'), none; // See: http://css-tricks.com/svg-fallbacks/
+  
+  h2 {
+    padding-bottom: 0.5em;
+  }
+
   @media screen and (min-width: 2000px) {
     // Stretch background width when wider than source image
     background-size: 100% auto;

--- a/source/stylesheets/about.css.scss
+++ b/source/stylesheets/about.css.scss
@@ -94,10 +94,6 @@ body.index {
   background-image: url("/images/background-shades.png");
   background-image: url('/images/background-shades.svg'), none; // See: http://css-tricks.com/svg-fallbacks/
   
-  h2 {
-    padding-bottom: 0.5em;
-  }
-
   @media screen and (min-width: 2000px) {
     // Stretch background width when wider than source image
     background-size: 100% auto;

--- a/source/stylesheets/base/_typography.scss
+++ b/source/stylesheets/base/_typography.scss
@@ -47,8 +47,7 @@ h2 {
   font-size: 1.75em;
   font-weight: bold; 
   line-height: 1;
-  margin-bottom: 0.5em;  
-  margin: 2em 0 0.2em 0;
+  margin: 2em 0 0.5em 0;
   @media screen and (min-width: 0) and (max-width: $screen-sm-max) {
     text-align: center;
   }


### PR DESCRIPTION
This is a tiny fix for something that bugs me - I think heading text looks more balanced when it has greater spacing than a typical line. Let me know what you think. I had a designer look through and he said that the spacing I'm adding should not be applied to other h2s throughout the site, just the home page, which is what I've done here.

### After:
![screen shot 2018-04-01 at 7 36 47 pm](https://user-images.githubusercontent.com/16627268/38178590-100ed6ac-35e4-11e8-8a38-1de9dc403d8f.png)

![screen shot 2018-04-01 at 7 36 39 pm](https://user-images.githubusercontent.com/16627268/38178589-09105d76-35e4-11e8-9274-c4f3d28a4252.png)

### Before
![screen shot 2018-04-01 at 7 37 29 pm](https://user-images.githubusercontent.com/16627268/38178596-27298bac-35e4-11e8-8e43-a91757c1c417.png)

![screen shot 2018-04-01 at 7 37 22 pm](https://user-images.githubusercontent.com/16627268/38178598-2b0a49dc-35e4-11e8-8575-390d33e86cc3.png)