### PR TITLE
temporarily removing API search from the website

### DIFF
--- a/source/javascripts/app/docsearch.js.erb
+++ b/source/javascripts/app/docsearch.js.erb
@@ -12,7 +12,7 @@ var apiKey = '<%= data.search.api_key %>';
 var inputSelector = '#search-input';
 var indexName = 'emberjs_versions';
 var hitsPerPage = 10;
-var facetFilters = '[["version:' + currentRevision + '","tags:api"]]';
+var facetFilters = '[["version:' + currentRevision + '"]]';
 
 $(window).load(function () {
     docsearch({


### PR DESCRIPTION
For anyone who doesn't know the context of this change: as discussed on today's learning team meeting we need to temporarily disable API search results on the website because of issues with our index. There are separate efforts trying to fix that and we can re-enable API search on the website if any of those efforts pay off.