### PR TITLE
Revert Ember Columbus meetup location to original

### DIFF
--- a/data/meetups.yml
+++ b/data/meetups.yml
@@ -367,8 +367,8 @@ locations:
       profileImage: http://photos2.meetupstatic.com/photos/member/d/a/c/c/member_91316012.jpeg
   - location: Columbus, OH
     url: http://www.meetup.com/ember-columbus/
-    lat: 39.9678407
-    lng: -82.9961547
+    lat: 40.098794
+    lng: -83.105245
     organizers:
     - organizer: Kevin Pfefferle
       profileImage: https://secure.meetupstatic.com/photos/member/c/3/4/d/member_268429997.jpeg


### PR DESCRIPTION
This reverts commit f824a4d3f96bd8ad5100aa0e01dc61c44e20d24a.

## What it does

This changes the location of the Ember Columbus meetup back to our original meeting location as we will be returning there starting with our next meeting: https://www.meetup.com/ember-columbus/events/258995807/