### PR TITLE
Remove InQuicker from Users

### DIFF
--- a/data/users.yml
+++ b/data/users.yml
@@ -828,6 +828,7 @@
   image: inquicker.png
   alt: "InQuicker"
   use: "We use Ember for our new customer-facing applications."
+  inactive: true
 - url: http://number42.de/
   image: num42.png
   alt: "number42"


### PR DESCRIPTION
## What it does

Removes InQuicker from the list of Ember Users

## Sources

I added InQuicker to the Users list when I worked there and we were actively advancing Ember development within the product and company. Sadly, our team has disbanded and there is no longer active Ember development going on within InQuicker.