### PR TITLE
Add Brazil Tomster image to emberjs.com/mascots

### DIFF
--- a/data/tomsters.yml
+++ b/data/tomsters.yml
@@ -315,6 +315,10 @@
   date: October 15, 2018
   image: /images/tomsters/paris.png
   tags: all tomster meetup
+- title: Brazil
+  date: January 10, 2019
+  image: /images/tomsters/brazil.png
+  tags: all tomster meetup
 
 # - title:
 #   date:


### PR DESCRIPTION
cc @MinThaMie 

I realized after merging https://github.com/emberjs/website/pull/3805 that the new Tomster has to be manually added to the `data/tomsters.yml`, similar to this PR: https://github.com/emberjs/website/pull/3639. Sorry about that!

## What it does
Add Brazil Tomster image to emberjs.com/mascots

## Related Issue(s)
Follow-on to https://github.com/emberjs/website/pull/3805

## Sources
Deployment looks good! https://ember-website-staging-pr-3806.herokuapp.com/mascots/
