### PR TITLE
Add Tony Ward as the Ember Dallas meetup organizer

### DIFF
--- a/data/meetups.yml
+++ b/data/meetups.yml
@@ -266,11 +266,8 @@ locations:
     lat: 32.7802618
     lng: -96.8009781
     organizers:
-    - organizer: Matthew Marcum
-    - organizer: Jeremy Brown
-      profileImage: http://photos2.meetupstatic.com/photos/member/2/5/e/6/thumb_200649702.jpeg
-    - organizer: Joshua Cochran
-      profileImage: http://photos4.meetupstatic.com/photos/member/c/b/c/2/thumb_219832162.jpeg
+    - organizer: Tony Ward
+      profileImage: https://secure.meetupstatic.com/photos/member/7/9/3/d/highres_276091037.jpeg
   - location: Orlando, FL
     url: http://www.meetup.com/Ember-js-Orlando/
     image: 01orlando.png


### PR DESCRIPTION
After EmberConf 2018, I met with the previous organizers and became the sole organizer for Ember Dallas (as seen at https://www.meetup.com/Ember-Dallas/events/past/)

## What it does
Remove previous Ember Dallas organizers and add myself

## Related Issue(s)
N/A

## Sources
N/A