### PR TITLE
Release Ember.js Times Issue #47

### DIFF
--- a/source/blog/2018-05-18-the-emberjs-times-issue-47.md
+++ b/source/blog/2018-05-18-the-emberjs-times-issue-47.md
@@ -1,0 +1,74 @@
+---
+title: The Ember.js Times - Issue No. 47
+author: the crowd
+tags: Recent Posts, Newsletter, Ember.js Times
+alias : "blog/2018/05/18/the-emberjs-times-issue-47.html"
+responsive: true
+---
+
+여보세요 Emberistas!
+
+Again you can enjoy reading the Ember.js Times in both the [e-mail](https://the-emberjs-times.ongoodbits.com/2018/05/18/issue-47) and the [blog format](https://emberjs.com/blog/2018/05/18/the-emberjs-times-issue-47.html) to share it even better with your Ember friends.
+
+....more intro
+
+---
+
+## [EMBER THINGS 🐹](#your-url-here)
+
+---
+
+## [EMBER DATA THINGS](#your-url-here)
+
+- new RFC here: https://github.com/emberjs/rfcs/pull/332
+
+
+---
+
+## [EMBER LEARN THINGS](#your-url-here)
+
+
+---
+
+## [SOMETHING ELSE HERE](#your-url-here)
+
+
+---
+
+## [SOMETHING ELSE HERE](#your-url-here)
+
+
+---
+
+## [SOMETHING ELSE HERE](#your-url-here)
+
+
+---
+
+## [Contributors' Corner](https://guides.emberjs.com/v3.1.0/contributing/repositories/)
+
+
+---
+
+## [Readers’ Questions: “....”](#praying-for-a-question)
+
+<div class="blog-row">
+  <img class="float-right small transparent padded" alt="Office Hours Tomster Mascot" title="Readers' Questions" src="/images/tomsters/officehours.png" />
+
+  <p>...</p>
+
+</div>
+
+<div class="blog-row">
+<a class="ember-button ember-button--centered" href="#">Read more</a>
+</div>
+
+**Submit your own** short and sweet **question** under [bit.ly/ask-ember-core](https://bit.ly/ask-ember-core). And don’t worry, there are no silly questions, we appreciate them all - promise! 🤞
+
+---
+
+That's another wrap!  ✨
+
+Be kind,
+
+the crowd

--- a/source/blog/2018-05-18-the-emberjs-times-issue-47.md
+++ b/source/blog/2018-05-18-the-emberjs-times-issue-47.md
@@ -10,7 +10,7 @@ responsive: true
 
 Again you can enjoy reading the Ember.js Times in both the [e-mail](https://the-emberjs-times.ongoodbits.com/2018/05/18/issue-47) and the [blog format](https://emberjs.com/blog/2018/05/18/the-emberjs-times-issue-47.html) to share it even better with your Ember friends.
 
-This week we have several RFCs from the Ember Data 📟 project for you, as well as an #Emberjs2018 countdown, a new way to cast some template transform magic 🎩 and a recap of what has happened in Readers' Questions for you:
+This week we have **several RFCs** from the Ember Data 📟 project for you, as well as an **#EmberJS2018 countdown**, a new way to cast some **template transform magic** 🎩 and a recap of what has happened in Readers' Questions for you:
 
 ---
 
@@ -51,10 +51,10 @@ Need to beat writer's block? Listen to Ember Core team member [Chad Hietala](htt
 
 ## [More Ember Data: RFC for removing `Ember.Evented`](https://github.com/emberjs/rfcs/pull/329)
 
-There's an [RFC](https://github.com/emberjs/rfcs/pull/329) on removing usage of the `Ember.Evented` mixin in Ember Data specifically. This would also lead to the future **removal** of several **lifecycle hooks** and methods on `Model`s and other Ember Data classes. 
+There's an RFC on removing usage of the `Ember.Evented` mixin in Ember Data specifically. This would also lead to the future **removal** of several **lifecycle hooks** and methods on `Model`s and other Ember Data classes.
 
 The use of `Ember.Evented` is mostly a legacy from pre 1.0 of Ember Data and is simply not needed anymore. 
-You can **follow the discussion** and read all about the implications of this change on the [RFC pull request.](https://github.com/emberjs/rfcs/pull/329)
+You can **follow the discussion** and read all about the implications of this change on the [RFC pull request](https://github.com/emberjs/rfcs/pull/329).
 
 ---
 


### PR DESCRIPTION
To be released on May 18th, 2018.

[Rendered](https://github.com/emberjs/website/blob/91cf20230f2b9d625f0a7c1d0f1e75cabbaba3f7/source/blog/2018-05-18-the-emberjs-times-issue-47.md)

Staging App: https://ember-website-staging-pr-3339.herokuapp.com/blog/

This week's topics include:

- New Ember Data RFC: https://github.com/emberjs/rfcs/pull/332
- re-mention Ember Data RFC for Evented Deprecation: https://github.com/emberjs/rfcs/pull/329
- New Guides App released 🤞 
- 2 weeks left for Ember roadmap 2018 blog posts
- Ember Template Recast: https://github.com/ember-template-lint/ember-template-recast
- Ember CLI Addon Docs Updates:
> ember-cli-addon-docs has been getting a lot of love lately. Ember decorators recently revamped their docs(http://ember-decorators.github.io/ember-decorators/latest/) using https://ember-learn.github.io/ember-cli-addon-docs/latest/, might be worth featuring ember-cli-addon-docs again.

Feel free to add further topics to the comments below or mention any that you find interesting at [#topic-embertimes](https://embercommunity.slack.com/archives/C8P6UPWNN/p1525448225000074)

