### PR TITLE
blog(embertimes): remove issue 55 + 54 from recent posts

### DIFF
--- a/source/blog/2018-07-06-the-ember-times-issue-54.md
+++ b/source/blog/2018-07-06-the-ember-times-issue-54.md
@@ -1,7 +1,7 @@
 ---
 title: The Ember Times - Issue No. 54
 author: Sivakumar Kailasam, Jessica Jordan, Alon Bukai, Amy Lam, Kenneth Larsen
-tags: Recent Posts, Newsletter, Ember.js Times, Ember Times, 2018
+tags: Newsletter, Ember.js Times, Ember Times, 2018
 alias : "blog/2018/07/06/the-ember-times-issue-54.html"
 responsive: true
 ---

--- a/source/blog/2018-07-13-the-ember-times-issue-55.md
+++ b/source/blog/2018-07-13-the-ember-times-issue-55.md
@@ -1,7 +1,7 @@
 ---
 title: The Ember Times - Issue No. 55
 author: Kenneth Larsen, Amy Lam, Miguel Braga Gomes, Ryan Mark, Sivakumar Kailasam, Jessica Jordan, Alon Bukai
-tags: Recent Posts, Newsletter, Ember.js Times, Ember Times, 2018
+tags: Newsletter, Ember.js Times, Ember Times, 2018
 alias : "blog/2018/07/13-the-ember-times-issue-55.html"
 responsive: true
 ---


### PR DESCRIPTION
<!--- Make sure to add a descriptive title in the field above! E.g. "Fixes the header title color on the homepage"  -->

## What it does
<!--- Tell us what this fix does in a few sentences. E.g. "This updates the header title's font color to Ember Orange." -->

This removes previous editions from the list of recent posts and only leaves the most recent edition (No. 58) up.

## Related Issue(s)
<!--- Please provide the issue(s) to which this pull request relates to or which issue it closes. E.g. "Closes #1234" -->

## Sources
<!-- Optional. If applicable be sure to add any screenshots or screen recordings of your work for your reviewers here -->
