### PR TITLE
ember times: Remove 0️⃣1️⃣ emojis

### DIFF
--- a/source/blog/2018-12-14-the-ember-times-issue-77.md
+++ b/source/blog/2018-12-14-the-ember-times-issue-77.md
@@ -8,11 +8,11 @@ responsive: true
 
 Salut Emberistas! 🐹
 
-This week boolean component arguments 0️⃣1️⃣ are in for an RFC, learn more about component patterns 📚🧐, Ember 3.6 released 🚀, and the EmberConf speakers have been announced! 👏
+This week boolean component arguments 👻 are in for an RFC, learn more about component patterns 📚🧐, Ember 3.6 released 🚀, and the EmberConf speakers have been announced! 👏
 
 ---
 
-## [Boolean Dreams Come True 0️⃣☁️1️⃣](https://github.com/emberjs/rfcs/pull/407)
+## [Boolean Dreams Come True ☁️](https://github.com/emberjs/rfcs/pull/407)
 
 Ever wanted to pass **boolean arguments** to your **components** _just_ like you would pass boolean attributes - like checked or readonly - to an HTML element?
 


### PR DESCRIPTION
These emojis don't display in Firefox on MacOS, not sure why yet

Will make a staging branch to verify

<img width="934" alt="screen shot 2018-12-21 at 3 23 39 pm" src="https://user-images.githubusercontent.com/1372946/50347265-390bf000-0535-11e9-8ee0-4180bf832b20.png">
