### PR TITLE
Add CLI guides to the navbar

### DIFF
--- a/source/_header.html.erb
+++ b/source/_header.html.erb
@@ -15,8 +15,9 @@
     <li class="dropdown">
      <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Docs <span class="caret"></span></a>
      <ul class="dropdown-menu">
-      <li><a href="//guides.emberjs.com">Guides</a></li>
+      <li><a href="//guides.emberjs.com">Ember.js Guides</a></li>
       <li><a href="/api/ember/release">API Reference</a></li>
+      <li><a href="//cli.emberjs.com">CLI Guides</a></li>
       <li role="separator" class="divider"></li>
       <li><a href="/learn">Learn Ember</a></li>
      </ul>


### PR DESCRIPTION
I have added the CLI guides to the "Docs" dropdown, and clarified "The Guides" as "Ember.js Guides".

I did not add a link to the CLI Guides API because I think it's ok for someone to get to it via the Guides. The CLI API docs also need some kind of review before they are included in the top navbar.

"The Guides" are really "The Ember.js Guides" because as we make more guides (like Ember Data, Ember CLI, etc) we need more granular descriptions.

These 3 PRs should be merged at the same time:
1. ember-styleguide https://github.com/ember-learn/ember-styleguide/pull/115
2. ember-api-docs https://github.com/ember-learn/ember-api-docs/pull/576
3. website https://github.com/emberjs/website/pull/3705
