### PR TITLE
Disable search temporarily

### DIFF
--- a/source/_header.html.erb
+++ b/source/_header.html.erb
@@ -66,7 +66,7 @@
       </ul>
      </li>
    </ul>
-   <form class="navbar-form navbar-right searchbox">
+   <!-- <form class="navbar-form navbar-right searchbox">
     <div class="input-group">
       <label for="search-input" class="control-label sr-only">Search</label>
         <input type="text"
@@ -82,7 +82,7 @@
         />
         <span></span>
     </div>
-   </form>
+   </form> -->
   </div>
   <!-- /.navbar-collapse -->
  </div>

--- a/source/javascripts/app/docsearch.js.erb
+++ b/source/javascripts/app/docsearch.js.erb
@@ -1,3 +1,4 @@
+/**
 (function() {
     var script = document.createElement('script');
     script.type = 'text/javascript';
@@ -10,9 +11,9 @@
 var currentRevision = '<%= current_version %>';
 var apiKey = '<%= data.search.api_key %>';
 var inputSelector = '#search-input';
-var indexName = 'emberjs_versions';
+var indexName = 'ember-guides';
 var hitsPerPage = 10;
-var facetFilters = '[["version:' + currentRevision + '"]]';
+# var facetFilters = '[["version:' + currentRevision + '"]]';
 
 $(window).load(function () {
     docsearch({
@@ -21,7 +22,9 @@ $(window).load(function () {
         inputSelector: inputSelector,
         algoliaOptions: {
             hitsPerPage: hitsPerPage,
-            facetFilters: facetFilters
+            # facetFilters: facetFilters
         }
     });
 });
+
+**/


### PR DESCRIPTION
Our API & guides apps have functional search, but until we can fix the search on the rest of the website its probably better to hide the search bar so that users don't feel that its broken.