### PR TITLE
Release Ember.js Times Issue #48

### DIFF
--- a/source/blog/2018-05-25-the-emberjs-times-issue-48.md
+++ b/source/blog/2018-05-25-the-emberjs-times-issue-48.md
@@ -37,7 +37,7 @@ Halloechen Emberistas!
 
 ---
 
-## Updates to the `ember-cli-addon-docs`(https://github.com/ember-learn/ember-cli-addon-docs)
+## [Updates to the ember-cli-addon-docs](https://github.com/ember-learn/ember-cli-addon-docs)
 
 It’s becoming harder to have an excuse to not document your software libraries as the AddonDocs is getting easier to use by the day.
 
@@ -47,7 +47,7 @@ Also, on the most recent releases, the following neatest features were made avai
 
 - new version selector: good news for when you feel nostalgic about old documentation. Now you can add to your navigation a version selector control that will enable you to jump back and forth to different documentation versions with ease, check it out <a href='https://github.com/ember-learn/ember-cli-addon-docs/pull/156' target='_blank'>here</a>.
 
-- "Magic mirror, on the wall – who is the most beautiful documentation one of all?" The AddonDocs has an even prettier UI now thanks to the `ember-cli-tailwind`, if you are unfamiliar with Tailwind, make yourself a favour and deep dive into its power <a href='https://tailwindcss.com/' target='_blank'>here</a>.
+- "Magic mirror, on the wall – who is the most beautiful documentation of all?" The AddonDocs has an even prettier UI now thanks to the `ember-cli-tailwind`, if you are unfamiliar with Tailwind, do yourself a favour and deep dive into its power <a href='https://tailwindcss.com/' target='_blank'>here</a>.
 
 ---
 

--- a/source/blog/2018-05-25-the-emberjs-times-issue-48.md
+++ b/source/blog/2018-05-25-the-emberjs-times-issue-48.md
@@ -12,7 +12,12 @@ Halloechen Emberistas!
 
 ---
 
-## [YOUR SECTION TITLE HERE](#your-url-here)
+## [What is your wish for Ember in 2018?](https://emberjs.com/blog/2018/05/02/ember-2018-roadmap-call-for-posts.html)
+There’s a week left of the Ember’s 2018 call for blog posts. There’s already been a lot of great blog posts from the community, but we’re hoping for more!
+
+Write a blog post by **May 30th** to propose goals and direction for Ember in the remainder of 2018. The content of these posts will help the core team to draft their first Roadmap RFC.
+
+Looking for inspiration? Check out the [#EmberJS2018 hashtag](https://twitter.com/search?q=%23EmberJS2018) on Twitter or [@zinyado’s repo collection posts](https://github.com/zinyando/emberjs2018-posts) on GitHub.
 
 
 ---

--- a/source/blog/2018-05-25-the-emberjs-times-issue-48.md
+++ b/source/blog/2018-05-25-the-emberjs-times-issue-48.md
@@ -37,8 +37,17 @@ Halloechen Emberistas!
 
 ---
 
-## [YOUR SECTION TITLE HERE](#your-url-here)
+## Updates to the `ember-cli-addon-docs`(https://github.com/ember-learn/ember-cli-addon-docs)
 
+It’s becoming harder to have an excuse to not document your software libraries as the AddonDocs is getting easier to use by the day.
+
+A real-world example of its usage is the the ember-decorators documentation: <a href='http://ember-decorators.github.io/ember-decorators/latest/docs' target='_blank'>ember-decorators</a>, which was recently revamped by leveraging the add-on, have a go at it and inspire yourself to your own documentation.
+
+Also, on the most recent releases, the following neatest features were made available:
+
+- new version selector: good news for when you feel nostalgic about old documentation. Now you can add to your navigation a version selector control that will enable you to jump back and forth to different documentation versions with ease, check it out <a href='https://github.com/ember-learn/ember-cli-addon-docs/pull/156' target='_blank'>here</a>.
+
+- "Magic mirror, on the wall – who is the most beautiful documentation one of all?" The AddonDocs has an even prettier UI now thanks to the `ember-cli-tailwind`, if you are unfamiliar with Tailwind, make yourself a favour and deep dive into its power <a href='https://tailwindcss.com/' target='_blank'>here</a>.
 
 ---
 

--- a/source/blog/2018-05-25-the-emberjs-times-issue-48.md
+++ b/source/blog/2018-05-25-the-emberjs-times-issue-48.md
@@ -1,0 +1,70 @@
+---
+title: The Ember.js Times - Issue No. 48
+author: the crowd
+tags: Newsletter, Ember.js Times, 2018
+alias : "blog/2018/05/25/the-emberjs-times-issue-48.html"
+responsive: true
+---
+
+Halloechen Emberistas!
+
+...intro text
+
+---
+
+## [YOUR SECTION TITLE HERE](#your-url-here)
+
+
+---
+
+## [YOUR SECTION TITLE HERE](#your-url-here)
+
+
+---
+
+## [YOUR SECTION TITLE HERE](#your-url-here)
+
+
+---
+
+## [YOUR SECTION TITLE HERE](#your-url-here)
+
+
+---
+
+## [YOUR SECTION TITLE HERE](#your-url-here)
+
+
+---
+
+## [YOUR SECTION TITLE HERE](#your-url-here)
+
+
+---
+
+## [Contributors' Corner](https://guides.emberjs.com/v3.1.0/contributing/repositories/)
+
+---
+
+## [Readers’ Questions: “Why does Ember still use RSVP?”](https://discuss.emberjs.com/t/readers-questions-why-does-ember-still-use-rsvp/14736)
+
+<div class="blog-row">
+  <img class="float-right small transparent padded" alt="Office Hours Tomster Mascot" title="Readers' Questions" src="/images/tomsters/officehours.png" />
+
+  <p>...text</p>
+
+</div>
+
+<div class="blog-row">
+<a class="ember-button ember-button--centered" href="#" target="embertimesq">Read more</a>
+</div>
+
+**Submit your own** short and sweet **question** under [bit.ly/ask-ember-core](https://bit.ly/ask-ember-core). And don’t worry, there are no silly questions, we appreciate them all - promise! 🤞
+
+---
+
+That's another wrap!  ✨
+
+Be kind,
+
+the crowd

--- a/source/blog/2018-05-25-the-emberjs-times-issue-48.md
+++ b/source/blog/2018-05-25-the-emberjs-times-issue-48.md
@@ -1,6 +1,6 @@
 ---
 title: The Ember.js Times - Issue No. 48
-author: Miguel Gomes, Kenneth Larsen, Sivakumar Kailasam, Amy Lam, Jessica Jordan
+author: Miguel Gomes, Kenneth Larsen, Sivakumar Kailasam, Amy Lam, Jessica Jordan, Jen Weber
 tags: Newsletter, Ember.js Times, 2018
 alias : "blog/2018/05/25/the-emberjs-times-issue-48.html"
 responsive: true
@@ -22,22 +22,12 @@ Looking for inspiration? Check out the [#EmberJS2018 hashtag](https://twitter.co
 
 ---
 
-## [A Package out for delivery to Ember CLI 📦♥︎🐹](#your-url-here)
+## [A Package out for delivery to Ember CLI 📦♥︎🐹](https://github.com/ember-cli/ember-cli/pull/7826)
 
 Recently, lots of work has landed 🛬 in Ember CLI to bring the long-awaited **Packager feature** to life ([1](https://github.com/ember-cli/ember-cli/pull/7826), [2](https://github.com/ember-cli/ember-cli/pull/7818), [3](https://github.com/ember-cli/ember-cli/pull/7816), [4](https://github.com/ember-cli/ember-cli/pull/7796), [5](https://github.com/ember-cli/ember-cli/pull/7788)). The Packager will increase the **flexibility** of Ember's **build pipeline**, paving the way for other neat features like code splitting and tree shaking and finally allowing developers to further reduce the filesize of their applications by dramatic amounts.
 
 Want a recap of what's in for the Packager feature? Be sure to check out both the  the [original RFC (Request for Comments) proposal](https://github.com/chadhietala/rfcs/blob/packager/active/0002-packager.md), as well as [this year's update](https://github.com/ember-cli/rfcs/blob/master/active/0051-packaging.md) that details the motivation behind it.
 And want to know **when** it will finally land for an Ember app near you? Of course we'll let you know ASAP 🔜 in one of the upcoming editions of the Ember.js Times!
-
----
-
-## [YOUR SECTION TITLE HERE](#your-url-here)
-
-
----
-
-## [YOUR SECTION TITLE HERE](#your-url-here)
-
 
 ---
 
@@ -47,7 +37,7 @@ The new [guides.emberjs.com](https://guides.emberjs.com) is live, hooray!
 
 The Guides are a cornerstone of the Ember experience, and one of our community's strengths is that anyone can get involved. So, it's important to make it easier for everyone to create content or functionality. For this reason, a team of contributors have been working for months to convert the Guides from a Ruby/Middleman app into an Ember app. Now, to help with content, contributors only need to work with markdown files, and to see how things would look on the website, they run an Ember app!
 
-[ember-learn/guides-app](https://github.com/ember-learn/guides-app) contains the static site generator that pulls written content from guides-source markdown files. The guides-app produces static HTML using [Prember](https://github.com/ef4/prember) and [FastBoot](https://www.ember-fastboot.com/). The app is currently served through Heroku who supports Ember in a big way by sponsoring hosting and advice. (Did you know that it takes a ton of back end infrastructure to run a front-end framework project? Other parts of our website rely on support from Fastly, like the API docs. We're thankful to have so many friends of open source!)
+[ember-learn/guides-app](https://github.com/ember-learn/guides-app) contains the static site generator that pulls written content from [guides-source](https://github.com/ember-learn/guides-source) markdown files. The guides-app produces static HTML using [Prember](https://github.com/ef4/prember) and [FastBoot](https://www.ember-fastboot.com/). The app is currently served through Heroku who supports Ember in a big way by sponsoring hosting and advice. (Did you know that it takes a ton of back end infrastructure to run a front-end framework project? Other parts of our website rely on support from Fastly, like the API docs. We're thankful to have so many friends of open source 👨‍👩‍👧‍👦!)
 
 Moving forward, the only part of our site that's not Ember is the website repo, which includes the home page, the blog, and some other odds and ends. Everything else has already been moved into Ember apps! If you want to help out, drop by the [#team-learning](https://embercommunity.slack.com/messages/C04KG57CF/) channel.
 


### PR DESCRIPTION
This week's topics include:

- (eventually) New Guides App released 🤞
- 1 week left for Ember roadmap 2018 blog posts
- Ember CLI Addon Docs Updates (Miguel):
  > ember-cli-addon-docs has been getting a lot of love lately. Ember decorators recently revamped their docs(http://ember-decorators.github.io/ember-decorators/latest/) using https://ember-learn.github.io/ember-cli-addon-docs/latest/, might be worth featuring ember-cli-addon-docs again.

Feel free to add further topics to the comments below or mention any that you find interesting at #topic-embertimes

<img width="795" alt="screen shot 2018-05-25 at 08 28 41" src="https://user-images.githubusercontent.com/8811742/40529549-b9658904-5ff5-11e8-8442-d5888f587730.png">
