### PR TITLE
Update Ember Times template 

### DIFF
--- a/source/blog/embertimes-template.md
+++ b/source/blog/embertimes-template.md
@@ -8,7 +8,7 @@ responsive: true
 
 <SAYING-HELLO-IN-YOUR-FAVORITE-LANGUAGE> Emberistas! 🐹
 
-Read either on the [Ember blog](https://www.emberjs.com/blog/xxxx/xx/xx/the-ember-times-issue-XX.html) or in our [e-mail newsletter](https://the-emberjs-times.ongoodbits.com/xxxx/xx/xx/issue-XX) what has been going on in Emberland this week.
+Read either on the [Ember blog](https://www.emberjs.com/blog/xxxx/xx/xx/the-ember-times-issue-XX.html) or in our [e-mail newsletter](https://the-emberjs-times.ongoodbits.com/) what has been going on in Emberland this week.
 
 <SOME-INTRO-HERE-TO-KEEP-THEM-SUBSCRIBERS-READING>
 


### PR DESCRIPTION
Sometimes the Goodbits had a different URL, but am not certain of the cause.

What do you think about changing https://www.emberjs.com/blog/xxxx/xx/xx/the-ember-times-issue-XX.html to https://emberjs.com/blog/tags/newsletter.html so we don't have to update it every time / less prone to error?