### PR TITLE
updated tags

### DIFF
--- a/source/blog/2018-05-18-the-emberjs-times-issue-47.md
+++ b/source/blog/2018-05-18-the-emberjs-times-issue-47.md
@@ -1,7 +1,7 @@
 ---
 title: The Ember.js Times - Issue No. 47
 author: Tobias Bieniek, Robert Jackson, Kenneth Larsen, Sivakumar Kailasam, Amy Lam, Ryan Mark, Jessica Jordan
-tags: Recent Posts, Newsletter, Ember.js Times, 2018
+tags: Newsletter, Ember.js Times, 2018
 alias : "blog/2018/05/18/the-emberjs-times-issue-47.html"
 responsive: true
 ---

--- a/source/blog/2018-05-25-the-emberjs-times-issue-48.md
+++ b/source/blog/2018-05-25-the-emberjs-times-issue-48.md
@@ -1,7 +1,7 @@
 ---
 title: The Ember.js Times - Issue No. 48
 author: Miguel Gomes, Kenneth Larsen, Sivakumar Kailasam, Amy Lam, Jessica Jordan, Jen Weber
-tags: Newsletter, Ember.js Times, 2018
+tags: Recent Posts, Newsletter, Ember.js Times, 2018
 alias : "blog/2018/05/25/the-emberjs-times-issue-48.html"
 responsive: true
 ---


### PR DESCRIPTION
The most recent Ember Times should have the Recent Post tag, older editions should have it removed

- added "Recent Post" tag to the most recent Ember Times post
- removed "Recent Post" tag from the previous edition