### PR TITLE
Add Ember Times Logo to Tag Page and Ember Times Posts

### DIFF
--- a/source/blog/tag.html.erb
+++ b/source/blog/tag.html.erb
@@ -5,7 +5,12 @@ responsive: true
 ---
 <% @title = tagname %>
 
-<h1 class="text-left"><%= tagname %></h1>
+<% if tagname == 'Newsletter' || tagname == 'Ember Times' %>
+  <h1 class="text-left blog-header--invisible"><%= tagname %></h1>
+  <div class="large ember-times-logo"></div>
+<% else %>
+  <h1 class="text-left"><%= tagname %></h1>
+<% end %>
 
 <% page_articles.each_with_index do |article, i| %>
   <article class="blog-post">

--- a/source/layouts/blog.erb
+++ b/source/layouts/blog.erb
@@ -2,9 +2,14 @@
 <% partial_for :sidebar, 'blog/sidebar' %>
 <% partial_for :foot, 'footer' %>
 <% wrap_layout :layout do %>
-  
+
   <article class="blog-post">
     <div class="blog-post-header">
+      <% if current_page.data.tags.include? 'Newsletter' %>
+        <a class="blog-header" href="<%= tag_path 'Newsletter' %>" aria-label="Read more issues of The Ember Times">
+          <div class="large ember-times-logo"></div>
+        </a>
+      <% end %>
       <h1 class="blog-post-title"><%= current_article.title %></h1>
       <div class="blog-post-meta">
         <% if current_page.data.author %>

--- a/source/stylesheets/blog.css.scss
+++ b/source/stylesheets/blog.css.scss
@@ -212,7 +212,6 @@ body.blog.responsive {
       .blog-post-tag {
         display: block;
         width: 100%;
-
       }
     }
   }

--- a/source/stylesheets/blog.css.scss
+++ b/source/stylesheets/blog.css.scss
@@ -132,6 +132,28 @@ body.blog.responsive {
       }
     }
   }
+
+  .blog-header--invisible {
+    visibility: hidden;
+    position: absolute;
+  }
+
+  .ember-times-logo {
+    background-image: url('/images/brand/ember_Times-Light.png');
+    background-position: left center;
+    background-color: transparent;
+    background-attachment: scroll;
+    background-repeat: no-repeat;
+    margin: 0 0 0.7em;
+    &.large {
+      background-size: 75%;
+      height: 155px;
+      @media screen and (max-width: $small-breakpoint) {
+        background-size: 90%;
+        height: 100px;
+      }
+    }
+  }
 }
 
 .blog {


### PR DESCRIPTION
<!--- Make sure to add a descriptive title in the field above! E.g. "Fixes the header title color on the homepage"  -->

## What it does
<!--- Tell us what this fix does in a few sentences. E.g. "This updates the header title's font color to Ember Orange." -->

This uses the Ember Times Logo and places it as a header item into the newsletter and Ember Times overview pages. It also adds the logo as a header item into each single Ember Times post that has been tagged as `Newsletter`.

To be discussed: On the tag page I decided to hide the heading `Newsletter` via `visibility:hidden` and include the image together with `Ember Times` as an `alt` attribute in the same `h1` tag.
If this isn't sufficient to provide a great a11y experience, I can improve it as suggested.
See also the screenshot and the screen recording below.

## To test locally:
Visit on the following routes on your local instance:
- Tag Pages: http://localhost:4567/blog/tags/newsletter.html and http://localhost:4567/blog/tags/ember-times.html
- Post Page, e.g. http://localhost:4567/blog/2018/06/29/the-ember-times-issue-53.html

## Related Issue(s)
<!--- Please provide the issue(s) to which this pull request relates to or which issue it closes. E.g. "Closes #1234" -->

Closes #3432

## Sources
<!-- Optional. If applicable be sure to add any screenshots or screen recordings of your work for your reviewers here -->

| UI | screen-read w/ Voice Over | inspected w/ Firefox A11Y Inspector |
|--|--|--|
| ![embertimeslogoheader](https://user-images.githubusercontent.com/8811742/42124849-b155ac12-7c6a-11e8-826d-c90ef514f90a.gif) | https://streamable.com/tqgcl | <img width="1678" alt="screen shot 2018-06-30 at 11 04 01" src="https://user-images.githubusercontent.com/8811742/42124828-621f206a-7c6a-11e8-8b0a-0d1e504209f2.png">|
