### PR TITLE
Reduce line-height of title

### DIFF
--- a/source/stylesheets/about.css.scss
+++ b/source/stylesheets/about.css.scss
@@ -74,7 +74,7 @@
   font-family: 'Source Sans Pro';
   font-size: 3rem;
   font-weight: 300;
-  line-height: 1.5;
+  line-height: 1.15;
   margin: 0 auto;
   max-width: 100%;
   text-align: center;


### PR DESCRIPTION
Line height and text size are typically inverses, so I'm proposing we take down the line-height of the title a bit.

Happy to provide some material on this if anyone would like!

<!--- Make sure to add a descriptive title in the field above! E.g. "Fixes the header title color on the homepage"  -->

## What it does
<!--- Tell us what this fix does in a few sentences. E.g. "This updates the header title's font color to Ember Orange." -->

## Related Issue(s)
<!--- Please provide the issue(s) to which this pull request relates to or which issue it closes. E.g. "Closes #1234" -->

## Sources
<!-- Optional. If applicable be sure to add any screenshots or screen recordings of your work for your reviewers here -->
