### PR TITLE
Fix grammar in Ember 3.8 Blog Post

### DIFF
--- a/source/blog/2019-02-27-ember-3-8-released.md
+++ b/source/blog/2019-02-27-ember-3-8-released.md
@@ -26,7 +26,7 @@ The 3.8.0 release is an Ember.js Long-Term Support candidate. In six weeks, the 
 
 For more information about Ember's LTS policies, see the [announcement blog post](http://emberjs.com/blog/2016/02/25/announcing-embers-first-lts.html) and [builds page](http://emberjs.com/builds/).
 
-Ember.js 3.8 is an incremental, backwards compatible release of Ember with bugfixes, performance improvements, and minor deprecations. There are two (2) new feature, four (4) deprecations, and six (6) bugfixes in this version.
+Ember.js 3.8 is an incremental, backwards compatible release of Ember with bugfixes, performance improvements, and minor deprecations. There are two (2) new features, four (4) deprecations, and six (6) bugfixes in this version.
 
 #### New Features (2)
 

--- a/source/blog/2019-02-27-ember-3-8-released.md
+++ b/source/blog/2019-02-27-ember-3-8-released.md
@@ -26,7 +26,7 @@ The 3.8.0 release is an Ember.js Long-Term Support candidate. In six weeks, the 
 
 For more information about Ember's LTS policies, see the [announcement blog post](http://emberjs.com/blog/2016/02/25/announcing-embers-first-lts.html) and [builds page](http://emberjs.com/builds/).
 
-Ember.js 3.8 is an incremental, backwards compatible release of Ember with bugfixes, performance improvements, and minor deprecations. There is two (2) new feature, four (4) deprecations, and six (6) bugfixes in this version.
+Ember.js 3.8 is an incremental, backwards compatible release of Ember with bugfixes, performance improvements, and minor deprecations. There are two (2) new feature, four (4) deprecations, and six (6) bugfixes in this version.
 
 #### New Features (2)
 


### PR DESCRIPTION
<!--- Make sure to add a descriptive title in the field above! E.g. "Fixes the header title color on the homepage"  -->

## What it does
Fix grammar `is two` -> `are two`
Fix s `two feature` -> `two features`

## Related Issue(s)
<!--- Please provide the issue(s) to which this pull request relates to or which issue it closes. E.g. "Closes #1234" -->

## Sources
<!-- Optional. If applicable be sure to add any screenshots or screen recordings of your work for your reviewers here -->
