### PR TITLE
blog(embertimes#48): remove #48 from recent posts

### DIFF
--- a/source/blog/2018-05-25-the-emberjs-times-issue-48.md
+++ b/source/blog/2018-05-25-the-emberjs-times-issue-48.md
@@ -1,7 +1,7 @@
 ---
 title: The Ember.js Times - Issue No. 48
 author: Miguel Gomes, Kenneth Larsen, Sivakumar Kailasam, Amy Lam, Jessica Jordan, Jen Weber
-tags: Recent Posts, Newsletter, Ember.js Times, 2018
+tags: Newsletter, Ember.js Times, 2018
 alias : "blog/2018/05/25/the-emberjs-times-issue-48.html"
 responsive: true
 ---


### PR DESCRIPTION
<!--- Make sure to add a descriptive title in the field above! E.g. "Fixes the header title color on the homepage"  -->

## What it does
<!--- Tell us what this fix does in a few sentences. E.g. "This updates the header title's font color to Ember Orange." -->

We're trying to only keep the latest edition of the Ember Times in the list of recent posts. Once edition No. 49 is out, we can remove No. 48 by removing the `Recent Posts` tag.

This PR removes the Issue #48 from the list of recent posts in favor of the latest edition #49.

## Related Issue(s)
<!--- Please provide the issue(s) to which this pull request relates to or which issue it closes. E.g. "Closes #1234" -->
Related to https://github.com/emberjs/website/pull/3374 and should be merged just after that one.

