### PR TITLE
revert design change for home page CTA

### DIFF
--- a/source/stylesheets/components/call-to-action.css.scss
+++ b/source/stylesheets/components/call-to-action.css.scss
@@ -52,7 +52,7 @@
 }
 
 .call-to-action__bottom {
-  background-color: $code-background;
+  background-color: $orange;
   color: $white;
   font-family: monospace;
   line-height: 0.5;


### PR DESCRIPTION
reverts the CTA color background change.

- there were not supposed to be any design changes at this point
- no (home page) change should be introduced in a PR with a different/unrelated change
- this version of the site is in freeze (the ember-learn/ember-website launch is soon). 