### PR TITLE
organizing our contributors blog post

### DIFF
--- a/data/team.yml
+++ b/data/team.yml
@@ -5,7 +5,8 @@
   twitter: https://twitter.com/wycats
   image: ykatz.jpg
   teams:
-    - core
+    - corejs
+    - steering
 - name: Tom Dale
   first: Tom
   last: Dale
@@ -13,7 +14,8 @@
   twitter: https://twitter.com/tomdale
   image: tdale.jpg
   teams:
-    - core
+    - corejs
+    - steering
 - name: Peter Wagenet
   first: Peter
   last: Wagenet
@@ -21,7 +23,7 @@
   twitter: https://twitter.com/wagenet
   image: pwagenet.jpg
   teams:
-    - corealumni
+    - alumni
 - name: Trek Glowacki
   first: Trek
   last: Glowack
@@ -29,7 +31,7 @@
   twitter: https://twitter.com/trek
   image: tglowaki.jpg
   teams:
-    - corealumni
+    - alumni
 - name: Erik Bryn
   first: Erik
   last: Bryn
@@ -37,7 +39,7 @@
   twitter: https://twitter.com/ebryn
   image: ebryn.jpg
   teams:
-    - corealumni
+    - alumni
 - name: Kris Selden
   first: Kris
   last: Selden
@@ -45,7 +47,7 @@
   twitter: https://twitter.com/krisselden
   image: kselden.jpg
   teams:
-    - core
+    - corejs
 - name: Stefan Penner
   first: Stefan
   last: Penner
@@ -53,7 +55,7 @@
   twitter: https://twitter.com/stefanpenner
   image: spenner.jpg
   teams:
-    - core
+    - corejs
     - cli
 - name: Leah Silber
   first: Leah
@@ -62,8 +64,9 @@
   twitter: https://twitter.com/wifelette
   image: lsilber.jpg
   teams:
-    - core
+    - corejs
     - learning
+    - steering
 - name: Alex Matchneer
   first: Alex
   last: Matchneer
@@ -71,7 +74,7 @@
   twitter: https://twitter.com/machty
   image: amatchneer.jpg
   teams:
-    - corealumni
+    - alumni
 - name: Robert Jackson
   first: Robert
   last: Jackson
@@ -79,7 +82,7 @@
   twitter: https://twitter.com/rwjblue
   image: rjackson.jpg
   teams:
-    - core
+    - corejs
     - cli
 - name: Igor Terzic
   first: Igor
@@ -88,7 +91,7 @@
   twitter: https://twitter.com/terzicigor
   image: iterzic.jpeg
   teams:
-    - core
+    - corejs
     - data
 - name: Matthew Beale
   first: Matthew
@@ -97,7 +100,7 @@
   twitter: https://twitter.com/mixonic
   image: mbeale.jpg
   teams:
-    - core
+    - corejs
 - name: Edward Faulkner
   first: Edward
   last: Faulkner
@@ -105,7 +108,8 @@
   twitter: https://twitter.com/eaf4
   image: efaulkner.jpg
   teams:
-    - core
+    - corejs
+    - steering
 - name: Martin Muñoz
   first: Martin
   last: Muñoz
@@ -113,7 +117,7 @@
   twitter: https://twitter.com/_mmun
   image: mmunoz.jpg
   teams:
-    - core
+    - corejs
 - name: Dan Gebhardt
   first: Dan
   last: Gebhardt
@@ -121,7 +125,7 @@
   twitter: https://twitter.com/dgeb
   image: dgeb.jpg
   teams:
-    - core
+    - corejs
 - name: Godfrey Chan
   first: Godfrey
   last: Chan
@@ -129,7 +133,7 @@
   twitter: https://twitter.com/chancancode
   image: godfrey.jpg
   teams:
-    - core
+    - corejs
 - name: Brendan McLoughlin
   first: Brendan
   last: McLoughlin
@@ -177,7 +181,7 @@
   twitter: https://twitter.com/locks
   image: rmendes.jpg
   teams:
-    - core
+    - corejs
     - learning
 - name: Todd Jordan
   first: Todd
@@ -195,8 +199,7 @@
   twitter: https://twitter.com/chadhietala
   image: chietala.jpg
   teams:
-    - core
-    - cli
+    - corejs
 - name: Jacob Bixby
   first: Jacob
   last: Bixby
@@ -204,7 +207,7 @@
   twitter: https://twitter.com/trabus
   image: jbixby.jpg
   teams:
-    - cli
+    - alumni
 - name: Katie Gengler
   first: Katie
   last: Gengler
@@ -212,8 +215,9 @@
   twitter: https://twitter.com/katiegengler
   image: kgengler.jpg
   teams:
-    - core
+    - corejs
     - cli
+    - steering
 - name: Kelly Selden
   first: Kelly
   last: Selden
@@ -229,7 +233,7 @@
   twitter: https://twitter.com/nathanhammond
   image: nhammond.jpg
   teams:
-    - cli
+    - alumni
 - name: Tobias Bieniek
   first: Tobias
   last: Bieniek
@@ -285,8 +289,9 @@
   twitter: https://twitter.com/melaniersumner
   image: msumner.jpg
   teams:
-    - core
+    - corejs
     - learning
+    - steering
 - name: Alex Navasardyan
   first: Alex
   last: Navasardyan

--- a/source/blog/2018-06-30-organizing-our-contributors.md
+++ b/source/blog/2018-06-30-organizing-our-contributors.md
@@ -15,7 +15,7 @@ As often happens, the way things naturally evolved wasn’t necessarily the best
 
 **Moving forward, all the official teams will be known as Core teams:** Ember.js Core, Ember CLI Core, Ember Data Core, and Ember Learning Core. The intent is to make it clear that we are all peers. In some areas this was already true, and in others we will work to make it true.
 
-All that as it is, we also can’t lose our central coordination point, so along with these reorganized teams, we’re establishing the Ember Steering Committee. The Steering Committee will take the lead on community support responsibilities that we’re previously under the Core Team’s purview, while the newly-refined Ember.js Core sticks with the technical leadership responsibilities. 
+All that as it is, we also can’t lose our central coordination point, so along with these reorganized teams, we’re establishing the Ember Steering Committee. The Steering Committee will take the lead on community support responsibilities that were previously under the Core Team’s purview, while the newly-refined Ember.js Core sticks with the technical leadership responsibilities.
 
 The Steering Committee will be responsible for things including, but not limited to:
 
@@ -41,8 +41,8 @@ The Ember.js Core Team will retain its traditional technical leadership responsi
 
 The initial membership of the Steering Committee comes from people on Ember.js Core who were already working on community support tasks: Leah Silber, Melanie Sumner, Yehuda Katz, Tom Dale, Edward Faulkner and Katie Gengler.
 
-How will this change impact the wider community? Hopefully you’ll notice both jobs being done more effectively than before. Look for more great things from coming soon, including a ton of framework features landing in the 3.x series, and a refresh of the public website and messaging.
+How will this change impact the wider community? Hopefully you’ll notice both jobs being done more effectively than before. Look for more great things coming soon, including a ton of framework features landing in the 3.x series, and a refresh of the public website and messaging.
 
-Lastly, Ember.js would not be what it is without a huge community of leaders: addon maintainers, strike team members, RFC authors, meetup organizers, and more. And with respect to the duties now reorganized under the steering committee, specifically to Leah Silber, who has been managing most of these responsibilities on her own as part of her Ember Core Team responsibilities since first organizing the very first Ember logo and website way back in 2011. 
+Lastly, Ember.js would not be what it is without a huge community of leaders: addon maintainers, strike team members, RFC authors, meetup organizers, and more. And with respect to the duties now reorganized under the steering committee, especially to Leah Silber, who has been managing most of these responsibilities on her own as part of her Ember Core Team responsibilities since first organizing the very first Ember logo and website way back in 2011.
 
 We’re so thankful to all of you for your work and for this incredible opportunity to build awesome things together.

--- a/source/blog/2018-06-30-organizing-our-contributors.md
+++ b/source/blog/2018-06-30-organizing-our-contributors.md
@@ -1,0 +1,48 @@
+---
+title: Organizing Our Contributors
+author: The Ember Team
+tags: Recent Posts, Announcement, Community, 2018
+responsive: true
+---
+
+Open source project management is different than inside a typical software company. It's an example of the purest form of leadership: you’re getting a bunch of peers all moving in the same direction, despite no formal hierarchy or authority structure. It comes down to building consensus, persuasion, and setting the right examples.
+
+The Ember Core Team was formed in 2011 because even decentralized open source communities need leadership and shared direction. As our community and core contributor group grew, there was simply too much going on to keep all the work under the direct attention of the Core Team. And so multiple other teams emerged organically; first the Ember CLI team and Ember Data, and later the Learning team.
+
+The work that all these teams do is equally important. But the historical accident of Ember Core being the first team left Ember Core with numerous varied jobs. It became the coordination point for both technical leadership and overall community support.
+
+As often happens, the way things naturally evolved wasn’t necessarily the best optimized. The disparate workload was hard for the Core team to manage well, because it's difficult to simultaneously optimize for the very different jobs. At times it was also unfair to other teams, who were no less important, but had less of a say in some areas. So today we’re announcing a plan to reorganize in a way that attempts to address both concerns.
+
+**Moving forward, all the official teams will be known as Core teams:** Ember.js Core, Ember CLI Core, Ember Data Core, and Ember Learning Core. The intent is to make it clear that we are all peers. In some areas this was already true, and in others we will work to make it true.
+
+All that as it is, we also can’t lose our central coordination point, so along with these reorganized teams, we’re establishing the Ember Steering Committee. The Steering Committee will take the lead on community support responsibilities that we’re previously under the Core Team’s purview, while the newly-refined Ember.js Core sticks with the technical leadership responsibilities. 
+
+The Steering Committee will be responsible for things including, but not limited to:
+
+- Owning the [Community Guidelines](https://emberjs.com/guidelines/) and helping people stick to them
+- Serving as the public-facing ombudsman
+- Organizing events and conferences
+- Supporting local meetup organizers
+- Managing Ember's brand and visual identity
+- Facilitating cross-team coordination
+- Owning meta-level work, like making improvements to the RFC process itself
+- Establishing a framework and processes for each team to thoughtfully manage its own membership
+- Dealing with policy/legal questions
+
+The Ember.js Core Team will retain its traditional technical leadership responsibilities around the Core Ember.js and Glimmer projects, including but not limited to:
+
+- Sorting out which RFCs have enough consensus to move forward
+- Merging PRs
+- Managing the release process
+- Promoting overall ecosystem compatibility and upgradeability
+- Handling security issues
+
+ The first concrete example of how the Steering Committee can serve as facilitators for community-wide projects is the EmberJS2018 road-mapping process. Everyone on Core is committed to making sure all that great feedback from the community doesn't get dropped or forgotten, and the Steering Committee is taking responsibility for making sure a clear community roadmap is synthesized. It's not the Steering Committee's job to set the items on that roadmap—that's going to emerge from work by all of the Core teams—but it's the Steering Commitee's job to make sure the work happens, by establishing helpful processes and leading the charge.
+
+The initial membership of the Steering Committee comes from people on Ember.js Core who were already working on community support tasks: Leah Silber, Melanie Sumner, Yehuda Katz, Tom Dale, Edward Faulkner and Katie Gengler.
+
+How will this change impact the wider community? Hopefully you’ll notice both jobs being done more effectively than before. Look for more great things from coming soon, including a ton of framework features landing in the 3.x series, and a refresh of the public website and messaging.
+
+Lastly, Ember.js would not be what it is without a huge community of leaders: addon maintainers, strike team members, RFC authors, meetup organizers, and more. And with respect to the duties now reorganized under the steering committee, specifically to Leah Silber, who has been managing most of these responsibilities on her own as part of her Ember Core Team responsibilities since first organizing the very first Ember logo and website way back in 2011. 
+
+We’re so thankful to all of you for your work and for this incredible opportunity to build awesome things together.

--- a/source/stylesheets/pages/teams.css.scss
+++ b/source/stylesheets/pages/teams.css.scss
@@ -6,72 +6,58 @@ body.team {
     background-color: #dfd7d4;
   }
 
-  .headshots { /* #content is needed for specifity override */
-    margin: 0 auto !important;
-    justify-content: center;
+  .list-team { /* #content is needed for specifity override */
     width: 100%;
     display: flex;
     flex-flow: row wrap;
-    list-style-type: none !important;
-    padding-left: 5%;
-    padding-right: 5%;
-    @media screen and (min-width: 0px) and (max-width: 767px) {
-      padding-left: 1%;
-      padding-right: 1%;
-    }
+    list-style-type: none;
+    justify-content: flex-start;
 
-    a:hover {
-      border-bottom: none;
-    }
-
-    > li {
-      box-sizing: border-box;
+    .list-team-item {
+      align-items: center;
       display: flex;
-      flex-flow: column wrap;
-      padding: 40px 0 0;
+      flex-flow: row wrap;
+      flex-grow: 1;
+      flex: 1 1 1;
+      height: 175px;
+      justify-content: center;
+      margin: 1em 0.5em;
+      padding: 0;
       text-align: center;
-      width: 25%;
-      flex: 1 1 auto;
-      text-align: center;
-      @media screen and (min-width: 0px) and (max-width: 767px) {
-        width: 49%;
-        &.team-avatar {
-          width: 33% !important;
-        }
-      }    
-      &.team-avatar {
-        width: 20%;
-      }
-      p {
-        flex: 1;
+      width: 150px;
+
+      .team-member-name {
+        align-content: center;
+        display: flex;
+        font-size: calc( 14px + 8 * ((100vw - 500px) / 1500));
         font-weight: bold;
-        margin: 0px 0px 5px 0px;
+        justify-content: center;
+        line-height: 1;
         min-width: 100%;
       }
 
-      img {
-        flex: 1;
-        border-radius: 50%;
-        border: 2px solid #faf4f1;
-        height: 120px;
-        margin-bottom: 10px;
-        width: 120px;
-
-        &.alumni {
-          height: 90px;
-          width: 90px;
-        }
+      .team-member-image {
+        align-self: center;
+        border-radius: 50%;      
+        display: flex;
+        height: 100px;
+        justify-content: center;
+        margin: auto;
+        width: 100px;
 
         &:hover,
         &:active,
         &:focus {
-          border: 0;
+          border-color: transparent;
         }
       }
-      .social {
+
+      .team-member-social {
+        display: flex;
         flex: 1;
-        min-width: 100%;
+        justify-content: center;
         margin: 0 auto !important;
+        min-width: 100%;
 
         > li {
           display: inline-block;
@@ -86,21 +72,6 @@ body.team {
             color: #444;
           }
         }
-      }
-    }
-
-    &.contributors {
-      .avatar {
-        position: relative;
-      }
-
-      img {
-        height: 90px;
-        width: 90px;
-      }
-
-      .type {
-        display: none;
       }
     }
   }

--- a/source/stylesheets/pages/teams.css.scss
+++ b/source/stylesheets/pages/teams.css.scss
@@ -21,7 +21,7 @@ body.team {
       flex: 1 1 1;
       height: 175px;
       justify-content: center;
-      margin: 1em 0.5em;
+      margin: 1.5em 0.75em;
       padding: 0;
       text-align: center;
       width: 150px;
@@ -30,8 +30,8 @@ body.team {
         align-content: center;
         display: flex;
         font-size: 1em;
-        font-size: calc( 14px + 4 * ((100vw - 500px) / 1500)); //this follows so that browsers that support it will use this instead
-        font-weight: bold;
+        font-size: calc( 14px + 3 * ((100vw - 500px) / 1500)); //this follows so that browsers that support it will use this instead
+        font-weight: normal;
         justify-content: center;
         line-height: 1;
         min-width: 100%;

--- a/source/stylesheets/pages/teams.css.scss
+++ b/source/stylesheets/pages/teams.css.scss
@@ -29,7 +29,8 @@ body.team {
       .team-member-name {
         align-content: center;
         display: flex;
-        font-size: calc( 14px + 8 * ((100vw - 500px) / 1500));
+        font-size: 1em;
+        font-size: calc( 14px + 4 * ((100vw - 500px) / 1500)); //this follows so that browsers that support it will use this instead
         font-weight: bold;
         justify-content: center;
         line-height: 1;

--- a/source/team.html.erb
+++ b/source/team.html.erb
@@ -78,7 +78,7 @@ responsive: true
   <h2 class="text-center">The Ember CLI Core Team</h2>
 
   <p class="text-center">
-    The Ember CLI team is responsible for maintaining ember-cli, the command line interface for managing and packaging 
+    The Ember CLI core team is responsible for maintaining ember-cli, the command line interface for managing and packaging 
     Ember.js applications and addons. The team also maintains many of the addons in the default blueprint as well as 
     fastboot.
   </p>
@@ -114,7 +114,7 @@ responsive: true
   <h2 class="text-center">The Ember Data Core Team</h2>
   
   <p class="text-center">
-    The Ember Data team is responsible for the official data persistence library for Ember.js applications.
+    The Ember Data core team is responsible for the official data persistence library for Ember.js applications.
   </p>
 
   <% edata = data.team.select { |m| m.teams.include?('data') } %>
@@ -148,7 +148,7 @@ responsive: true
   <h2 class="text-center">The Ember Learning Core Team</h2>
 
   <p class="text-center">
-    The mission of the Ember Learning Team is to empower Ember users to learn, build and teach. This team is responsible
+    The mission of the Ember Learning core team is to empower Ember users to learn, build and teach. This team is responsible
     for keeping the guides and API documentation updated, and manages the initiatives that support learning Ember.
   </p>
 
@@ -181,7 +181,7 @@ responsive: true
 <hr/>
 
 <section class="section-team">
-  <h2 class="text-center">Program Alumni</h2>
+  <h2 class="text-center">Project Alumni</h2>
 
   <p class="text-center">
     Serving as a member of the Core Team(s) of an open source project like Ember is a huge amount of work. These are 

--- a/source/team.html.erb
+++ b/source/team.html.erb
@@ -9,40 +9,33 @@ responsive: true
   Ember is an Open Source project that relies on the tireless support of individual contributors. These are the teams 
   that guide the development and instruction of Ember.js. 
 </p>
+<section class="section-team">
+ <h2 class="text-center">The Steering Committee</h2>
 
-<section class="team section">
-  <h2 class="text-center">The Core Team</h2>
+<p class="text-center">
+    The Steering Committee is responsible for the overall governance of the Ember project. 
+</p>
 
-  <% core = data.team.select { |m| m.teams.include?('core') } %>
-
-  <ul class="headshots">
-    <% core.each do |user| %>
-      <li>
-        <a href="<%= user.github %>" rel="nofollow" class="avatar">
-          <img src="/images/team/<%= user.image %>" alt="<%= user.name %>">
-        </a>
-
-        <p class="name">
+<% steering = data.team.select { |m| m.teams.include?('steering') } %>
+  <ul class="list-team">
+    <% steering.each do |user| %>
+      <li class="list-team-item">
+        <img src="/images/team/<%= user.image %>" alt="<%= user.name %>" class="team-member-image">
+        <div class="team-member-name">
           <%= user.name %>
-        </p>
-
-        <ul class="social">
+        </div>
+        <ul class="team-member-social">
           <li>
-            <a class="twitter" href="<%= user.twitter %>" aria-label="<%= user.name %> Twitter">
+            <a class="team-member-twitter" href="<%= user.twitter %>" aria-label="<%= user.name %> Twitter">
               <i class="icon-twitter" aria-hidden="true"></i>
             </a>
           </li>
-
           <li>
-            <a class="github" href="<%= user.github %>" aria-label="<%= user.name %> Github Profile">
+            <a class="team-member-github" href="<%= user.github %>" aria-label="<%= user.name %> Github Profile">
               <i class="icon-github" aria-hidden="true"></i>
             </a>
           </li>
         </ul>
-
-        <p class="bio">
-          <%= user.bio %>
-        </p>
       </li>
     <% end %>
   </ul>
@@ -50,45 +43,62 @@ responsive: true
 
 <hr/>
 
-<section class="team section">
-  <h2 class="text-center">The Ember CLI Team</h2>
+<section class="section-team">
+  <h2 class="text-center">The Ember.js Core Team</h2>
 
-  <p class="lead text-center">
+  <% ecorejs = data.team.select { |m| m.teams.include?('corejs') } %>
+  <ul class="list-team">
+    <% ecorejs.sort_by { |user| user.last }.each do |user| %>
+      <li class="list-team-item">
+        <img src="/images/team/<%= user.image %>" alt="<%= user.name %>" class="team-member-image">
+        <div class="team-member-name">
+          <%= user.name %>
+        </div>
+        <ul class="team-member-social">
+          <li>
+            <a class="team-member-twitter" href="<%= user.twitter %>" aria-label="<%= user.name %> Twitter">
+              <i class="icon-twitter" aria-hidden="true"></i>
+            </a>
+          </li>
+
+          <li>
+            <a class="team-member-github" href="<%= user.github %>" aria-label="<%= user.name %> Github Profile">
+              <i class="icon-github" aria-hidden="true"></i>
+            </a>
+          </li>
+        </ul>
+      </li>
+    <% end %>
+  </ul>
+</section>
+
+<hr/>
+
+<section class="section-team">
+  <h2 class="text-center">The Ember CLI Core Team</h2>
+
+  <p class="text-center">
     The Ember CLI team is responsible for maintaining ember-cli, the command line interface for managing and packaging 
     Ember.js applications and addons. The team also maintains many of the addons in the default blueprint as well as 
     fastboot.
   </p>
 
-  <%
-    subteams = ['cli'];
-
-    subteams = subteams.map { |team|
-      data.team.select {|u| u.teams.include?(team); }.map {|u| u['type'] = team; u }
-    }.flatten
-
-    subteams.sort_by! {|u| [u.last] }
-  %>
-
-  <ul class="contributors headshots">
-    <% subteams.each do |user| %>
-      <li class="team-avatar">
-        <a href="<%= user.github %>" rel="nofollow" class="avatar" >
-          <img src="/images/team/<%= user.image %>" alt="<%= user.name %>">
-        </a>
-
-        <p class="name">
+  <% ecli = data.team.select { |m| m.teams.include?('cli') } %>
+  <ul class="list-team">
+    <% ecli.sort_by { |user| user.last }.each do |user| %>
+      <li class="list-team-item">
+        <img src="/images/team/<%= user.image %>" alt="<%= user.name %>" class="team-member-image">
+        <div class="team-member-name">
           <%= user.name %>
-        </p>
-
-        <ul class="social">
+        </div>
+        <ul class="team-member-social">
           <li>
-            <a class="twitter" href="<%= user.twitter %>" aria-label="<%= user.name %> Twitter">
+            <a class="team-member-twitter" href="<%= user.twitter %>" aria-label="<%= user.name %> Twitter">
               <i class="icon-twitter" aria-hidden="true"></i>
             </a>
           </li>
-
           <li>
-            <a class="github" href="<%= user.github %>" aria-label="<%= user.name %> Github Profile">
+            <a class="team-member-github" href="<%= user.github %>" aria-label="<%= user.name %> Github Profile">
               <i class="icon-github" aria-hidden="true"></i>
             </a>
           </li>
@@ -100,43 +110,29 @@ responsive: true
 
 <hr/>
 
-<section class="team section">
-  <h2 class="text-center">The Ember Data Team</h2>
+<section class="section-team">
+  <h2 class="text-center">The Ember Data Core Team</h2>
   
-  <p class="lead text-center">
+  <p class="text-center">
     The Ember Data team is responsible for the official data persistence library for Ember.js applications.
   </p>
 
-  <%
-    subteams = ['data'];
-
-    subteams = subteams.map { |team|
-      data.team.select {|u| u.teams.include?(team); }.map {|u| u['type'] = team; u }
-    }.flatten
-
-    subteams.sort_by! {|u| [u.last] }
-  %>
-
-  <ul class="contributors headshots">
-    <% subteams.each do |user| %>
-      <li class="team-avatar">
-        <a href="<%= user.github %>" rel="nofollow" class="avatar" aria-label="<%= user.name %>">
-          <img src="/images/team/<%= user.image %>" role="presentation" alt="">
-        </a>
-
-        <p class="name">
+  <% edata = data.team.select { |m| m.teams.include?('data') } %>
+  <ul class="list-team">
+    <% edata.sort_by { |user| user.last }.each do |user| %>
+      <li class="list-team-item">
+        <img src="/images/team/<%= user.image %>" alt="<%= user.name %>" class="team-member-image">
+        <div class="team-member-name">
           <%= user.name %>
-        </p>
-
-        <ul class="social">
+        </div>
+        <ul class="team-member-social">
           <li>
-            <a class="twitter" href="<%= user.twitter %>" aria-label="<%= user.name %> Twitter">
+            <a class="team-member-twitter" href="<%= user.twitter %>" aria-label="<%= user.name %> Twitter">
               <i class="icon-twitter" aria-hidden="true"></i>
             </a>
           </li>
-
           <li>
-            <a class="github" href="<%= user.github %>" aria-label="<%= user.name %> Github Profile">
+            <a class="team-member-github" href="<%= user.github %>" aria-label="<%= user.name %> Github Profile">
               <i class="icon-github" aria-hidden="true"></i>
             </a>
           </li>
@@ -148,44 +144,31 @@ responsive: true
 
 <hr/>
 
-<section class="team section">
-  <h2 class="text-center">The Ember Learning Team</h2>
+<section class="section-team">
+  <h2 class="text-center">The Ember Learning Core Team</h2>
 
-  <p class="lead text-center">
+  <p class="text-center">
     The mission of the Ember Learning Team is to empower Ember users to learn, build and teach. This team is responsible
     for keeping the guides and API documentation updated, and manages the initiatives that support learning Ember.
   </p>
 
-  <%
-    subteams = ['learning'];
-
-    subteams = subteams.map { |team|
-      data.team.select {|u| u.teams.include?(team); }.map {|u| u['type'] = team; u }
-    }.flatten
-
-    subteams.sort_by! {|u| [u.last] }
-  %>
-
-  <ul class="contributors headshots">
-    <% subteams.each do |user| %>
-      <li class="team-avatar">
-        <a href="<%= user.github %>" rel="nofollow" class="avatar">
-          <img src="/images/team/<%= user.image %>" alt="<%= user.name %>">
-        </a>
-
-        <p class="name">
+  <% learning = data.team.select { |m| m.teams.include?('learning') } %>
+  <ul class="list-team">
+    <% learning.sort_by { |user| user.last }.each do |user| %>
+      <li class="list-team-item">
+        <img src="/images/team/<%= user.image %>" alt="<%= user.name %>" class="team-member-image">
+        <div class="team-member-name">
           <%= user.name %>
-        </p>
-
-        <ul class="social">
+        </div>
+        <ul class="team-member-social">
           <li>
-            <a class="twitter" href="<%= user.twitter %>" aria-label="<%= user.name %> Twitter">
+            <a class="team-member-twitter" href="<%= user.twitter %>" aria-label="<%= user.name %> Twitter">
               <i class="icon-twitter" aria-hidden="true"></i>
             </a>
           </li>
 
           <li>
-            <a class="github" href="<%= user.github %>" aria-label="<%= user.name %> Github Profile">
+            <a class="team-member-github" href="<%= user.github %>" aria-label="<%= user.name %> Github Profile">
               <i class="icon-github" aria-hidden="true"></i>
             </a>
           </li>
@@ -197,26 +180,22 @@ responsive: true
 
 <hr/>
 
-<section class="team section">
-  <h2 class="text-center">Ember Core Alumni</h2>
+<section class="section-team">
+  <h2 class="text-center">Program Alumni</h2>
 
-  <p class="lead text-center">
-    Serving as a member of the Core Team of an open source project like Ember is a huge amount of work. These are 
-    retired members of the Ember Core Team, to whom we will always be grateful.
+  <p class="text-center">
+    Serving as a member of the Core Team(s) of an open source project like Ember is a huge amount of work. These are 
+    retired members of the Ember Core Teams, to whom we will always be grateful.
   </p>
 
-  <% alumni = data.team.select { |m| m.teams.include?('corealumni') } %>
-
-  <ul class="headshots">
-    <% alumni.each do |user| %>
-      <li class="team-avatar">
-        <a href="<%= user.github %>" rel="nofollow">
-          <img class="alumni" src="/images/team/<%= user.image %>" alt="<%= user.name %>" />
-        </a>
-    
-        <p>
+  <% alumni = data.team.select { |m| m.teams.include?('alumni') } %>
+  <ul class="list-team">
+    <% alumni.sort_by { |user| user.last }.each do |user| %>
+      <li class="list-team-item">
+        <img src="/images/team/<%= user.image %>" alt="<%= user.name %>" class="team-member-image">
+        <div class="team-member-name">
           <%= user.name %>
-        </p>
+        </div>
       </li>
     <% end %>
   </ul>


### PR DESCRIPTION
## What it does
This PR adds the "organizing our contributors" blog post and updates the team page to reflect the new organization. 

## Changes
team data: 
- changed `corealumni` to `alumni`
- change `core` to `corejs`
- added alumni status to ember-cli team members as per that team
- added `steering` as appropriate

team page: 
- added "Core" designation to all teams
- added the Steering Committee 
- updated the template code for consistency
- alphabetically sorted teams by last name (except the steering committee)
- re-wrote the CSS to use flexbox 

blog post: 
- added the "Organizing Our Contributors" blog post (dated 6/30/18)