### PR TITLE
Remove 3.9 deprecations

### DIFF
--- a/source/blog/2019-02-27-ember-3-8-released.md
+++ b/source/blog/2019-02-27-ember-3-8-released.md
@@ -26,7 +26,7 @@ The 3.8.0 release is an Ember.js Long-Term Support candidate. In six weeks, the 
 
 For more information about Ember's LTS policies, see the [announcement blog post](http://emberjs.com/blog/2016/02/25/announcing-embers-first-lts.html) and [builds page](http://emberjs.com/builds/).
 
-Ember.js 3.8 is an incremental, backwards compatible release of Ember with bugfixes, performance improvements, and minor deprecations. There are two (2) new features, one (1) deprecations, and six (6) bugfixes in this version.
+Ember.js 3.8 is an incremental, backwards compatible release of Ember with bugfixes, performance improvements, and minor deprecations. There are two (2) new features, one (1) deprecation, and six (6) bugfixes in this version.
 
 #### New Features (2)
 

--- a/source/blog/2019-02-27-ember-3-8-released.md
+++ b/source/blog/2019-02-27-ember-3-8-released.md
@@ -26,7 +26,7 @@ The 3.8.0 release is an Ember.js Long-Term Support candidate. In six weeks, the 
 
 For more information about Ember's LTS policies, see the [announcement blog post](http://emberjs.com/blog/2016/02/25/announcing-embers-first-lts.html) and [builds page](http://emberjs.com/builds/).
 
-Ember.js 3.8 is an incremental, backwards compatible release of Ember with bugfixes, performance improvements, and minor deprecations. There are two (2) new features, four (4) deprecations, and six (6) bugfixes in this version.
+Ember.js 3.8 is an incremental, backwards compatible release of Ember with bugfixes, performance improvements, and minor deprecations. There are two (2) new features, one (1) deprecations, and six (6) bugfixes in this version.
 
 #### New Features (2)
 
@@ -53,25 +53,7 @@ Consider using the [ember-cli-deprecation-workflow](https://github.com/mixonic/e
 
 For more details on changes in Ember.js 3.8, please review the [Ember.js 3.8.0 release page](https://github.com/emberjs/ember.js/releases/tag/v3.8.0).
 
-**Computed Property Overridability (1 of 5)**
-
-Ember's computed properties are overridable by default if no setter is defined. This behavior is bug prone and has been deprecated. `readOnly()`, the modifier that prevents this behavior, will be deprecated once overridability has been removed. Please have a look at [the deprecations app](https://emberjs.com/deprecations/v3.x#toc_computed-property-override) for more information on this deprecation.
-
-**Computed Property `.property()` Modifier (2 of 5)**
-
-`.property()` is a modifier that adds additional property dependencies to an existing computed property. To update, move the dependencies to the main computed property definition and you shouldn't see a deprecation warning any more. For more information please refer to [the deprecations app](https://emberjs.com/deprecations/v3.x#toc_computed-property-property).
-
-**Computed Property Volatility (3 of 5)**
-
-`.volatile()` is a computed property modifier which makes a computed property recalculate every time it is accessed, instead of caching. It also prevents property notifications from ever occuring on the property, which is generally not the behavior that developers are after. Volatile properties are usually used to simulate the behavior of native getters, which means that they would otherwise behave like normal properties.
-
-To update, consider upgrading to native class syntax and using native getters directly instead. There's guide on how to do this in the [deprecations app](https://emberjs.com/deprecations/v3.x#toc_computed-property-volatile).
-
-**Deprecate `@ember/object#aliasMethod` (4 of 5)**
-
-`@ember/object#aliasMethod` is a little known and rarely used method that allows user's to add aliases to objects defined with EmberObject. The deprecation warning can be removed by refactoring it into having one function call the other directly. To see how to do this, please refer to the [deprecations app](https://emberjs.com/deprecations/v3.x#toc_object-alias-method)
-
-**Component Manager Factory Function (5 of 5)**
+**Component Manager Factory Function (1 of 1)**
 
 `setComponentManager` no longer takes a string to associate the custom component class and the component manager. Instead you must pass a factory function that produces an instance of the component manager. For more information please refer to the [deprecations app](https://emberjs.com/deprecations/v3.x#toc_component-manager-string-lookup)
 


### PR DESCRIPTION
## What it does
It seems that four deprecations were wrongfully tagged as `3.8` instead of `3.9` so I have updated the release post to reflect reality.

