### PR TITLE
Ember Times Issue 65

### DIFF
--- a/source/blog/2018-09-14-the-ember-times-issue-64.md
+++ b/source/blog/2018-09-14-the-ember-times-issue-64.md
@@ -1,7 +1,7 @@
 ---
 title: The Ember Times - Issue No. 64
 author: Alon Bukai, Chris Ng, Amy Lam, Ryan Mark, Jessica Jordan
-tags: Recent Posts, Newsletter, Ember.js Times, Ember Times, 2018
+tags: Newsletter, Ember.js Times, Ember Times, 2018
 alias : "blog/2018/09/14-the-ember-times-issue-64.html"
 responsive: true
 ---

--- a/source/blog/2018-09-21-the-ember-times-issue-65.md
+++ b/source/blog/2018-09-21-the-ember-times-issue-65.md
@@ -1,12 +1,12 @@
 ---
-title: The Ember Times - Issue No. XX
+title: The Ember Times - Issue No. 65
 author: the crowd
 tags: Recent Posts, Newsletter, Ember.js Times, Ember Times, 2018
-alias : "blog/xxxx/xx/xx-the-ember-times-issue-XX.html"
+alias : "blog/2018/09/21-the-ember-times-issue-65.html"
 responsive: true
 ---
 
-<SAYING-HELLO-IN-YOUR-FAVORITE-LANGUAGE> Emberistas! 🐹
+Ahoj Emberistas! 🐹
 
 <SOME-INTRO-HERE-TO-KEEP-THEM-SUBSCRIBERS-READING>
 

--- a/source/blog/2018-09-21-the-ember-times-issue-65.md
+++ b/source/blog/2018-09-21-the-ember-times-issue-65.md
@@ -8,7 +8,7 @@ responsive: true
 
 Ahoj Emberistas! 🐹
 
-In this week's edition we're sharing news about a fresh 🥒  RFC to deprecate `.property()`, exciting addon updates 🚀 for sparkles-component and ember-css-modules, and how Ember is a modern framework - tell your friends! 
+In this week's edition we're sharing news about a fresh 🥒  RFC to deprecate `.property()`, exciting addon updates 🚀 for sparkles-component and ember-css-modules, and how Ember is a modern framework 🎉 - tell your friends! 
 
 ---
 

--- a/source/blog/2018-09-21-the-ember-times-issue-65.md
+++ b/source/blog/2018-09-21-the-ember-times-issue-65.md
@@ -1,0 +1,89 @@
+---
+title: The Ember Times - Issue No. XX
+author: the crowd
+tags: Recent Posts, Newsletter, Ember.js Times, Ember Times, 2018
+alias : "blog/xxxx/xx/xx-the-ember-times-issue-XX.html"
+responsive: true
+---
+
+<SAYING-HELLO-IN-YOUR-FAVORITE-LANGUAGE> Emberistas! 🐹
+
+<SOME-INTRO-HERE-TO-KEEP-THEM-SUBSCRIBERS-READING>
+
+---
+
+## [SECTION TITLE](#section-url)
+
+
+---
+
+## [SECTION TITLE](#section-url)
+
+
+---
+
+## [SECTION TITLE](#section-url)
+
+
+---
+
+## [SECTION TITLE](#section-url)
+
+
+---
+
+## [SECTION TITLE](#section-url)
+
+
+---
+
+## [SECTION TITLE](#section-url)
+
+
+---
+
+## [SECTION TITLE](#section-url)
+
+
+---
+
+## [SECTION TITLE](#section-url)
+
+
+---
+
+## [SECTION TITLE](#section-url)
+
+
+---
+
+
+## [Contributors' Corner](https://guides.emberjs.com/release/contributing/repositories/)
+
+<p>This week we'd like to thank our siblings for their contributions to Ember and related repositories 💖!</p>
+
+---
+
+## [Got a question? Ask Readers' Questions! 🤓](https://docs.google.com/forms/d/e/1FAIpQLScqu7Lw_9cIkRtAiXKitgkAo4xX_pV1pdCfMJgIr6Py1V-9Og/viewform)
+
+<div class="blog-row">
+  <img class="float-right small transparent padded" alt="Office Hours Tomster Mascot" title="Readers' Questions" src="/images/tomsters/officehours.png" />
+
+  <p>Wondering about something related to Ember, Ember Data, Glimmer, or addons in the Ember ecosystem, but don't know where to ask? Readers’ Questions are just for you!</p>
+
+<p><strong>Submit your own</strong> short and sweet <strong>question</strong> under <a href="https://bit.ly/ask-ember-core" target="rq">bit.ly/ask-ember-core</a>. And don’t worry, there are no silly questions, we appreciate them all - promise! 🤞</p>
+
+</div>
+
+---
+
+Want to write for the Ember Times? Have a suggestion for next week's issue? Join us at #support-ember-times on the [Ember Community Discord](https://discordapp.com/invite/zT3asNS) or ping us [@embertimes](https://twitter.com/embertimes) on Twitter.
+
+---
+
+
+That's another wrap! ✨
+
+Be kind,
+
+the crowd and the Learning Team

--- a/source/blog/2018-09-21-the-ember-times-issue-65.md
+++ b/source/blog/2018-09-21-the-ember-times-issue-65.md
@@ -49,7 +49,7 @@ To learn more, [@rwjblue](https://github.com/rwjblue) together with [@mike-north
 
 ---
 
-## [Ember is a modern framework, tell your friends 😄](https://dev.to/nullvoxpopuli/the-emberjs-of-the-future-today-12c)
+## [Ember Is a Modern Framework, Tell Your Friends 😄](https://dev.to/nullvoxpopuli/the-emberjs-of-the-future-today-12c)
 
 <!--alex ignore hooks destroy-->
 Community member [@NullVoxPopuli](https://github.com/NullVoxPopuli) has written a summary of a set of his favorite features that showcase how Ember is a modern framework, and can be attractive to people looking for all the shiny things. Check out [The EmberJS of the future... today!](https://dev.to/nullvoxpopuli/the-emberjs-of-the-future-today-12c) where he discusses async lifecycle hooks, syntax for components, testing, dependency injection, keyboard accessibility and more.
@@ -68,7 +68,7 @@ Community member [@NullVoxPopuli](https://github.com/NullVoxPopuli) has written 
 
 ---
 
-## [Got a question? Ask Readers' Questions! 🤓](https://docs.google.com/forms/d/e/1FAIpQLScqu7Lw_9cIkRtAiXKitgkAo4xX_pV1pdCfMJgIr6Py1V-9Og/viewform)
+## [Got a Question? Ask Readers' Questions! 🤓](https://docs.google.com/forms/d/e/1FAIpQLScqu7Lw_9cIkRtAiXKitgkAo4xX_pV1pdCfMJgIr6Py1V-9Og/viewform)
 
 <div class="blog-row">
   <img class="float-right small transparent padded" alt="Office Hours Tomster Mascot" title="Readers' Questions" src="/images/tomsters/officehours.png" />

--- a/source/blog/2018-09-21-the-ember-times-issue-65.md
+++ b/source/blog/2018-09-21-the-ember-times-issue-65.md
@@ -91,4 +91,4 @@ That's another wrap! ✨
 
 Be kind,
 
-the crowd and the Learning Team
+Chris Ng and the Learning Team

--- a/source/blog/2018-09-21-the-ember-times-issue-65.md
+++ b/source/blog/2018-09-21-the-ember-times-issue-65.md
@@ -1,6 +1,6 @@
 ---
 title: The Ember Times - Issue No. 65
-author: the crowd
+author: Chris Ng, L. Preston Sego III, Amy Lam, Ryan Mark, Jessica Jordan
 tags: Recent Posts, Newsletter, Ember.js Times, Ember Times, 2018
 alias : "blog/2018/09/21-the-ember-times-issue-65.html"
 responsive: true


### PR DESCRIPTION
- [x] https://dev.to/nullvoxpopuli/the-emberjs-of-the-future-today-12c (:lock: @NullVoxPopuli / @amyrlam)
- [x] [sparkles-component 1.1.0 published](https://twitter.com/rwjblue/status/1042162296854925314) (🔒 @chrisrng)
- [ ] from #news-and-announcements: ember-apollo-client v2.0.0-beta.1 released! This release switches us to use ember-auto-import instead of our custom webpack-based build setup. It also removes deprecated imports and options. :rocket: :first_quarter_moon:  https://github.com/bgentry/ember-apollo-client/releases/tag/v2.0.0-beta.1
- [x] https://twitter.com/__dfreeman/status/1042837440417988610 from #news-and-announcements (:lock: @amyrlam)
- [ ] https://twitter.com/rwjblue/status/1042894434839478272 (🔒 @kennethlarsen)