### PR TITLE
Fixes logo on subpages

### DIFF
--- a/source/_header.html.erb
+++ b/source/_header.html.erb
@@ -8,7 +8,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-   <a class="navbar-brand" href="/"><img src="images/logos/ember-logo.svg" alt="home" /></a>
+   <a class="navbar-brand" href="/"><img src="/images/logos/ember-logo.svg" alt="home" /></a>
   </div>
   <div class="collapse navbar-collapse" id="navbar-collapse">
    <ul class="nav navbar-nav">


### PR DESCRIPTION
Logo was using a relative URL and therefore not being available on any subpage (expect for API docs which is generating header on it's own). This was introduced in 9278d2381788dc607fcef62efe6e92c2953e7ae6.