### PR TITLE
blog(embertimes): remove issue 53 from recent posts

### DIFF
--- a/source/blog/2018-06-29-the-ember-times-issue-53.md
+++ b/source/blog/2018-06-29-the-ember-times-issue-53.md
@@ -1,7 +1,7 @@
 ---
 title: The Ember Times - Issue No. 53
 author: Kenneth Larsen, Sivakumar Kailasam, Alon Bukai, Ryan Mark, Jen Weber, Jessica Jordan
-tags: Recent Posts, Newsletter, Ember.js Times, Ember Times, 2018
+tags: Newsletter, Ember.js Times, Ember Times, 2018
 alias : "blog/2018/06/29/the-ember-times-issue-53.html"
 responsive: true
 ---


### PR DESCRIPTION
<!--- Make sure to add a descriptive title in the field above! E.g. "Fixes the header title color on the homepage"  -->

## What it does
<!--- Tell us what this fix does in a few sentences. E.g. "This updates the header title's font color to Ember Orange." -->

This removes the Ember Times No.53 from the list of recent blog posts. This should be merged once edition 54 is released.

## Related Issue(s)
<!--- Please provide the issue(s) to which this pull request relates to or which issue it closes. E.g. "Closes #1234" -->

Relates to #3438 

## Sources
<!-- Optional. If applicable be sure to add any screenshots or screen recordings of your work for your reviewers here -->
