### PR TITLE
Fixes discord links on community page (#3593)

### DIFF
--- a/source/community.html.erb
+++ b/source/community.html.erb
@@ -19,7 +19,7 @@ responsive: true
   </p>
 
   <p>
-    <a href="https://discordapp.com/invite/zT3asNS">Ember Community Discord</a> &mdash; ask questions and chat with community members in real-time. (Looking for the Ember Community Slack? We recently switched away from Slack to [Discord](https://discordapp.com). Read more about why [here](https://github.com/emberjs/rfcs/pull/345)).
+    <a href="https://discordapp.com/invite/zT3asNS">Ember Community Discord</a> &mdash; ask questions and chat with community members in real-time. (Looking for the Ember Community Slack? We recently switched away from Slack to <a href="https://discordapp.com">Discord</a>. Read more about why <a href="https://github.com/emberjs/rfcs/pull/345">here</a>).
   </p>
 
   <p>


### PR DESCRIPTION
## What it does
This PR updates two discord links on Ember Community Page.
To see the _error_ at image below:

![ember](https://user-images.githubusercontent.com/5417662/46350904-60d17300-c62c-11e8-88f9-5f63ffbda1d1.png)

## Related Issue(s)
Closes #3593