### PR TITLE
 Update number of features and deprecations in prelude in Ember 3.4 blog post

### DIFF
--- a/source/blog/2018-10-07-ember-3-4-released.md
+++ b/source/blog/2018-10-07-ember-3-4-released.md
@@ -28,7 +28,7 @@ The 3.4.0 release is an Ember.js Long-Term Support candidate. In six weeks, the 
 
 For more information about Ember's LTS policies, see the [announcement blog post](http://emberjs.com/blog/2016/02/25/announcing-embers-first-lts.html) and [builds page](http://emberjs.com/builds/).
 
-Ember.js 3.4 is an incremental, backwards compatible release of Ember with bugfixes, performance improvements, and minor deprecations. There is one (1) new feature, three (3) deprecations, and eight (8) bugfixes in this version.
+Ember.js 3.4 is an incremental, backwards compatible release of Ember with bugfixes, performance improvements, and minor deprecations. There are two (2) new feature, two (2) deprecations, and eight (8) bugfixes in this version.
 
 #### New Features (2)
 

--- a/source/blog/2018-10-07-ember-3-4-released.md
+++ b/source/blog/2018-10-07-ember-3-4-released.md
@@ -28,7 +28,7 @@ The 3.4.0 release is an Ember.js Long-Term Support candidate. In six weeks, the 
 
 For more information about Ember's LTS policies, see the [announcement blog post](http://emberjs.com/blog/2016/02/25/announcing-embers-first-lts.html) and [builds page](http://emberjs.com/builds/).
 
-Ember.js 3.4 is an incremental, backwards compatible release of Ember with bugfixes, performance improvements, and minor deprecations. There are two (2) new feature, two (2) deprecations, and eight (8) bugfixes in this version.
+Ember.js 3.4 is an incremental, backwards compatible release of Ember with bugfixes, performance improvements, and minor deprecations. There are two (2) new features, two (2) deprecations, and eight (8) bugfixes in this version.
 
 #### New Features (2)
 


### PR DESCRIPTION
Prelude has wording "There is one (1) new feature, three (3) deprecations" but respective sections have titles "New Features (2)" and "Deprecations (2)"