### PR TITLE
removed misplaced semicolon

### DIFF
--- a/source/blog/tag.html.erb
+++ b/source/blog/tag.html.erb
@@ -1,7 +1,7 @@
 ---
 pageable: true
 per_page: 12
-responsive: true;
+responsive: true
 ---
 <% @title = tagname %>
 


### PR DESCRIPTION
Removed a misplaced semicolon that was preventing the tag.html.erb from rendering responsively.