### PR TITLE
Remove Ember CLI instructions from the call to action.

### DIFF
--- a/source/about.html.erb
+++ b/source/about.html.erb
@@ -44,10 +44,6 @@ $(function() {
 
       <a href="https://guides.emberjs.com/current/getting-started/quick-start/">View Quick Start guide</a>
     </div>
-    <div class="call-to-action__bottom">
-      <p>$ npm install -g ember-cli</p>
-      <p>$ ember new ember-quickstart</p>
-    </div>
   </div>
 </div>
 


### PR DESCRIPTION
The Ember CLI instructions are only useful if you already
have enough context to understand what they accomplish.
To that end, I think directing people to our quick start guide
should be enough.