### PR TITLE
docs(blog contributing): updates for alex linter, emoji title, addon word

### DIFF
--- a/source/blog/CONTRIBUTING.md
+++ b/source/blog/CONTRIBUTING.md
@@ -20,6 +20,11 @@ npm install -g alex
 bash scripts/language-check.sh
 ```
 
+If you are consciously overriding the Alex linter you can add an annotation before the paragraph as shown below.
+
+```
+<!--alex ignore THEWORD-->
+```
 
 # Ember Times
 
@@ -43,8 +48,10 @@ The answers are posted on [discuss.emberjs.com](https://discuss.emberjs.com/) an
 ## Writing Style Guide
 
 * Use Title Case for section headings, when in doubt use https://titlecaseconverter.com/.
+* Please add an emoji at the end of your title, if you're having trouble finding an emoji use a search tool like https://emojipedia.org/.
 * In general, refer to people by their GitHub handle, e.g. `[@your_name_here](https://www.github.com/your_name_here)`. (If the person is mentioned more than one time in the same paragraph, feel free to deviate after one @ mention!]
 * We tend to refer to `Ember`, `Ember Data`, and `Ember CLI` as their name (versus the repo name) because we mention them so often. For most other repos, use the repo name e.g. `[machty/ember-concurrency](https://github.com/machty/ember-concurrency)`.
+* The word `addon` is usually denoted as lowercase and as a single word.
 * Add your name to the author list at the bottom of the Times when submitting a PR for the week.
 
 ### Goodbits


### PR DESCRIPTION
[rendered](https://github.com/chrisrng/website/blob/bddc800476cc3ec0b54a4de5d3dc949f90e23052/source/blog/CONTRIBUTING.md)

Changes:
- How to ignore alex linter
- Add emoji to title
- `addon` as a word