### PR TITLE
updating h4 style for the blog posts

### DIFF
--- a/source/stylesheets/blog.css.scss
+++ b/source/stylesheets/blog.css.scss
@@ -248,7 +248,17 @@ body.blog.responsive {
   }
 }
 article.blog-post {
-
+  h4.anchorable-toc { 
+    border-bottom: 1px solid $gray-lighter;
+    font-size: 1em;
+    font-style: normal;
+    font-weight: bold;
+    letter-spacing: 1px;
+    line-height: 1;
+    margin: 3em 0 1.75em 0;
+    padding-bottom: 10px;
+    text-transform: uppercase;
+  }
   li {
     margin: 14px 0;
   }


### PR DESCRIPTION
Modified the style of the h4 in the blog posts to make it easier to digest the information (note- the images make the text size look smaller than it really is). 

Before: 
![image](https://user-images.githubusercontent.com/4587451/53522886-fcaec000-3aa0-11e9-8485-d66f5bcf4bb5.png)

After:
![image](https://user-images.githubusercontent.com/4587451/53522837-e0128800-3aa0-11e9-815e-1d5e9621d4e1.png)
