### PR TITLE
Add 'for' into sentence about logo usage in `logos.htmls.erb`

### DIFF
--- a/source/logos.html.erb
+++ b/source/logos.html.erb
@@ -71,7 +71,7 @@ responsive: true
         <li><img src="/images/brand/ember_Jobs-1c-Light.png"></li>
         <li><img src="/images/brand/ember_Jobs-1c-Dark.png"></li>
       </ul>
-      <p>Ember communities and smaller projects have logos based on Ember’s <span class="code">code</span> style. They are only to be used by the project owners themselves the official properties.</p>
+      <p>Ember communities and smaller projects have logos based on Ember’s <span class="code">code</span> style. They are only to be used by the project owners themselves for the official properties.</p>
     </li>
   </ul>
 </section>


### PR DESCRIPTION
## What it does
Fixes a typo in the usage description on the logos page.