### PR TITLE
point api link in header to /api/ember/release

### DIFF
--- a/source/_header.html.erb
+++ b/source/_header.html.erb
@@ -16,7 +16,7 @@
      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Docs <span class="caret"></span></a>
      <ul class="dropdown-menu">
       <li><a href="//guides.emberjs.com">Guides</a></li>
-      <li><a href="/api">API Reference</a></li>
+      <li><a href="/api/ember/release">API Reference</a></li>
       <li role="separator" class="divider"></li>
       <li><a href="/learn">Learn Ember</a></li>
      </ul>


### PR DESCRIPTION
This is gonna be a big help for seo, as it will let web crawlers get to api through emberjs.com

There's currently an issue in fastboot that hampers server render when there's a redirect. See https://github.com/ember-fastboot/ember-cli-fastboot/issues/349