### PR TITLE
Add Ember Learn update for Ember Times 43 or 44

### DIFF
--- a/source/blog/2018-04-01-the-emberjs-times-issue-43.md
+++ b/source/blog/2018-04-01-the-emberjs-times-issue-43.md
@@ -54,10 +54,11 @@ and give your thoughts and suggestions in the discussion.
 
 ---
 
-## [EMBER LEARN](yoururl)
+## [Learning Team happenings](https://ember-twiddle.com/)
 
+[Ember Twiddle](https://ember-twiddle.com/) now (finally!) uses Babel 6 instead of Babel 5 to transpile your code. Please encourage folks to test the canary so that any issues with Ember addons and existing twiddles might be found. Thanks for the update [@Gaurav0](https://github.com/Gaurav0)!
 
-[MAIN TEXT]
+The Learning Team merged a bunch of pull requests in emberjs/guides recently, many from first time contributors - thank you [@sdhull](https://github.com/sdhull). [@rmminusrfslash](https://github.com/rmminusrfslash), [@karan-pathak](https://github.com/karan-pathak) and [@chrisrng](https://github.com/chrisrng). The Learning Team is working on closing out outstanding issues and PRs on emberjs/guides in an effort to launch the built with Ember [ember-learn/guides-app](https://github.com/ember-learn/guides-app) in its place! 🔜
 
 ---
 


### PR DESCRIPTION
UPDATE: Feel free to pass on this for the April 20 edition if there is not time, it can go in next week also!

Never mind, unstaged it:
~~Aside: it seems like my `.editorconfig` is making some whitespace changes to copy I didn't touch as well. Can fix if undesired.~~