### PR TITLE
release(blog): The Ember.js Times - Issue #43

### DIFF
--- a/source/blog/2018-04-01-the-emberjs-times-issue-43.md
+++ b/source/blog/2018-04-01-the-emberjs-times-issue-43.md
@@ -1,0 +1,78 @@
+---
+title: The Ember.js Times - Issue No. 43
+author: Alon Bukai, Ryan Mark, Amy Lam, Ricardo Mendes, Jessica Jordan
+tags: Recent Posts, Newsletter, Ember.js Times
+alias : "blog/2018/04/01/the-emberjs-times-issue-43.html"
+responsive: true
+---
+
+Ola Emberistas!
+
+This week we try out another format for the newsletter and bring it right to the
+Ember blog, to make it accessible to even more Ember enthusiasts in the community.
+
+And this week we not only have news about the 2018 roadmap for Ember CLI for you,
+but also highlights from the latest Ember 3.1 release. 
+Last but not least, a brand-new Readers' Question about contributions for you.
+
+Here's what's happened this week 🐹 :
+
+---
+
+## [The Road Ahead for Ember CLI in 2018](https://discuss.emberjs.com/t/ember-cli-2018-edition/14543)
+
+This week the Ember CLI team has published their *official roadmap* for the
+command-line tool to keep the Ember community posted on which shiny new things
+might be landing in an Ember app near you soon.
+
+The current project goals for 2018 include a dedicated migration story to
+[Module Unification](https://github.com/emberjs/rfcs/pull/143), enabling
+[Treeshaking](https://github.com/ember-cli/rfcs/pull/110), adding service worker support
+to the blueprint of Ember apps by default and many other exciting topics.
+
+You can read more about the roadmap on the [Ember Forum](https://discuss.emberjs.com/t/ember-cli-2018-edition/14543)
+and give your thoughts and suggestions in the discussion.
+
+---
+
+## [EMBER](/blog/2018/04/13/ember-3-1-released.html)
+
+<div class="blog-row">
+  <img class="transparent padded float-left small" src="/images/brand/ember_Ember-Light.png" alt="Ember Brand Logo" />
+
+  <p>
+    [MAIN TEXT]
+  </p>
+</div>
+
+<a class="ember-button ember-button--centered href="/blog/2018/04/13/ember-3-1-released.html">Read more</a>
+
+---
+
+## [EMBER LEARN](yoururl)
+
+
+[MAIN TEXT]
+
+---
+
+## [Readers' Questions: When and how will we be able to use decorators in Ember apps?](#yoururl)
+
+<div class="blog-row">
+  <img class="float-right small transparent padded" alt="Office Hours Tomster Mascot" title="Readers' Questions" src="/images/tomsters/officehours.png" />
+  <p>In this week's brand new Readers’ Question it's all about the new and cool and shiny that will 
+  be coming to your Ember apps soon: When will we be able to make use of the decorator syntax when writing Ember apps? 
+  </p>
+ <p>In his detailed write-up <a href="https://github.com/pzuraq">@pzuraq</a> will answer everything you need to know about the current state of the decorators
+  proposal itself and when you will be able to decorate your own application. Read the full answer 
+  on the <a href="#">offical Ember forum</a>.
+</div>
+<a class="ember-button ember-button--centered href="#">Read more</a> 
+
+---
+
+That's another wrap!  ✨
+
+Be kind,
+
+Alon Bukai, Amy Lam, Ryan Mark, Ricardo Mendes, Jessica Jordan and the Learning Team

--- a/source/stylesheets/pages/blog.css.scss
+++ b/source/stylesheets/pages/blog.css.scss
@@ -43,6 +43,23 @@
       float: right;
     }
 
+    img.float-left {
+      float: left;
+    }
+
+    img.small {
+      width: 33%;
+      height: auto;
+    }
+
+    img.transparent {
+      background-color: transparent;
+    }
+
+    img.padded {
+      margin: .5em 1em;
+    }
+
     ul {
       list-style: disc;
     }
@@ -77,6 +94,14 @@
         border-bottom: 1px solid lighten($orange, 10%);
       }
     }
+  }
+}
+
+.blog-row {
+  &:before, &:after {
+    content: '';
+    display: table;
+    clear: both;
   }
 }
 


### PR DESCRIPTION
This publishes the upcoming edition of the [Ember.js Times](https://the-emberjs-times.ongoodbits.com/) to the blog.

This should be released until Friday, April 20, 22 h UTC the latest and be cross-linked through the Ember.js Times newsletter accordingly


<img width="610" alt="screen shot 2018-04-18 at 21 58 12" src="https://user-images.githubusercontent.com/8811742/38955004-9695aabc-4353-11e8-9ef7-505da8c9c634.png">
