### PR TITLE
Update blog link for Ember Times

### DIFF
--- a/source/blog/2018-05-04-the-emberjs-times-issue-45.md
+++ b/source/blog/2018-05-04-the-emberjs-times-issue-45.md
@@ -83,7 +83,7 @@ Check out Katie Gengler's awesome [call for blog posts here](https://emberjs.com
 
 ## [The Stack Overflow problem](https://medium.com/front-end-hacking/whats-up-with-ember-js-and-stack-overflow-1961ac29ebde)
 
-Jen Weber and Chris Manson are taking a deep dive into Ember's presence on Stack Overflow this month. They're even recording their efforts once a week at **9am EST on Fridays**! You can tune into their [YouTube channel](https://www.youtube.com/channel/UCyErLHzPqLAkL1F-SivFDcA) or [Twitch stream](https://www.twitch.tv/videos/252443184).
+Jen Weber and Chris Manson are taking a deep dive into Ember's presence on Stack Overflow this month. They're even recording their efforts once a week at **9am EST on Fridays**! You can tune into their [YouTube channel](https://www.youtube.com/channel/UCyErLHzPqLAkL1F-SivFDcA) or [Twitch stream](https://www.twitch.tv/real_ate/videos/all).
 
 Collectively, question by question, we can try to create a better Ember presence on Stack Overflow. Check out some tips and tricks on how to get involved in the Stack Overflow effort in the [What’s up with Ember.js and Stack Overflow?](https://medium.com/front-end-hacking/whats-up-with-ember-js-and-stack-overflow-1961ac29ebde) post. It's gonna be...May. 🥁
 


### PR DESCRIPTION
Original Twitch link expired after 2wk. Jen updated it in her Medium post as well. re: https://embercommunity.slack.com/archives/C04KG57CF/p1525524488000007?thread_ts=1525470060.000346&cid=C04KG57CF

@jenweber @jessica-jordan 