### PR TITLE
Fix hover state of social icons

### DIFF
--- a/source/_footer.html.erb
+++ b/source/_footer.html.erb
@@ -17,15 +17,9 @@
     <div class="footer-statement">
       Ember.js is free, open source and always will be.
       <div class="footer-social">
-        <a href="http://twitter.com/emberjs" title="Twitter" aria-label="Ember on Twitter">
-          <i class="icon-twitter" aria-hidden="true"></i>
-        </a>
-        <a href="https://github.com/emberjs/ember.js" title="GitHub" aria-label="Github repository">
-          <i class="icon-github" aria-hidden="true"></i>
-        </a>
-        <a href="https://plus.google.com/communities/106387049790387471205" title="Google+" aria-label="google plus profile">
-          <i class="icon-gplus" aria-hidden="true"></i>
-        </a>
+        <a href="http://twitter.com/emberjs" title="Twitter" aria-label="Ember on Twitter"><i class="icon-twitter" aria-hidden="true"></i></a>
+        <a href="https://github.com/emberjs/ember.js" title="GitHub" aria-label="Github repository"><i class="icon-github" aria-hidden="true"></i></a>
+        <a href="https://plus.google.com/communities/106387049790387471205" title="Google+" aria-label="google plus profile"><i class="icon-gplus" aria-hidden="true"></i></a>
       </div>
     </div>
 


### PR DESCRIPTION
The social icons in the footer have `:hover { text-decoration: underline }` inherited from base `a` styles. But because the icon links are inline, the whitespace in the html source around the `<i>` icon tags shows up as underlined text on hover.

This removes that whitespace from the html source, ensuring no errant lines show up on hover.

**Before**

![image](https://user-images.githubusercontent.com/707213/38526802-f2d5197a-3c14-11e8-993f-b4e5c5acafb0.png)


**After**

![image](https://user-images.githubusercontent.com/707213/38526826-0983685c-3c15-11e8-917e-def60c0c533f.png)
