### PR TITLE
remove pink/beige background from non-homepages

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -55,7 +55,6 @@ $small-max-width: 767px;
 
 body {
   -webkit-font-smoothing: antialiased;
-  background-color: rgba(250,235,232,0.36); //white is too white in contrast to ember orange
   color: #444444;
   font-family: $base-font-family;
   font-weight: normal; //for iOS


### PR DESCRIPTION
## What it does
This PR removes one line of CSS that made the blog, team page, etc. background a pinky-beige color. My change brings it into harmony with the ember-styleguide CSS used in apps like The Guides. The website repo was inconsistent with past design decisions for ember-styleguide that improved the freshness and legibility of our newer Ember apps.

This change does not affect the homepage, which as always looked slightly different than our other pages on purpose.

## Sources

Before:
![screen shot 2018-10-24 at 11 35 00 pm](https://user-images.githubusercontent.com/16627268/47474583-9f022280-d7e5-11e8-86a5-dc2a27235b68.png)

After:
![screen shot 2018-10-24 at 11 34 47 pm](https://user-images.githubusercontent.com/16627268/47474580-9c073200-d7e5-11e8-967f-42dc3896102b.png)

Comparison to currently deployed Guides:
![screen shot 2018-10-24 at 11 37 10 pm](https://user-images.githubusercontent.com/16627268/47474607-b3deb600-d7e5-11e8-8a8b-9e7ecfabdaba.png)

