### PR TITLE
Quick survey announcement fixes

### DIFF
--- a/source/blog/2019-02-19-ember-community-survey.md
+++ b/source/blog/2019-02-19-ember-community-survey.md
@@ -13,7 +13,7 @@ What an incredible time to be in the Ember Community!
 
 With 2019 already under way, we would like your help to learn about who is in the Ember community and how they work with the framework. To that end, we're pleased to announce the official 2019 Ember Community Survey.
 
-<a href="/ember-community-survey-2018" class="survey-button orange button">
+<a href="/ember-community-survey-2019" class="survey-button orange button">
 Survey Landing Page <img src="/images/survey/right-arrow.png" alt="" role="presentation" />
 </a>
 

--- a/source/ember-community-survey-2019.html.erb
+++ b/source/ember-community-survey-2019.html.erb
@@ -80,14 +80,15 @@ no_survey_reminder: true
         <a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-size="large" data-text="Do you use @emberjs? It&#39;s time for the 2019 survey! " data-url="https://emberjs.com/ember-community-survey-2019" data-hashtags="EmberJS" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
       </p>
       <p>
-        Questions? Feedback? Please join us in the #dev-ember-learning channel on the Discord community chat.
+        Questions? Feedback? Please join us in the #dev-ember-learning channel on the Discord community chat, or
+        email the survey team via <a href="mailto:survey@emberjscommunity.com">survey@emberjscommunity.com</a>.
       </p>
       <p>
         ...and see you at <a href="http://emberconf.com/">EmberConf 2019!</a>!
       </p>
     </div>
     <div class="survey-credits">
-      <p>Brought to you by</p>
+      <p>Sponsored by</p>
       <a href="http://codeallday.com/">
         <img src="/images/survey/cad-right.svg" alt="code all day" />
       </a>


### PR DESCRIPTION
## What it does

Fixes a link in the survey announcement blog post to go to 2019 instead of 2018 😬 

Tweaks some wording on the landing page.

## Related Issue(s)

https://github.com/emberjs/website/pull/3823