### PR TITLE
Remove Ember.js Times #47 from Recent Posts Category

### DIFF
--- a/source/blog/2018-05-18-the-emberjs-times-issue-47.md
+++ b/source/blog/2018-05-18-the-emberjs-times-issue-47.md
@@ -1,7 +1,7 @@
 ---
 title: The Ember.js Times - Issue No. 47
 author: Tobias Bieniek, Robert Jackson, Kenneth Larsen, Sivakumar Kailasam, Amy Lam, Ryan Mark, Jessica Jordan
-tags: Recent Posts, Newsletter, Ember.js Times, 2018
+tags: Newsletter, Ember.js Times, 2018
 alias : "blog/2018/05/18/the-emberjs-times-issue-47.html"
 responsive: true
 ---


### PR DESCRIPTION
With the new categorization feature of blog posts that has been launched through https://github.com/emberjs/website/pull/3280 the Ember.js Times now has their own dedicated post category. 

This moves the Issue No. 47 which was just launched last week away from the more general `Recent Posts` section and makes it only show up in the dedicated embertimes section instead.

| **before** | **after** |
|------------|----------|
| <img width="311" alt="screen shot 2018-05-25 at 08 42 22" src="https://user-images.githubusercontent.com/8811742/40530081-b61b23ec-5ff7-11e8-9543-2e6ef7624774.png">| <img width="336" alt="screen shot 2018-05-25 at 08 42 04" src="https://user-images.githubusercontent.com/8811742/40530096-c06030ae-5ff7-11e8-80e8-c0b3d0d7b627.png"> |

