### PR TITLE
issue #3410 - renamed the Ember.js Times to the Ember Times

### DIFF
--- a/source/blog/2018-04-20-the-emberjs-times-issue-43.md
+++ b/source/blog/2018-04-20-the-emberjs-times-issue-43.md
@@ -1,5 +1,5 @@
 ---
-title: The Ember.js Times - Issue No. 43
+title: The Ember Times - Issue No. 43
 author: Kenneth Larsen, Chris Garrett, Sivakumar Kailasam, Alon Bukai, Amy Lam, Ryan Mark, Ricardo Mendes, Jessica Jordan
 tags: Newsletter, Ember.js Times, 2018
 alias : "blog/2018/04/20/the-emberjs-times-issue-43.html"
@@ -93,7 +93,7 @@ The Learning Team merged a bunch of pull requests in emberjs/guides recently, ma
 ---
 
 ## [We love Ember.js Times 😍](https://embercommunity.slack.com/messages/C8P6UPWNN/)
-Do you? If so, contribute!  The Ember.js Times is always looking for people to help spread the word about all things Ember.
+Do you? If so, contribute!  The Ember Times is always looking for people to help spread the word about all things Ember.
 Drop by the Slack channel to [say "hi!"](https://embercommunity.slack.com/messages/C8P6UPWNN/) and learn how to get started.
 
 ---
@@ -137,7 +137,7 @@ so if you aren't currently using it, now is a great time to start!
 ---
 
 ## [Slack ⭐️](https://ember-community-slackin.herokuapp.com/)
-Ember Times would like to give a shoutout to <a href="https://github.com/runspired">@runspired</a> (Chris Thoburn), for being incredibly helpful and responsive in a majority of the Slack channels this last week
+The Ember Times would like to give a shoutout to <a href="https://github.com/runspired">@runspired</a> (Chris Thoburn), for being incredibly helpful and responsive in a majority of the Slack channels this last week
 by supporting community members migrate through the many versions of Ember data from 2.12 all the way to 3.2.0-beta.2.
 
 Chris is a major contributor to the Ember ecosystem and to ember-data specifically.

--- a/source/blog/2018-04-27-the-emberjs-times-issue-44.md
+++ b/source/blog/2018-04-27-the-emberjs-times-issue-44.md
@@ -42,7 +42,7 @@ Ember 3.1.1 contains several more fixes. You can go though them all in [the rele
 This week, contributors to Ember CLI worked on improving the test suite by
 [extending the list of Node versions](https://github.com/ember-cli/ember-cli/pull/7791) tested against.
 This means that you will be able to use your favorite command line tool
-on the the latest version smoothly and without any worries.
+on the latest version smoothly and without any worries.
 
 Lots of efforts are underway to bring **Treeshaking capabilities** to your
 Ember app very soon. Treeshaking is the removal of unused code in order

--- a/source/blog/2018-04-27-the-emberjs-times-issue-44.md
+++ b/source/blog/2018-04-27-the-emberjs-times-issue-44.md
@@ -1,5 +1,5 @@
 ---
-title: The Ember.js Times - Issue No. 44
+title: The Ember Times - Issue No. 44
 author: Kenneth Larsen, Sivakumar Kailasam, Amy Lam, Jen Weber, Jessica Jordan
 tags: Newsletter, Ember.js Times, 2018
 alias : "blog/2018/04/27/the-emberjs-times-issue-44.html"
@@ -109,7 +109,7 @@ As we tie up loose ends and move to production, we'll give updates via the
   </ul>
 </div>
 
-Apart from that we’d like to ask you for **many more questions** to be answered in future editions of the Ember.js Times!
+Apart from that we’d like to ask you for **many more questions** to be answered in future editions of The Ember Times!
 
 **Submit your own** short and sweet **question** under [bit.ly/ask-ember-core](https://bit.ly/ask-ember-core). And don’t worry, there are no silly questions, we appreciate them all - promise! 🤞
 

--- a/source/blog/2018-05-04-the-emberjs-times-issue-45.md
+++ b/source/blog/2018-05-04-the-emberjs-times-issue-45.md
@@ -1,5 +1,5 @@
 ---
-title: The Ember.js Times - Issue No. 45
+title: The Ember Times - Issue No. 45
 author: Kenneth Larsen, Sivakumar Kailasam, Amy Lam, Jen Weber, Jessica Jordan
 tags: Newsletter, Ember.js Times, 2018
 alias : "blog/2018/05/04/the-emberjs-times-issue-44.html"
@@ -104,7 +104,7 @@ Collectively, question by question, we can try to create a better Ember presence
   <p>Wondering about something related to Ember, Ember Data, Glimmer, or addons in the Ember
   ecosystem, but don't know where to ask? Readers’ Questions are just for you!</p>
 
-  <p><strong>Submit your own</strong> short and sweet <strong>question</strong> under <a href="bit.ly/ask-ember-core" target="ask-ember-core">https://bit.ly/ask-ember-core</a> and a member of the Ember team will answer in a future edition of the Ember.js Times. And don’t worry, there are no silly questions, we appreciate them all - promise! 🤞</p>
+  <p><strong>Submit your own</strong> short and sweet <strong>question</strong> under <a href="bit.ly/ask-ember-core" target="ask-ember-core">https://bit.ly/ask-ember-core</a> and a member of the Ember team will answer in a future edition of The Ember Times. And don’t worry, there are no silly questions, we appreciate them all - promise! 🤞</p>
 </div>
 
 

--- a/source/blog/2018-05-11-the-emberjs-times-issue-46.md
+++ b/source/blog/2018-05-11-the-emberjs-times-issue-46.md
@@ -1,5 +1,5 @@
 ---
-title: The Ember.js Times - Issue No. 46
+title: The Ember Times - Issue No. 46
 author: Gaurav Munjal, Edward Faulkner, Sivakumar Kailasam, Kenneth Larsen, Amy Lam, Jessica Jordan
 tags: Newsletter, Ember.js Times, 2018
 alias : "blog/2018/05/11/the-emberjs-times-issue-46.html"
@@ -8,9 +8,9 @@ responsive: true
 
 හෙලෝ Emberistas!
 
-Again you can enjoy reading the Ember.js Times in both the [e-mail](https://the-emberjs-times.ongoodbits.com/2018/05/11/issue-46) and the [blog format](https://emberjs.com/blog/2018/05/11/the-emberjs-times-issue-46.html) to share it even better with your Ember friends.
+Again you can enjoy reading The Ember Times in both the [e-mail](https://the-emberjs-times.ongoodbits.com/2018/05/11/issue-46) and the [blog format](https://emberjs.com/blog/2018/05/11/the-emberjs-times-issue-46.html) to share it even better with your Ember friends.
 
-This week we'll highlight a new RFC deprecating features from ancient Ember times and a sweet reminder for blogging about your best wishes for Ember and - last, but not least - we have a brand-new Readers' Question❓✨ for you!
+This week we'll highlight a new RFC deprecating features from ancient The Ember Times and a sweet reminder for blogging about your best wishes for Ember and - last, but not least - we have a brand-new Readers' Question❓✨ for you!
 
 ---
 

--- a/source/blog/2018-05-18-the-emberjs-times-issue-47.md
+++ b/source/blog/2018-05-18-the-emberjs-times-issue-47.md
@@ -1,5 +1,5 @@
 ---
-title: The Ember.js Times - Issue No. 47
+title: The Ember Times - Issue No. 47
 author: Tobias Bieniek, Robert Jackson, Kenneth Larsen, Sivakumar Kailasam, Amy Lam, Ryan Mark, Jessica Jordan
 tags: Newsletter, Ember.js Times, 2018
 alias : "blog/2018/05/18/the-emberjs-times-issue-47.html"
@@ -8,7 +8,7 @@ responsive: true
 
 안녕하세요 Emberistas!
 
-Again you can enjoy reading the Ember.js Times in both the [e-mail](https://the-emberjs-times.ongoodbits.com/2018/05/18/issue-47) and the [blog format](https://emberjs.com/blog/2018/05/18/the-emberjs-times-issue-47.html) to share it even better with your Ember friends.
+Again you can enjoy reading The Ember Times in both the [e-mail](https://the-emberjs-times.ongoodbits.com/2018/05/18/issue-47) and the [blog format](https://emberjs.com/blog/2018/05/18/the-emberjs-times-issue-47.html) to share it even better with your Ember friends.
 
 This week we have **several RFCs** from the Ember Data 📟 project for you, as well as an **#EmberJS2018 countdown**, a new way to cast some **template transform magic** 🎩 and a recap of what has happened in Readers' Questions for you:
 

--- a/source/blog/2018-05-25-the-emberjs-times-issue-48.md
+++ b/source/blog/2018-05-25-the-emberjs-times-issue-48.md
@@ -1,5 +1,5 @@
 ---
-title: The Ember.js Times - Issue No. 48
+title: The Ember Times - Issue No. 48
 author: Miguel Gomes, Kenneth Larsen, Sivakumar Kailasam, Amy Lam, Jessica Jordan, Jen Weber
 tags: Newsletter, Ember.js Times, 2018
 alias : "blog/2018/05/25/the-emberjs-times-issue-48.html"
@@ -27,7 +27,7 @@ Looking for inspiration? Check out the [#EmberJS2018 hashtag](https://twitter.co
 Recently, lots of work has landed 🛬 in Ember CLI to bring the long-awaited **Packager feature** to life ([1](https://github.com/ember-cli/ember-cli/pull/7826), [2](https://github.com/ember-cli/ember-cli/pull/7818), [3](https://github.com/ember-cli/ember-cli/pull/7816), [4](https://github.com/ember-cli/ember-cli/pull/7796), [5](https://github.com/ember-cli/ember-cli/pull/7788)). The Packager will increase the **flexibility** of Ember's **build pipeline**, paving the way for other neat features like code splitting and tree shaking and finally allowing developers to further reduce the filesize of their applications by dramatic amounts.
 
 Want a recap of what's in for the Packager feature? Be sure to check out both the  the [original RFC (Request for Comments) proposal](https://github.com/chadhietala/rfcs/blob/packager/active/0002-packager.md), as well as [this year's update](https://github.com/ember-cli/rfcs/blob/master/active/0051-packaging.md) that details the motivation behind it.
-And want to know **when** it will finally land for an Ember app near you? Of course we'll let you know ASAP 🔜 in one of the upcoming editions of the Ember.js Times!
+And want to know **when** it will finally land for an Ember app near you? Of course we'll let you know ASAP 🔜 in one of the upcoming editions of The Ember Times!
 
 ---
 

--- a/source/blog/2018-06-01-the-emberjs-times-issue-49.md
+++ b/source/blog/2018-06-01-the-emberjs-times-issue-49.md
@@ -1,5 +1,5 @@
 ---
-title: The Ember.js Times - Issue No. 49
+title: The Ember Times - Issue No. 49
 author: Chris Manson, Sivakumar Kailasam, Amy Lam, Ryan Mark, Jessica Jordan
 tags: Newsletter, Ember.js Times, 2018
 alias : "blog/2018/06/01/the-emberjs-times-issue-49.html"
@@ -21,7 +21,7 @@ responsive: true
 This week we have a 🌟 **Special Edition** 🌟😲 for you: we'll take a look into the internals of the new
 Ember Guides website, which has had a [complete makeover and relaunched this month](https://www.emberjs.com/blog/2018/05/25/the-emberjs-times-issue-48.html#toc_a-href-https-guides-emberjs-com-new-ember-guides-launched-a) to finally run on an amazing Ember app. This will finally make contributions through the Ember community immensely easier. ✨
 
-In this special edition of The Ember.js Times, [@real_ate](https://github.com/mansona) who championed the **migration of the Guides** will let us have a peek into [the new app's](https://github.com/ember-learn/guides-app) internals and into its **Broccoli** powered **build pipeline**. So get ready to hit your recommended daily intake of veggies 🥒🥕 and read either on the [Ember blog](https://www.emberjs.com/blog/2018/06/01/the-emberjs-times-issue-49.html) or in our [e-mail newsletter](https://the-emberjs-times.ongoodbits.com/2018/06/01/issue-49) about what has been going on in Emberland this week...
+In this special edition of The Ember Times, [@real_ate](https://github.com/mansona) who championed the **migration of the Guides** will let us have a peek into [the new app's](https://github.com/ember-learn/guides-app) internals and into its **Broccoli** powered **build pipeline**. So get ready to hit your recommended daily intake of veggies 🥒🥕 and read either on the [Ember blog](https://www.emberjs.com/blog/2018/06/01/the-emberjs-times-issue-49.html) or in our [e-mail newsletter](https://the-emberjs-times.ongoodbits.com/2018/06/01/issue-49) about what has been going on in Emberland this week...
 
 ---
 

--- a/source/blog/2018-06-08-the-emberjs-times-issue-50.md
+++ b/source/blog/2018-06-08-the-emberjs-times-issue-50.md
@@ -1,5 +1,5 @@
 ---
-title: The Ember.js Times - Issue No. 50
+title: The Ember Times - Issue No. 50
 author: Kenneth Larsen, Sivakumar Kailasam, Alon Bukai, Ryan Mark, Amy Lam, Jen Weber, Jessica Jordan
 tags: Newsletter, Ember.js Times, 2018
 alias : "blog/2018/06/08/the-emberjs-times-issue-50.html"

--- a/source/blog/2018-06-15-the-emberjs-times-issue-51.md
+++ b/source/blog/2018-06-15-the-emberjs-times-issue-51.md
@@ -1,5 +1,5 @@
 ---
-title: The Ember.js Times - Issue No. 51
+title: The Ember Times - Issue No. 51
 author: Gaurav Munjal, Melanie Sumner, Miguel Braga Gomes, Sivakumar Kailasam, Kenneth Larsen, Jessica Jordan
 tags: Newsletter, Ember.js Times, 2018
 alias : "blog/2018/06/15/the-emberjs-times-issue-51.html"
@@ -30,7 +30,7 @@ Named arguments already landed in [Ember 3.1](https://www.emberjs.com/blog/2018/
 
 Quite recently **a plethora of RFCs (Request for Comments)** proposed ground-breaking, **new
 features** for Ember. These included the proposals for [ES5 Getters](https://github.com/emberjs/rfcs/blob/master/text/0281-es5-getters.md) and [named arguments for Components](https://github.com/emberjs/rfcs/blob/master/text/0276-named-args.md) which already found their way into the **previous 3.1 release** in a [stable fashion](https://www.emberjs.com/blog/2018/04/13/ember-3-1-released.html#toc_changes-in-ember-js-3-1).
-But what about all the other cool things that we mentioned in previous editions of the Ember Times?
+But what about all the other cool things that we mentioned in previous editions of the The Ember Times?
 When are all of these proposal finally gonna land?
 
 Features which haven't found their way into a stable release and have not been recommended by the [official Guides](https://github.com/ember-learn/guides-app) yet,
@@ -120,9 +120,9 @@ A heads-up that this RFC has entered the FCP (Final Comment Period), so this wee
   <p><strong>Submit your own</strong> short and sweet <strong>question</strong> at <a href="https://bit.ly/ask-ember-core" target="rq">bit.ly/ask-ember-core</a>. And don’t worry, there are no silly questions, we appreciate them all - promise! 🤞</p>
 </div>
 
-## [The Ember Times is What We Make It 🙌](https://the-emberjs-times.ongoodbits.com/)
+## [The The Ember Times is What We Make It 🙌](https://the-emberjs-times.ongoodbits.com/)
 
-The **Ember Times** is a **weekly news editorial** featuring all the new things that are going on in Emberland.
+The **The Ember Times** is a **weekly news editorial** featuring all the new things that are going on in Emberland.
 [Subscribe to our e-mail newsletter](https://the-emberjs-times.ongoodbits.com/) to get the next edition **right to your inbox**.
 If you ❤️ what you're reading and you feel like a **writer** at heart,
 drop by [#topic-embertimes](https://embercommunity.slack.com/messages/C8P6UPWNN/convo/C4TD5JJ7R-1497022015.688894/) on the Ember Community Slack Chat to join the discussion or even **become the co-author** of a future edition!

--- a/source/blog/2018-06-15-the-emberjs-times-issue-51.md
+++ b/source/blog/2018-06-15-the-emberjs-times-issue-51.md
@@ -30,7 +30,7 @@ Named arguments already landed in [Ember 3.1](https://www.emberjs.com/blog/2018/
 
 Quite recently **a plethora of RFCs (Request for Comments)** proposed ground-breaking, **new
 features** for Ember. These included the proposals for [ES5 Getters](https://github.com/emberjs/rfcs/blob/master/text/0281-es5-getters.md) and [named arguments for Components](https://github.com/emberjs/rfcs/blob/master/text/0276-named-args.md) which already found their way into the **previous 3.1 release** in a [stable fashion](https://www.emberjs.com/blog/2018/04/13/ember-3-1-released.html#toc_changes-in-ember-js-3-1).
-But what about all the other cool things that we mentioned in previous editions of the The Ember Times?
+But what about all the other cool things that we mentioned in previous editions of the Ember Times?
 When are all of these proposal finally gonna land?
 
 Features which haven't found their way into a stable release and have not been recommended by the [official Guides](https://github.com/ember-learn/guides-app) yet,
@@ -120,7 +120,7 @@ A heads-up that this RFC has entered the FCP (Final Comment Period), so this wee
   <p><strong>Submit your own</strong> short and sweet <strong>question</strong> at <a href="https://bit.ly/ask-ember-core" target="rq">bit.ly/ask-ember-core</a>. And don’t worry, there are no silly questions, we appreciate them all - promise! 🤞</p>
 </div>
 
-## [The The Ember Times is What We Make It 🙌](https://the-emberjs-times.ongoodbits.com/)
+## [The Ember Times is What We Make It 🙌](https://the-emberjs-times.ongoodbits.com/)
 
 The **The Ember Times** is a **weekly news editorial** featuring all the new things that are going on in Emberland.
 [Subscribe to our e-mail newsletter](https://the-emberjs-times.ongoodbits.com/) to get the next edition **right to your inbox**.

--- a/source/blog/2018-06-22-the-ember-times-issue-52.md
+++ b/source/blog/2018-06-22-the-ember-times-issue-52.md
@@ -134,14 +134,14 @@ the deprecation story and comment on the pull request what you think about it. �
 
 ---
 
-## [The The Ember Times is What We Make It 🙌](https://embercommunity.slack.com/messages/C8P6UPWNN/)
+## [The Ember Times is What We Make It 🙌](https://embercommunity.slack.com/messages/C8P6UPWNN/)
 
 The **The Ember Times** is a **weekly news editorial** featuring all the new things that are going on in Emberland.
 [Subscribe to our e-mail newsletter](https://the-emberjs-times.ongoodbits.com/) to get the next edition **right to your inbox**.
 And if you've always wanted to be an OSS journalist yourself,
 drop by [#topic-embertimes](https://embercommunity.slack.com/messages/C8P6UPWNN/)
 on the Ember Community [Slack Chat](https://ember-community-slackin.herokuapp.com/)
-and **write** the next edition of the The Ember Times **together with us**!
+and **write** the next edition of the Ember Times **together with us**!
 
 
 ---

--- a/source/blog/2018-06-22-the-ember-times-issue-52.md
+++ b/source/blog/2018-06-22-the-ember-times-issue-52.md
@@ -1,7 +1,7 @@
 ---
 title: The Ember Times - Issue No. 52
 author: Miguel Braga Gomes, Kenneth Larsen, Jessica Jordan
-tags: Recent Posts, Newsletter, Ember.js Times, Ember Times, 2018
+tags: Recent Posts, Newsletter, Ember.js Times, The Ember Times, 2018
 alias : "blog/2018/06/22/the-ember-times-issue-52.html"
 responsive: true
 ---
@@ -134,14 +134,14 @@ the deprecation story and comment on the pull request what you think about it. �
 
 ---
 
-## [The Ember Times is What We Make It 🙌](https://embercommunity.slack.com/messages/C8P6UPWNN/)
+## [The The Ember Times is What We Make It 🙌](https://embercommunity.slack.com/messages/C8P6UPWNN/)
 
-The **Ember Times** is a **weekly news editorial** featuring all the new things that are going on in Emberland.
+The **The Ember Times** is a **weekly news editorial** featuring all the new things that are going on in Emberland.
 [Subscribe to our e-mail newsletter](https://the-emberjs-times.ongoodbits.com/) to get the next edition **right to your inbox**.
 And if you've always wanted to be an OSS journalist yourself,
 drop by [#topic-embertimes](https://embercommunity.slack.com/messages/C8P6UPWNN/)
 on the Ember Community [Slack Chat](https://ember-community-slackin.herokuapp.com/)
-and **write** the next edition of the Ember Times **together with us**!
+and **write** the next edition of the The Ember Times **together with us**!
 
 
 ---


### PR DESCRIPTION
## What it does
Replaces instances of the Ember.js Times to the Ember Times. 

## Related Issue(s)
Closes #3410 
