### PR TITLE
blog(embertimes): Adds ember times template

### DIFF
--- a/source/blog/embertimes-template.md
+++ b/source/blog/embertimes-template.md
@@ -1,0 +1,91 @@
+---
+title: The Ember Times - Issue No. XX
+author: the crowd
+tags: Recent Posts, Newsletter, Ember.js Times, Ember Times, 2018
+alias : "blog/xxxx/xx/xx-the-ember-times-issue-XX.html"
+responsive: true
+---
+
+<SAYING-HELLO-IN-YOUR-FAVORITE-LANGUAGE> Emberistas! 🐹
+
+Read either on the [Ember blog](https://www.emberjs.com/blog/xxxx/xx/xx/the-ember-times-issue-XX.html) or in our [e-mail newsletter](https://the-emberjs-times.ongoodbits.com/xxxx/xx/xx/issue-XX) what has been going on in Emberland this week.
+
+<SOME-INTRO-HERE-TO-KEEP-THEM-SUBSCRIBERS-READING>
+
+---
+
+## [SECTION TITLE](#section-url)
+
+
+---
+
+## [SECTION TITLE](#section-url)
+
+
+---
+
+## [SECTION TITLE](#section-url)
+
+
+---
+
+## [SECTION TITLE](#section-url)
+
+
+---
+
+## [SECTION TITLE](#section-url)
+
+
+---
+
+## [SECTION TITLE](#section-url)
+
+
+---
+
+## [SECTION TITLE](#section-url)
+
+
+---
+
+## [SECTION TITLE](#section-url)
+
+
+---
+
+## [SECTION TITLE](#section-url)
+
+
+---
+
+
+## [Contributors' Corner](https://guides.emberjs.com/release/contributing/repositories/)
+
+<p>This week we'd like to thank our siblings for their contributions to Ember and related repositories 💖!</p>
+
+---
+
+## [Got a question? Ask Readers' Questions! 🤓](https://docs.google.com/forms/d/e/1FAIpQLScqu7Lw_9cIkRtAiXKitgkAo4xX_pV1pdCfMJgIr6Py1V-9Og/viewform)
+
+<div class="blog-row">
+  <img class="float-right small transparent padded" alt="Office Hours Tomster Mascot" title="Readers' Questions" src="/images/tomsters/officehours.png" />
+
+  <p>Wondering about something related to Ember, Ember Data, Glimmer, or addons in the Ember ecosystem, but don't know where to ask? Readers’ Questions are just for you!</p>
+
+<p><strong>Submit your own</strong> short and sweet <strong>question</strong> under <a href="https://bit.ly/ask-ember-core" target="rq">bit.ly/ask-ember-core</a>. And don’t worry, there are no silly questions, we appreciate them all - promise! 🤞</p>
+
+</div>
+
+---
+
+Want to write for the Ember Times? Have a suggestion for next week's issue? Join us at [#topic-embertimes](https://embercommunity.slack.com/messages/C8P6UPWNN/) on Slack or tweet us [@embertimes](https://twitter.com/embertimes) on Twitter.
+
+---
+
+
+That's another wrap! ✨
+
+Be kind,
+
+the crowd and the Learning Team


### PR DESCRIPTION
<!--- Make sure to add a descriptive title in the field above! E.g. "Fixes the header title color on the homepage"  -->

## What it does
<!--- Tell us what this fix does in a few sentences. E.g. "This updates the header title's font color to Ember Orange." -->

This adds a template for making it easier to create a new feature branch for each week's Ember Times edition. You can generate a new template from it by copying it in your favorite editor or by using `cp` in the command line as follows:

```bash
// Example: create No. 99 of Ember Times to be released on Jan 1st, 1970
cd website/
cp source/blog/embertimes-template.md source/blog/1970-01-01-the-ember-times-issue-99.md
```

## Related Issue(s)
<!--- Please provide the issue(s) to which this pull request relates to or which issue it closes. E.g. "Closes #1234" -->

## Sources
<!-- Optional. If applicable be sure to add any screenshots or screen recordings of your work for your reviewers here -->
