### PR TITLE
blog(embertimes#52): add more emphasis on the possible depr. of E.Obj

### DIFF
--- a/source/blog/2018-06-22-the-ember-times-issue-52.md
+++ b/source/blog/2018-06-22-the-ember-times-issue-52.md
@@ -74,7 +74,8 @@ class EmberObject {
 
 This would assign the properties _after_ all of the class fields for any subclasses have been assigned.
 
-One thing worth mentioning is that `EmberObject` will likely be deprecated in the near future and that ideally for non-Ember classes (things that aren't Components, Services, etc.) users should drop `EmberObject` altogether and use native classes only.
+One thing worth mentioning is that the RFC claims that `EmberObject` might not be necessary in the future.
+The RFC states that, in this possible scenario, users would drop `EmberObject` ideally for non-Ember classes (things that aren’t Components, Services, etc.) altogether and that they would use native classes only.
 
 👉 As always, all comments to this [RFC](https://github.com/emberjs/rfcs/pull/337) are more than welcome, so let's help out in order to finalize it! ✨
 


### PR DESCRIPTION
<!--- Make sure to add a descriptive title in the field above! E.g. "Fixes the header title color on the homepage"  -->

## What it does
<!--- Tell us what this fix does in a few sentences. E.g. "This updates the header title's font color to Ember Orange." -->

See also the wording from [the original RFC](https://github.com/pzuraq/emberjs-rfcs/blob/94b38d429eb2964fa86cd13bea6823a01b3ef68d/text/0000-native-class-constructor-update.md):

> One thing we should make clear is that EmberObject will likely be deprecated in the near future, and that ideally for non-Ember classes (things that aren't Components, Services, etc.) users should drop EmberObject altogether and use native classes only.

I changed it up a bit so it sounds less set into stone.

## Related Issue(s)
<!--- Please provide the issue(s) to which this pull request relates to or which issue it closes. E.g. "Closes #1234" -->

## Sources
<!-- Optional. If applicable be sure to add any screenshots or screen recordings of your work for your reviewers here -->
