### PR TITLE
Add link to Slack -> Discord RFC

### DIFF
--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -19,7 +19,7 @@ responsive: true
   </p>
 
   <p>
-    <a href="https://discordapp.com/invite/zT3asNS">Ember Community Discord</a> &mdash; use <a href="https://discordapp.com/invite/zT3asNS">this link</a> to receive an invitation.
+    <a href="https://discordapp.com/invite/zT3asNS">Ember Community Discord</a> &mdash; use <a href="https://discordapp.com/invite/zT3asNS">this link</a> to receive an invitation. (Looking for the Ember Community Slack? We recently switched away from Slack to [Discord](https://discordapp.com). Read more about why [here](https://github.com/emberjs/rfcs/pull/345)).
   </p>
 
   <p>

--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -19,7 +19,7 @@ responsive: true
   </p>
 
   <p>
-    <a href="https://discordapp.com/invite/zT3asNS">Ember Community Discord</a> &mdash; use <a href="https://discordapp.com/invite/zT3asNS">this link</a> to receive an invitation. (Looking for the Ember Community Slack? We recently switched away from Slack to [Discord](https://discordapp.com). Read more about why [here](https://github.com/emberjs/rfcs/pull/345)).
+    <a href="https://discordapp.com/invite/zT3asNS">Ember Community Discord</a> &mdash; ask questions and chat with community members in real-time. (Looking for the Ember Community Slack? We recently switched away from Slack to [Discord](https://discordapp.com). Read more about why [here](https://github.com/emberjs/rfcs/pull/345)).
   </p>
 
   <p>


### PR DESCRIPTION
I think we have a lot of messaging to do over the coming 6-12+ months about the move to Discord, so I thought it would be helpful to add a pointer for someone grep'ing the site for Slack.

<!--- Make sure to add a descriptive title in the field above! E.g. "Fixes the header title color on the homepage"  -->

## What it does
<!--- Tell us what this fix does in a few sentences. E.g. "This updates the header title's font color to Ember Orange." -->

## Related Issue(s)
<!--- Please provide the issue(s) to which this pull request relates to or which issue it closes. E.g. "Closes #1234" -->

## Sources
<!-- Optional. If applicable be sure to add any screenshots or screen recordings of your work for your reviewers here -->
